### PR TITLE
[Setting] add common base entity

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -3,6 +3,7 @@ ext {
 }
 
 dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/common/src/main/java/com/ojosama/common/audit/AuditorAwareImpl.java
+++ b/common/src/main/java/com/ojosama/common/audit/AuditorAwareImpl.java
@@ -1,0 +1,15 @@
+package com.ojosama.common.audit;
+
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AuditorAwareImpl implements AuditorAware<UUID> {
+
+    @Override
+    public Optional<UUID> getCurrentAuditor() {
+        return Optional.empty(); //todo: 사용자 값 나중ㅇ 연결 예정
+    }
+}

--- a/common/src/main/java/com/ojosama/common/audit/BaseEntity.java
+++ b/common/src/main/java/com/ojosama/common/audit/BaseEntity.java
@@ -3,12 +3,11 @@ package com.ojosama.common.audit;
 import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
 import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
-
-import java.time.LocalDateTime;
 
 @Getter
 @MappedSuperclass
@@ -25,4 +24,8 @@ public abstract class BaseEntity {
 
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
+
+    public void deleted() {
+        this.deletedAt = LocalDateTime.now();
+    }
 }

--- a/common/src/main/java/com/ojosama/common/audit/BaseEntity.java
+++ b/common/src/main/java/com/ojosama/common/audit/BaseEntity.java
@@ -1,0 +1,28 @@
+package com.ojosama.common.audit;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+}

--- a/common/src/main/java/com/ojosama/common/audit/BaseUserEntity.java
+++ b/common/src/main/java/com/ojosama/common/audit/BaseUserEntity.java
@@ -1,0 +1,24 @@
+package com.ojosama.common.audit;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.MappedSuperclass;
+import java.util.UUID;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.LastModifiedBy;
+
+@Getter
+@MappedSuperclass
+public abstract class BaseUserEntity extends BaseEntity {
+
+    @CreatedBy
+    @Column(name = "created_by", updatable = false)
+    private UUID createdBy;
+
+    @LastModifiedBy
+    @Column(name = "updated_by")
+    private UUID updatedBy;
+
+    @Column(name = "deleted_by")
+    private UUID deletedBy;
+}

--- a/common/src/main/java/com/ojosama/common/audit/BaseUserEntity.java
+++ b/common/src/main/java/com/ojosama/common/audit/BaseUserEntity.java
@@ -21,4 +21,9 @@ public abstract class BaseUserEntity extends BaseEntity {
 
     @Column(name = "deleted_by")
     private UUID deletedBy;
+
+    public void deleted(final UUID deletedBy) {
+        super.deleted();
+        this.deletedBy = deletedBy;
+    }
 }


### PR DESCRIPTION
## 🔗 Issue Number
- close #3 

## 📝 작업 내역

- BaseEntity 생성
- createdAt, updatedAt, deletedAt 추가

- BaseUserEntity 생성
- createdBy, updatedBy, deletedBy 추가

- AuditorAwareImpl 생성
- soft delete 메서드 추가

## 💡 PR 특이사항

- 현재는 공통 구조만 구성했으며 도메인 엔티티 적용은 이후 진행 예정
- createdBy, updatedBy는 추후 인증 정보 연동 후 자동 주입 예정
- JPA Auditing 활성화는 각 서비스 application에서 처리 예정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 데이터의 변경 시간(생성, 수정, 삭제)을 자동으로 추적하는 감시 기능이 추가되었습니다.
  * 각 변경 작업을 수행한 사용자 정보를 기록하여 더욱 상세한 변경 이력 관리가 가능해졌습니다.
  * 이를 통해 데이터 무결성 모니터링과 감사 추적이 개선됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->