### PR TITLE
[FEATURE] 일정 도메인 설계(entity, repository)

### DIFF
--- a/calendar-service/src/main/java/com/ojosama/calendarservice/CalendarServiceApplication.java
+++ b/calendar-service/src/main/java/com/ojosama/calendarservice/CalendarServiceApplication.java
@@ -2,8 +2,12 @@ package com.ojosama.calendarservice;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableFeignClients
+@EnableJpaAuditing
 public class CalendarServiceApplication {
 
 	public static void main(String[] args) {

--- a/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/domain/exception/CalendarErrorCode.java
+++ b/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/domain/exception/CalendarErrorCode.java
@@ -1,0 +1,27 @@
+package com.ojosama.calendarservice.calendar.domain.exception;
+
+import com.ojosama.common.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum CalendarErrorCode implements ErrorCode {
+
+    CALENDAR_NOT_FOUND(HttpStatus.NOT_FOUND, "요청하신 일정을 찾을 수 없습니다."),
+    CALENDAR_ACCESS_DENIED(HttpStatus.FORBIDDEN, "다른 사용자의 일정은 수정할 수 없습니다."),
+    CALENDAR_DELETE_DENIED(HttpStatus.FORBIDDEN, "다른 사용자의 일정은 삭제할 수 없습니다."),
+    EVENT_SCHEDULE_NOT_FOUND(HttpStatus.NOT_FOUND, "요청하신 행사 일정을 찾을 수 없습니다.");
+
+    private final HttpStatus status;
+    private final String message;
+
+    @Override
+    public HttpStatus getStatus() {
+        return status;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/domain/exception/CalendarErrorCode.java
+++ b/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/domain/exception/CalendarErrorCode.java
@@ -10,7 +10,8 @@ public enum CalendarErrorCode implements ErrorCode {
     CALENDAR_NOT_FOUND(HttpStatus.NOT_FOUND, "요청하신 일정을 찾을 수 없습니다."),
     CALENDAR_ACCESS_DENIED(HttpStatus.FORBIDDEN, "다른 사용자의 일정은 수정할 수 없습니다."),
     CALENDAR_DELETE_DENIED(HttpStatus.FORBIDDEN, "다른 사용자의 일정은 삭제할 수 없습니다."),
-    EVENT_SCHEDULE_NOT_FOUND(HttpStatus.NOT_FOUND, "요청하신 행사 일정을 찾을 수 없습니다.");
+    EVENT_SCHEDULE_NOT_FOUND(HttpStatus.NOT_FOUND, "요청하신 행사 일정을 찾을 수 없습니다."),
+    INVALID_INPUT(HttpStatus.BAD_REQUEST, "입력값이 올바르지 않습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/domain/exception/CalendarException.java
+++ b/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/domain/exception/CalendarException.java
@@ -1,0 +1,11 @@
+package com.ojosama.calendarservice.calendar.domain.exception;
+
+import com.ojosama.common.exception.CustomException;
+import com.ojosama.common.exception.ErrorCode;
+
+public class CalendarException extends CustomException {
+
+    public CalendarException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/domain/model/Calendar.java
+++ b/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/domain/model/Calendar.java
@@ -1,0 +1,90 @@
+package com.ojosama.calendarservice.calendar.domain.model;
+
+import com.ojosama.calendarservice.calendar.domain.exception.CalendarErrorCode;
+import com.ojosama.calendarservice.calendar.domain.exception.CalendarException;
+import com.ojosama.common.audit.BaseUserEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "p_calendar")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Calendar extends BaseUserEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(name = "user_id", nullable = false)
+    private UUID userId;
+
+    @Column(name = "event_schedule_id", nullable = false)
+    private UUID eventScheduleId;
+
+    @Column(name = "event_date", nullable = false)
+    private LocalDateTime eventDate;
+
+    @Column(name = "memo", length = 1000)
+    private String memo;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private Calendar(UUID userId, UUID eventScheduleId, LocalDateTime eventDate, String memo) {
+        validateUserId(userId);
+        validateEventScheduleId(eventScheduleId);
+        validateEventDate(eventDate);
+        validateMemo(memo);
+        this.userId = userId;
+        this.eventScheduleId = eventScheduleId;
+        this.eventDate = eventDate;
+        this.memo = memo;
+    }
+
+    public static Calendar create(UUID userId, UUID eventScheduleId, LocalDateTime eventDate, String memo) {
+        return Calendar.builder()
+                .userId(userId)
+                .eventScheduleId(eventScheduleId)
+                .eventDate(eventDate)
+                .memo(memo)
+                .build();
+    }
+
+    public void updateMemo(String memo) {
+        validateMemo(memo);
+        this.memo = memo;
+    }
+
+    private void validateUserId(UUID userId) {
+        if (userId == null) {
+            throw new CalendarException(CalendarErrorCode.CALENDAR_ACCESS_DENIED);
+        }
+    }
+
+    private void validateEventScheduleId(UUID eventScheduleId) {
+        if (eventScheduleId == null) {
+            throw new CalendarException(CalendarErrorCode.EVENT_SCHEDULE_NOT_FOUND);
+        }
+    }
+
+    private void validateEventDate(LocalDateTime eventDate) {
+        if (eventDate == null) {
+            throw new CalendarException(CalendarErrorCode.EVENT_SCHEDULE_NOT_FOUND);
+        }
+    }
+
+    private void validateMemo(String memo) {
+        if (memo != null && memo.length() > 1000) {
+            throw new IllegalArgumentException("메모는 1000자를 초과할 수 없습니다.");
+        }
+    }
+}

--- a/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/domain/model/Calendar.java
+++ b/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/domain/model/Calendar.java
@@ -8,6 +8,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import java.util.UUID;
@@ -17,7 +18,13 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "p_calendar")
+@Table(
+        name = "p_calendar",
+        indexes = {
+                @Index(name = "idx_calendar_user_deleted", columnList = "user_id,deleted_at"),
+                @Index(name = "idx_calendar_user_eventdate_deleted", columnList = "user_id,event_date,deleted_at")
+        }
+)
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Calendar extends BaseUserEntity {
@@ -66,25 +73,25 @@ public class Calendar extends BaseUserEntity {
 
     private void validateUserId(UUID userId) {
         if (userId == null) {
-            throw new CalendarException(CalendarErrorCode.CALENDAR_ACCESS_DENIED);
+            throw new CalendarException(CalendarErrorCode.INVALID_INPUT);
         }
     }
 
     private void validateEventScheduleId(UUID eventScheduleId) {
         if (eventScheduleId == null) {
-            throw new CalendarException(CalendarErrorCode.EVENT_SCHEDULE_NOT_FOUND);
+            throw new CalendarException(CalendarErrorCode.INVALID_INPUT);
         }
     }
 
     private void validateEventDate(LocalDateTime eventDate) {
         if (eventDate == null) {
-            throw new CalendarException(CalendarErrorCode.EVENT_SCHEDULE_NOT_FOUND);
+            throw new CalendarException(CalendarErrorCode.INVALID_INPUT);
         }
     }
 
     private void validateMemo(String memo) {
         if (memo != null && memo.length() > 1000) {
-            throw new IllegalArgumentException("메모는 1000자를 초과할 수 없습니다.");
+            throw new CalendarException(CalendarErrorCode.INVALID_INPUT);
         }
     }
 }

--- a/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/domain/repository/CalendarRepository.java
+++ b/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/domain/repository/CalendarRepository.java
@@ -1,0 +1,20 @@
+package com.ojosama.calendarservice.calendar.domain.repository;
+
+import com.ojosama.calendarservice.calendar.domain.model.Calendar;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface CalendarRepository {
+
+    Calendar save(Calendar calendar);
+
+    Optional<Calendar> findByIdAndDeletedAtIsNull(UUID id);
+
+    Page<Calendar> findByUserIdAndDeletedAtIsNull(UUID userId, Pageable pageable);
+
+    Page<Calendar> findByUserIdAndEventDateBetweenAndDeletedAtIsNull(
+            UUID userId, LocalDateTime start, LocalDateTime end, Pageable pageable);
+}

--- a/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/infrastructure/persistence/CalendarRepositoryImpl.java
+++ b/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/infrastructure/persistence/CalendarRepositoryImpl.java
@@ -1,0 +1,39 @@
+package com.ojosama.calendarservice.calendar.infrastructure.persistence;
+
+import com.ojosama.calendarservice.calendar.domain.model.Calendar;
+import com.ojosama.calendarservice.calendar.domain.repository.CalendarRepository;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class CalendarRepositoryImpl implements CalendarRepository {
+
+    private final JpaCalendarRepository jpaCalendarRepository;
+
+    @Override
+    public Calendar save(Calendar calendar) {
+        return jpaCalendarRepository.save(calendar);
+    }
+
+    @Override
+    public Optional<Calendar> findByIdAndDeletedAtIsNull(UUID id) {
+        return jpaCalendarRepository.findByIdAndDeletedAtIsNull(id);
+    }
+
+    @Override
+    public Page<Calendar> findByUserIdAndDeletedAtIsNull(UUID userId, Pageable pageable) {
+        return jpaCalendarRepository.findByUserIdAndDeletedAtIsNull(userId, pageable);
+    }
+
+    @Override
+    public Page<Calendar> findByUserIdAndEventDateBetweenAndDeletedAtIsNull(
+            UUID userId, LocalDateTime start, LocalDateTime end, Pageable pageable) {
+        return jpaCalendarRepository.findByUserIdAndEventDateBetweenAndDeletedAtIsNull(userId, start, end, pageable);
+    }
+}

--- a/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/infrastructure/persistence/JpaCalendarRepository.java
+++ b/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/infrastructure/persistence/JpaCalendarRepository.java
@@ -1,0 +1,19 @@
+package com.ojosama.calendarservice.calendar.infrastructure.persistence;
+
+import com.ojosama.calendarservice.calendar.domain.model.Calendar;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JpaCalendarRepository extends JpaRepository<Calendar, UUID> {
+
+    Optional<Calendar> findByIdAndDeletedAtIsNull(UUID id);
+
+    Page<Calendar> findByUserIdAndDeletedAtIsNull(UUID userId, Pageable pageable);
+
+    Page<Calendar> findByUserIdAndEventDateBetweenAndDeletedAtIsNull(
+            UUID userId, LocalDateTime start, LocalDateTime end, Pageable pageable);
+}


### PR DESCRIPTION
## 🔗 Issue Number
- close #37 

## 📝 작업 내역

- Calendar 엔티티 구현
- CalendarErrorCode / CalendarException 예외 처리 구현
- CalendarRepository 도메인 인터페이스 정의
- JpaCalendarRepository / CalendarRepositoryImpl 인프라 레이어 구현
- CalendarServiceApplication @EnableFeignClients, @EnableJpaAuditing 추가

## 💡 PR 특이사항

 - 서비스 레이어(Command/Query) 및 컨트롤러는 후속 PR에서 구현 예정
  - 목록 조회 동적 필터링(year, month)은 QueryDSL CalendarQueryRepository로 처리 예정으로, 후속 PR에서 build.gradle QueryDSL 의존성 추가 필요
  - eventDate는 생성 시 event-service Feign 호출로 startTime을 복사 저장하는 구조이며, event-service 내부 API(GET /internal/v1/event-schedules/{id})는 별도 PR로 추가 예정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 캘린더 일정 생성, 조회 및 메모 업데이트 가능
  * 사용자별 캘린더 관리 및 접근권한·삭제 제어 제공
  * 특정 날짜 범위 검색과 페이지 기반 조회 지원
  * 입력 유효성 검사 도입으로 잘못된 입력에 대한 명확한 오류 응답 제공
  * 변경 감사 정보 기록으로 일정 변경 이력 신뢰성 향상
<!-- end of auto-generated comment: release notes by coderabbit.ai -->