### PR TITLE
[FEATUER] chat-service exception 추가/도메인 검증 로직 추가

### DIFF
--- a/chat-service/src/main/java/com/ojosama/chatservice/domain/exception/ChatErrorCode.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/domain/exception/ChatErrorCode.java
@@ -12,7 +12,7 @@ public enum ChatErrorCode implements ErrorCode {
     CHAT_ROOM_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 해당 행사에 대한 채팅방이 존재합니다."),
     CHAT_ROOM_NOT_OPEN(HttpStatus.BAD_REQUEST, "오픈된 채팅방에서만 메시지를 보낼 수 있습니다."),
     CHAT_ROOM_ALREADY_OPENED(HttpStatus.BAD_REQUEST, "이미 오픈된 채팅방입니다."),
-    CHAT_ROOM_ALREADY_ENDED(HttpStatus.NOT_FOUND, "이미 채팅방이 종료되었습니다."),
+    CHAT_ROOM_ALREADY_ENDED(HttpStatus.CONFLICT, "이미 채팅방이 종료되었습니다."),
     CHAT_ROOM_INVALID_TIME(HttpStatus.BAD_REQUEST, "종료 시간은 오픈 시간보다 이후여야 합니다."),
     CHAT_ROOM_EVENT_ID_REQUIRED(HttpStatus.BAD_REQUEST, "eventId는 필수입니다."),
     CHAT_ROOM_STATUS_INVALID(HttpStatus.BAD_REQUEST, "요청한 작업을 수행할 수 없는 상태입니다."),

--- a/chat-service/src/main/java/com/ojosama/chatservice/domain/exception/ChatErrorCode.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/domain/exception/ChatErrorCode.java
@@ -7,13 +7,30 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum ChatErrorCode implements ErrorCode {
 
-    MESSAGE_NOT_EXIST(HttpStatus.BAD_REQUEST, "메시지가 이미 삭제되었습니다."),
-    MESSAGE_NOT_ACTIVE(HttpStatus.BAD_REQUEST, "ACTIVE 상태에서만 블라인드할 수 있습니다."),
-    INVALID_ADMIN_ID(HttpStatus.BAD_REQUEST, "adminId는 필수입니다."),
+    // ChatRoom
     CHAT_ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "채팅방을 찾을 수 없습니다."),
+    CHAT_ROOM_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 해당 행사에 대한 채팅방이 존재합니다."),
+    CHAT_ROOM_NOT_OPEN(HttpStatus.BAD_REQUEST, "오픈된 채팅방에서만 메시지를 보낼 수 있습니다."),
+    CHAT_ROOM_ALREADY_OPENED(HttpStatus.BAD_REQUEST, "이미 오픈된 채팅방입니다."),
+    CHAT_ROOM_ALREADY_ENDED(HttpStatus.NOT_FOUND, "이미 채팅방이 종료되었습니다."),
     CHAT_ROOM_INVALID_TIME(HttpStatus.BAD_REQUEST, "종료 시간은 오픈 시간보다 이후여야 합니다."),
+    CHAT_ROOM_EVENT_ID_REQUIRED(HttpStatus.BAD_REQUEST, "eventId는 필수입니다."),
 
-    ;
+    // Message
+    MESSAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "메시지를 찾을 수 없습니다."),
+    MESSAGE_ALREADY_DELETED(HttpStatus.BAD_REQUEST, "메시지가 이미 삭제되었습니다."),
+    MESSAGE_ALREADY_BLINDED(HttpStatus.BAD_REQUEST, "이미 블라인드 처리된 메시지입니다."),
+    MESSAGE_NOT_ACTIVE(HttpStatus.BAD_REQUEST, "ACTIVE 상태에서만 블라인드할 수 있습니다."),
+    MESSAGE_CONTENT_REQUIRED(HttpStatus.BAD_REQUEST, "메시지 내용은 필수입니다."),
+    MESSAGE_CONTENT_TOO_LONG(HttpStatus.BAD_REQUEST, "메시지 내용이 최대 길이를 초과했습니다."),
+    MESSAGE_SEND_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "현재 채팅방에는 메시지를 보낼 수 없습니다."),
+
+    // Permission
+    INVALID_USER_ID(HttpStatus.BAD_REQUEST, "userId는 필수입니다."),
+    INVALID_ADMIN_ID(HttpStatus.BAD_REQUEST, "adminId는 필수입니다."),
+    MESSAGE_DELETE_FORBIDDEN(HttpStatus.FORBIDDEN, "본인의 메시지만 삭제할 수 있습니다."),
+    MESSAGE_BLIND_FORBIDDEN(HttpStatus.FORBIDDEN, "메시지 블라인드 권한이 없습니다."),
+    CHAT_ROOM_CLOSE_FORBIDDEN(HttpStatus.FORBIDDEN, "채팅방 종료 권한이 없습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/chat-service/src/main/java/com/ojosama/chatservice/domain/exception/ChatErrorCode.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/domain/exception/ChatErrorCode.java
@@ -15,6 +15,7 @@ public enum ChatErrorCode implements ErrorCode {
     CHAT_ROOM_ALREADY_ENDED(HttpStatus.NOT_FOUND, "이미 채팅방이 종료되었습니다."),
     CHAT_ROOM_INVALID_TIME(HttpStatus.BAD_REQUEST, "종료 시간은 오픈 시간보다 이후여야 합니다."),
     CHAT_ROOM_EVENT_ID_REQUIRED(HttpStatus.BAD_REQUEST, "eventId는 필수입니다."),
+    CHAT_ROOM_STATUS_INVALID(HttpStatus.BAD_REQUEST, "요청한 작업을 수행할 수 없는 상태입니다."),
 
     // Message
     MESSAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "메시지를 찾을 수 없습니다."),

--- a/chat-service/src/main/java/com/ojosama/chatservice/domain/exception/ChatErrorCode.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/domain/exception/ChatErrorCode.java
@@ -7,10 +7,13 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum ChatErrorCode implements ErrorCode {
 
+    MESSAGE_NOT_EXIST(HttpStatus.BAD_REQUEST, "메시지가 이미 삭제되었습니다."),
     MESSAGE_NOT_ACTIVE(HttpStatus.BAD_REQUEST, "ACTIVE 상태에서만 블라인드할 수 있습니다."),
     INVALID_ADMIN_ID(HttpStatus.BAD_REQUEST, "adminId는 필수입니다."),
     CHAT_ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "채팅방을 찾을 수 없습니다."),
-    CHAT_ROOM_INVALID_TIME(HttpStatus.BAD_REQUEST, "종료 시간은 오픈 시간보다 이후여야 합니다.");
+    CHAT_ROOM_INVALID_TIME(HttpStatus.BAD_REQUEST, "종료 시간은 오픈 시간보다 이후여야 합니다."),
+
+    ;
 
     private final HttpStatus status;
     private final String message;

--- a/chat-service/src/main/java/com/ojosama/chatservice/domain/exception/ChatErrorCode.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/domain/exception/ChatErrorCode.java
@@ -1,0 +1,23 @@
+package com.ojosama.chatservice.domain.exception;
+
+import com.ojosama.common.exception.ErrorCode;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum ChatErrorCode implements ErrorCode {
+
+    MESSAGE_NOT_ACTIVE(HttpStatus.BAD_REQUEST, "ACTIVE 상태에서만 블라인드할 수 있습니다."),
+    INVALID_ADMIN_ID(HttpStatus.BAD_REQUEST, "adminId는 필수입니다."),
+    CHAT_ROOM_NOT_FOUND(HttpStatus.NOT_FOUND, "채팅방을 찾을 수 없습니다."),
+    CHAT_ROOM_INVALID_TIME(HttpStatus.BAD_REQUEST, "종료 시간은 오픈 시간보다 이후여야 합니다.");
+
+    private final HttpStatus status;
+    private final String message;
+
+    ChatErrorCode(HttpStatus status, String message) {
+        this.status = status;
+        this.message = message;
+    }
+
+}

--- a/chat-service/src/main/java/com/ojosama/chatservice/domain/exception/ChatException.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/domain/exception/ChatException.java
@@ -1,0 +1,9 @@
+package com.ojosama.chatservice.domain.exception;
+
+import com.ojosama.common.exception.CustomException;
+
+public class ChatException extends CustomException {
+    public ChatException(ChatErrorCode code) {
+        super(code);
+    }
+}

--- a/chat-service/src/main/java/com/ojosama/chatservice/domain/exception/ChatException.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/domain/exception/ChatException.java
@@ -1,9 +1,10 @@
 package com.ojosama.chatservice.domain.exception;
 
 import com.ojosama.common.exception.CustomException;
+import com.ojosama.common.exception.ErrorCode;
 
 public class ChatException extends CustomException {
-    public ChatException(ChatErrorCode code) {
+    public ChatException(ErrorCode code) {
         super(code);
     }
 }

--- a/chat-service/src/main/java/com/ojosama/chatservice/domain/model/ChatRoom.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/domain/model/ChatRoom.java
@@ -101,7 +101,7 @@ public class ChatRoom extends BaseEntity {
             throw new ChatException(ChatErrorCode.CHAT_ROOM_STATUS_INVALID);
         }
     }
-    
+
     // 서비스 레이어 호출용
     public boolean isOpen() {
         return this.status == ChatRoomStatus.OPEN;
@@ -111,19 +111,16 @@ public class ChatRoom extends BaseEntity {
         return this.status == ChatRoomStatus.CLOSED || this.status == ChatRoomStatus.FORCE_CLOSED;
     }
 
-    // 채팅방 상태 확인 메서드 : 생성 확인
     public void validateSchedulable() {
         validateStatus(ChatRoomStatus.SCHEDULED);
     }
 
-    // 채팅방 상태 확인 메서드 : 오픈 확인
     public void validateOpen() {
         validateStatus(ChatRoomStatus.OPEN);
     }
 
-    // 채팅방 상태 확인 메서드 : 종료 확인
     public void validateClosed() {
-        if (this.status != ChatRoomStatus.CLOSED && this.status != ChatRoomStatus.FORCE_CLOSED) {
+        if (!isClosed()) {
             throw new ChatException(ChatErrorCode.CHAT_ROOM_STATUS_INVALID);
         }
     }

--- a/chat-service/src/main/java/com/ojosama/chatservice/domain/model/ChatRoom.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/domain/model/ChatRoom.java
@@ -86,7 +86,7 @@ public class ChatRoom extends BaseEntity {
 
     public void forceClose(UUID adminId) {
         if (this.status == ChatRoomStatus.CLOSED || this.status == ChatRoomStatus.FORCE_CLOSED) {
-            throw new IllegalStateException("이미 종료된 채팅방입니다.");
+            throw new ChatException(ChatErrorCode.CHAT_ROOM_INVALID_TIME);
         }
         this.status = ChatRoomStatus.FORCE_CLOSED;
         this.closedAt = LocalDateTime.now();

--- a/chat-service/src/main/java/com/ojosama/chatservice/domain/model/ChatRoom.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/domain/model/ChatRoom.java
@@ -1,6 +1,9 @@
 package com.ojosama.chatservice.domain.model;
 
+import com.ojosama.chatservice.domain.exception.ChatErrorCode;
+import com.ojosama.chatservice.domain.exception.ChatException;
 import com.ojosama.common.audit.BaseEntity;
+import com.ojosama.common.exception.CommonErrorCode;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -56,12 +59,11 @@ public class ChatRoom extends BaseEntity {
     private ChatRoom(UUID eventId, EventCategory category,
                      LocalDateTime scheduledOpenAt, LocalDateTime scheduledCloseAt) {
         if (eventId == null || category == null || scheduledOpenAt == null || scheduledCloseAt == null) {
-            throw new IllegalArgumentException("필수 값이 누락되었습니다.");
+            throw new ChatException(CommonErrorCode.INVALID_REQUEST);
         }
         if (!scheduledCloseAt.isAfter(scheduledOpenAt)) {
-            throw new IllegalArgumentException("종료 예정 시간은 오픈 예정 시간 이후여야 합니다.");
+            throw new ChatException(ChatErrorCode.CHAT_ROOM_INVALID_TIME);
         }
-
         this.eventId = eventId;
         this.category = category;
         this.status = ChatRoomStatus.SCHEDULED;

--- a/chat-service/src/main/java/com/ojosama/chatservice/domain/model/ChatRoom.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/domain/model/ChatRoom.java
@@ -5,6 +5,7 @@ import com.ojosama.chatservice.domain.exception.ChatException;
 import com.ojosama.common.audit.BaseEntity;
 import com.ojosama.common.exception.CommonErrorCode;
 import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -40,11 +41,8 @@ public class ChatRoom extends BaseEntity {
     @Column(nullable = false)
     private ChatRoomStatus status;
 
-    @Column(nullable = false)
-    private LocalDateTime scheduledOpenAt;
-
-    @Column(nullable = false)
-    private LocalDateTime scheduledCloseAt;
+    @Embedded
+    private ChatRoomSchedule schedule;
 
     @Column
     private LocalDateTime openedAt;
@@ -56,19 +54,14 @@ public class ChatRoom extends BaseEntity {
     private UUID forceClosedBy;
 
     @Builder
-    private ChatRoom(UUID eventId, EventCategory category,
-                     LocalDateTime scheduledOpenAt, LocalDateTime scheduledCloseAt) {
-        if (eventId == null || category == null || scheduledOpenAt == null || scheduledCloseAt == null) {
+    private ChatRoom(UUID eventId, EventCategory category, ChatRoomSchedule schedule) {
+        if (eventId == null || category == null || schedule == null) {
             throw new ChatException(CommonErrorCode.INVALID_REQUEST);
-        }
-        if (!scheduledCloseAt.isAfter(scheduledOpenAt)) {
-            throw new ChatException(ChatErrorCode.CHAT_ROOM_INVALID_TIME);
         }
         this.eventId = eventId;
         this.category = category;
         this.status = ChatRoomStatus.SCHEDULED;
-        this.scheduledOpenAt = scheduledOpenAt;
-        this.scheduledCloseAt = scheduledCloseAt;
+        this.schedule = schedule;
     }
 
     public void open() {
@@ -102,7 +95,6 @@ public class ChatRoom extends BaseEntity {
         }
     }
 
-    // 서비스 레이어 호출용
     public boolean isOpen() {
         return this.status == ChatRoomStatus.OPEN;
     }
@@ -111,19 +103,11 @@ public class ChatRoom extends BaseEntity {
         return this.status == ChatRoomStatus.CLOSED || this.status == ChatRoomStatus.FORCE_CLOSED;
     }
 
-    public void validateSchedulable() {
-        validateStatus(ChatRoomStatus.SCHEDULED);
+    public boolean shouldOpen(LocalDateTime now) {
+        return this.schedule.shouldOpen(now);
     }
 
-    public void validateOpen() {
-        validateStatus(ChatRoomStatus.OPEN);
+    public boolean shouldClose(LocalDateTime now) {
+        return this.schedule.shouldClose(now);
     }
-
-    public void validateClosed() {
-        if (!isClosed()) {
-            throw new ChatException(ChatErrorCode.CHAT_ROOM_STATUS_INVALID);
-        }
-    }
-
-
 }

--- a/chat-service/src/main/java/com/ojosama/chatservice/domain/model/ChatRoom.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/domain/model/ChatRoom.java
@@ -71,37 +71,62 @@ public class ChatRoom extends BaseEntity {
         this.scheduledCloseAt = scheduledCloseAt;
     }
 
-    // 도메인 행위 메서드
     public void open() {
-        validateStatus(ChatRoomStatus.SCHEDULED, "채팅방 오픈");
+        validateStatus(ChatRoomStatus.SCHEDULED);
         this.status = ChatRoomStatus.OPEN;
         this.openedAt = LocalDateTime.now();
     }
 
     public void close() {
-        validateStatus(ChatRoomStatus.OPEN, "채팅방 종료");
+        validateStatus(ChatRoomStatus.OPEN);
         this.status = ChatRoomStatus.CLOSED;
         this.closedAt = LocalDateTime.now();
     }
 
     public void forceClose(UUID adminId) {
+        if (adminId == null) {
+            throw new ChatException(ChatErrorCode.INVALID_ADMIN_ID);
+        }
         if (this.status == ChatRoomStatus.CLOSED || this.status == ChatRoomStatus.FORCE_CLOSED) {
-            throw new ChatException(ChatErrorCode.CHAT_ROOM_INVALID_TIME);
+            throw new ChatException(ChatErrorCode.CHAT_ROOM_ALREADY_ENDED);
         }
         this.status = ChatRoomStatus.FORCE_CLOSED;
         this.closedAt = LocalDateTime.now();
         this.forceClosedBy = adminId;
     }
 
+    // 채팅방 상태 확인 메서드
+    private void validateStatus(ChatRoomStatus required) {
+        if (this.status != required) {
+            throw new ChatException(ChatErrorCode.CHAT_ROOM_STATUS_INVALID);
+        }
+    }
+    
+    // 서비스 레이어 호출용
     public boolean isOpen() {
         return this.status == ChatRoomStatus.OPEN;
     }
 
-    // 채팅방 상태 확인 메서드
-    private void validateStatus(ChatRoomStatus required, String action) {
-        if (this.status != required) {
-            throw new IllegalStateException(
-                    action + " 불가: 현재 상태 = " + this.status);
+    public boolean isClosed() {
+        return this.status == ChatRoomStatus.CLOSED || this.status == ChatRoomStatus.FORCE_CLOSED;
+    }
+
+    // 채팅방 상태 확인 메서드 : 생성 확인
+    public void validateSchedulable() {
+        validateStatus(ChatRoomStatus.SCHEDULED);
+    }
+
+    // 채팅방 상태 확인 메서드 : 오픈 확인
+    public void validateOpen() {
+        validateStatus(ChatRoomStatus.OPEN);
+    }
+
+    // 채팅방 상태 확인 메서드 : 종료 확인
+    public void validateClosed() {
+        if (this.status != ChatRoomStatus.CLOSED && this.status != ChatRoomStatus.FORCE_CLOSED) {
+            throw new ChatException(ChatErrorCode.CHAT_ROOM_STATUS_INVALID);
         }
     }
+
+
 }

--- a/chat-service/src/main/java/com/ojosama/chatservice/domain/model/ChatRoomSchedule.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/domain/model/ChatRoomSchedule.java
@@ -1,0 +1,42 @@
+package com.ojosama.chatservice.domain.model;
+
+import com.ojosama.chatservice.domain.exception.ChatErrorCode;
+import com.ojosama.chatservice.domain.exception.ChatException;
+import com.ojosama.common.exception.CommonErrorCode;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatRoomSchedule {
+
+    @Column(nullable = false)
+    private LocalDateTime scheduledOpenAt;
+
+    @Column(nullable = false)
+    private LocalDateTime scheduledCloseAt;
+
+    public ChatRoomSchedule(LocalDateTime scheduledOpenAt, LocalDateTime scheduledCloseAt) {
+        if (scheduledOpenAt == null || scheduledCloseAt == null) {
+            throw new ChatException(CommonErrorCode.INVALID_REQUEST);
+        }
+        if (!scheduledCloseAt.isAfter(scheduledOpenAt)) {
+            throw new ChatException(ChatErrorCode.CHAT_ROOM_INVALID_TIME);
+        }
+        this.scheduledOpenAt = scheduledOpenAt;
+        this.scheduledCloseAt = scheduledCloseAt;
+    }
+
+    public boolean shouldOpen(LocalDateTime now) {
+        return !now.isBefore(scheduledOpenAt);
+    }
+
+    public boolean shouldClose(LocalDateTime now) {
+        return !now.isBefore(scheduledCloseAt);
+    }
+}

--- a/chat-service/src/main/java/com/ojosama/chatservice/domain/model/Message.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/domain/model/Message.java
@@ -1,5 +1,7 @@
 package com.ojosama.chatservice.domain.model;
 
+import com.ojosama.chatservice.domain.exception.ChatErrorCode;
+import com.ojosama.chatservice.domain.exception.ChatException;
 import com.ojosama.common.audit.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -57,12 +59,21 @@ public class Message extends BaseEntity {
 
     // 도메인 행위 메서드
     public void blind(UUID adminId) {
+        if (this.status != MessageStatus.ACTIVE) {
+            throw new ChatException(ChatErrorCode.MESSAGE_NOT_ACTIVE);
+        }
+        if (adminId == null) {
+            throw new ChatException(ChatErrorCode.INVALID_ADMIN_ID);
+        }
         this.status = MessageStatus.BLINDED;
         this.blindedAt = LocalDateTime.now();
         this.blindedBy = adminId;
     }
 
     public void delete() {
+        if (this.status == MessageStatus.DELETED) {
+            throw new ChatException(ChatErrorCode.MESSAGE_NOT_EXIST);
+        }
         this.status = MessageStatus.DELETED;
     }
 

--- a/chat-service/src/main/java/com/ojosama/chatservice/domain/model/Message.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/domain/model/Message.java
@@ -72,7 +72,7 @@ public class Message extends BaseEntity {
 
     public void delete() {
         if (this.status == MessageStatus.DELETED) {
-            throw new ChatException(ChatErrorCode.MESSAGE_NOT_EXIST);
+            throw new ChatException(ChatErrorCode.MESSAGE_NOT_FOUND);
         }
         this.status = MessageStatus.DELETED;
     }

--- a/chat-service/src/main/java/com/ojosama/chatservice/infrastructure/persistence/ChatRoomJpaRepository.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/infrastructure/persistence/ChatRoomJpaRepository.java
@@ -16,10 +16,10 @@ public interface ChatRoomJpaRepository extends JpaRepository<ChatRoom, UUID> {
 
     List<ChatRoom> findAllByStatus(ChatRoomStatus status);
 
-    @Query("SELECT c FROM ChatRoom c WHERE c.status = 'SCHEDULED' AND c.scheduledOpenAt <= :now")
+    @Query("SELECT c FROM ChatRoom c WHERE c.status = 'SCHEDULED' AND c.schedule.scheduledOpenAt <= :now")
     List<ChatRoom> findScheduledToOpen(@Param("now") LocalDateTime now);
 
-    @Query("SELECT c FROM ChatRoom c WHERE c.status = 'OPEN' AND c.scheduledCloseAt <= :now")
+    @Query("SELECT c FROM ChatRoom c WHERE c.status = 'OPEN' AND c.schedule.scheduledCloseAt <= :now")
     List<ChatRoom> findScheduledToClose(@Param("now") LocalDateTime now);
 
 }


### PR DESCRIPTION
## 🔗 Issue Number
- close #29 

## 📝 작업 내역

**Exception**
- Common의 Exception 상속받은 ChatException 생성
     - 파라미터 ChatErrorCode -> ErrorCode로 변경
- Common의 ErrorCode 구현한 ChatErrorCode 생성

**도메인 검증 로직 추가**
- 도메인 단에서 검증 로직 추가
- ChatException 사용해 에러 던짐

## 💡 PR 특이사항



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 채팅 방 생성·예약 시간 검증 강화로 잘못된 생성 방지
  * 메시지 블라인드·삭제 시 상태 및 관리자 검증 추가로 중복·무효 작업 차단
  * 강제 종료·상태 전환 검증 강화로 잘못된 상태 변경 방지
  * 오류 발생 시 일관된 한글 메시지와 HTTP 상태 코드 제공으로 사용자 안내 개선

* **기능 개선**
  * 서비스층 검사용 공개 검증 메서드 추가로 안정적 흐름 제어 지원
  * 통일된 예외 타입과 표준화된 오류 코드(한글 메시지 포함) 추가로 오류 처리 일관성 향상
<!-- end of auto-generated comment: release notes by coderabbit.ai -->