### PR TITLE
[FEATURE] chat-service Kafka 기반 행사 생성 시 채팅방 자동 생성

### DIFF
--- a/chat-service/build.gradle
+++ b/chat-service/build.gradle
@@ -13,6 +13,8 @@ dependencies {
     // 커먼 모듈
     implementation project(':common')
 
+    implementation 'org.springframework.kafka:spring-kafka'
+
     // zipkin 테스트용 추가
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     runtimeOnly 'org.postgresql:postgresql'

--- a/chat-service/src/main/java/com/ojosama/chatservice/ChatServiceApplication.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/ChatServiceApplication.java
@@ -1,15 +1,31 @@
 package com.ojosama.chatservice;
 
+import com.ojosama.common.kafka.domain.IdempotentEventHandler;
+import com.ojosama.common.kafka.domain.OutboxRepository;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.context.annotation.ComponentScan.Filter;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableScheduling
+@EntityScan(basePackages = {
+        "com.ojosama.chatservice.domain.model",
+        "com.ojosama.common.kafka.domain"
+})
+@EnableJpaRepositories(basePackages = {
+        "com.ojosama.chatservice.infrastructure.persistence",
+        "com.ojosama.common.kafka.domain"
+}, excludeFilters = @Filter(type = FilterType.ASSIGNABLE_TYPE, classes = OutboxRepository.class))
+@Import(IdempotentEventHandler.class)
 public class ChatServiceApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(ChatServiceApplication.class, args);
-	}
+    public static void main(String[] args) {
+        SpringApplication.run(ChatServiceApplication.class, args);
+    }
 
 }

--- a/chat-service/src/main/java/com/ojosama/chatservice/ChatServiceApplication.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/ChatServiceApplication.java
@@ -9,9 +9,11 @@ import org.springframework.context.annotation.ComponentScan.Filter;
 import org.springframework.context.annotation.FilterType;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableJpaAuditing
 @EnableScheduling
 @EntityScan(basePackages = {
         "com.ojosama.chatservice.domain.model",

--- a/chat-service/src/main/java/com/ojosama/chatservice/application/dto/command/CreateChatRoomCommand.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/application/dto/command/CreateChatRoomCommand.java
@@ -6,6 +6,7 @@ import java.util.UUID;
 
 public record CreateChatRoomCommand(
         UUID eventId,
+        String eventName,
         EventCategory category,
         LocalDateTime scheduledOpenAt,
         LocalDateTime scheduledCloseAt

--- a/chat-service/src/main/java/com/ojosama/chatservice/application/dto/result/ChatRoomResult.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/application/dto/result/ChatRoomResult.java
@@ -9,6 +9,7 @@ import java.util.UUID;
 public record ChatRoomResult(
         UUID chatRoomId,
         UUID eventId,
+        String eventName,
         EventCategory category,
         ChatRoomStatus status,
         LocalDateTime scheduledOpenAt,
@@ -22,6 +23,7 @@ public record ChatRoomResult(
         return new ChatRoomResult(
                 chatRoom.getId(),
                 chatRoom.getEventId(),
+                chatRoom.getEventName(),
                 chatRoom.getCategory(),
                 chatRoom.getStatus(),
                 chatRoom.getSchedule().getScheduledOpenAt(),

--- a/chat-service/src/main/java/com/ojosama/chatservice/application/dto/result/ChatRoomSummaryResult.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/application/dto/result/ChatRoomSummaryResult.java
@@ -1,0 +1,40 @@
+package com.ojosama.chatservice.application.dto.result;
+
+import com.ojosama.chatservice.domain.model.ChatRoom;
+import com.ojosama.chatservice.domain.model.ChatRoomStatus;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record ChatRoomSummaryResult(
+        boolean chatRoomExists,
+        UUID chatRoomId,
+        ChatRoomStatus chatRoomStatus,
+        LocalDateTime scheduledOpenAt,
+        LocalDateTime scheduledCloseAt,
+        LocalDateTime openedAt,
+        LocalDateTime closedAt
+) {
+    public static ChatRoomSummaryResult from(ChatRoom chatRoom) {
+        return new ChatRoomSummaryResult(
+                true,
+                chatRoom.getId(),
+                chatRoom.getStatus(),
+                chatRoom.getSchedule().getScheduledOpenAt(),
+                chatRoom.getSchedule().getScheduledCloseAt(),
+                chatRoom.getOpenedAt(),
+                chatRoom.getClosedAt()
+        );
+    }
+
+    public static ChatRoomSummaryResult empty() {
+        return new ChatRoomSummaryResult(
+                false,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null
+        );
+    }
+}

--- a/chat-service/src/main/java/com/ojosama/chatservice/application/service/ChatRoomSchedulePolicy.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/application/service/ChatRoomSchedulePolicy.java
@@ -5,7 +5,9 @@ import com.ojosama.chatservice.domain.exception.ChatException;
 import com.ojosama.chatservice.domain.model.ChatRoomSchedule;
 import com.ojosama.common.exception.CommonErrorCode;
 import java.time.LocalDateTime;
+import org.springframework.stereotype.Component;
 
+@Component
 public class ChatRoomSchedulePolicy {
 
     public ChatRoomSchedule calculate(LocalDateTime eventStartAt, LocalDateTime eventEndAt) {

--- a/chat-service/src/main/java/com/ojosama/chatservice/application/service/ChatRoomService.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/application/service/ChatRoomService.java
@@ -5,6 +5,7 @@ import com.ojosama.chatservice.application.dto.command.CreateChatRoomCommand;
 import com.ojosama.chatservice.application.dto.query.FindChatRoomByEventIdQuery;
 import com.ojosama.chatservice.application.dto.query.FindChatRoomQuery;
 import com.ojosama.chatservice.application.dto.result.ChatRoomResult;
+import com.ojosama.chatservice.application.dto.result.ChatRoomSummaryResult;
 import com.ojosama.chatservice.domain.exception.ChatErrorCode;
 import com.ojosama.chatservice.domain.exception.ChatException;
 import com.ojosama.chatservice.domain.model.ChatRoom;
@@ -67,6 +68,16 @@ public class ChatRoomService {
         }
         return ChatRoomResult.from(chatRoomRepository.findByEventId(query.eventId())
                 .orElseThrow(() -> new ChatException(ChatErrorCode.CHAT_ROOM_NOT_FOUND)));
+    }
+
+    @Transactional(readOnly = true)
+    public ChatRoomSummaryResult getChatRoomSummaryByEventId(FindChatRoomByEventIdQuery query) {
+        if (query == null || query.eventId() == null) {
+            throw new ChatException(ChatErrorCode.CHAT_ROOM_EVENT_ID_REQUIRED);
+        }
+        return chatRoomRepository.findByEventId(query.eventId())
+                .map(ChatRoomSummaryResult::from)
+                .orElseGet(ChatRoomSummaryResult::empty);
     }
 
     // 상태 분기 : 상태 변경 요청 API 가 들어왔을 때

--- a/chat-service/src/main/java/com/ojosama/chatservice/application/service/ChatRoomService.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/application/service/ChatRoomService.java
@@ -12,10 +12,12 @@ import com.ojosama.chatservice.domain.model.ChatRoom;
 import com.ojosama.chatservice.domain.model.ChatRoomSchedule;
 import com.ojosama.chatservice.domain.repository.ChatRoomRepository;
 import com.ojosama.common.exception.CommonErrorCode;
+import java.sql.SQLException;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.hibernate.exception.ConstraintViolationException;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -146,8 +148,23 @@ public class ChatRoomService {
     }
 
     private boolean isDuplicateEventIdViolation(DataIntegrityViolationException e) {
+        // eventId 유니크 제약 위반만 "채팅방 이미 존재"로 해석
+        // 다른 무결성 오류까지 중복 생성으로 오인하지 않도록, 제약명과 SQLState를 함께 확인
         Throwable cause = e;
         while (cause != null) {
+            // ChatRoom 의 유니크 제약 확인
+            if (cause instanceof ConstraintViolationException constraintViolationException) {
+                if ("uk_chat_room_event_id".equals(constraintViolationException.getConstraintName())) {
+                    return true;
+                }
+            }
+            // PostgreSQL에서 unique key 충돌 제약 23505
+            if (cause instanceof SQLException sqlException) {
+                if ("23505".equals(sqlException.getSQLState())
+                        && isEventIdConstraintMessage(sqlException.getMessage())) {
+                    return true;
+                }
+            }
             String message = cause.getMessage();
             if (message != null && isEventIdConstraintMessage(message)) {
                 return true;
@@ -158,11 +175,13 @@ public class ChatRoomService {
     }
 
     private boolean isEventIdConstraintMessage(String message) {
+        // DB 드라이버/버전에 따라 예외 메시지 포맷이 조금씩 달라질 수 있어서
+        // constraint name / SQLState를 우선 보고, 이 문자열 체크는 보조 수단으로 사용
         String normalized = message.toLowerCase();
         return normalized.contains("uk_chat_room_event_id")
                 || normalized.contains("p_chat_room_event_id_key")
-                || normalized.contains("event_id")
-                && normalized.contains("duplicate key");
+                || (normalized.contains("event_id")
+                && normalized.contains("duplicate key"));
     }
 
 }

--- a/chat-service/src/main/java/com/ojosama/chatservice/application/service/ChatRoomService.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/application/service/ChatRoomService.java
@@ -29,6 +29,7 @@ public class ChatRoomService {
     public ChatRoomResult createChatRoom(CreateChatRoomCommand command) {
         if (command == null
                 || command.eventId() == null
+                || command.eventName() == null || command.eventName().isBlank()
                 || command.category() == null
                 || command.scheduledOpenAt() == null
                 || command.scheduledCloseAt() == null) {
@@ -40,6 +41,7 @@ public class ChatRoomService {
 
         ChatRoom chatRoom = ChatRoom.builder()
                 .eventId(command.eventId())
+                .eventName(command.eventName())
                 .category(command.category())
                 .schedule(new ChatRoomSchedule(command.scheduledOpenAt(), command.scheduledCloseAt()))
                 .build();

--- a/chat-service/src/main/java/com/ojosama/chatservice/application/service/ChatRoomService.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/application/service/ChatRoomService.java
@@ -49,7 +49,10 @@ public class ChatRoomService {
         try {
             return ChatRoomResult.from(chatRoomRepository.save(chatRoom));
         } catch (DataIntegrityViolationException e) {
-            throw new ChatException(ChatErrorCode.CHAT_ROOM_ALREADY_EXISTS);
+            if (isDuplicateEventIdViolation(e)) {
+                throw new ChatException(ChatErrorCode.CHAT_ROOM_ALREADY_EXISTS);
+            }
+            throw e;
         }
     }
 
@@ -141,4 +144,25 @@ public class ChatRoomService {
         return chatRoomRepository.findById(chatRoomId)
                 .orElseThrow(() -> new ChatException(ChatErrorCode.CHAT_ROOM_NOT_FOUND));
     }
+
+    private boolean isDuplicateEventIdViolation(DataIntegrityViolationException e) {
+        Throwable cause = e;
+        while (cause != null) {
+            String message = cause.getMessage();
+            if (message != null && isEventIdConstraintMessage(message)) {
+                return true;
+            }
+            cause = cause.getCause();
+        }
+        return false;
+    }
+
+    private boolean isEventIdConstraintMessage(String message) {
+        String normalized = message.toLowerCase();
+        return normalized.contains("uk_chat_room_event_id")
+                || normalized.contains("p_chat_room_event_id_key")
+                || normalized.contains("event_id")
+                && normalized.contains("duplicate key");
+    }
+
 }

--- a/chat-service/src/main/java/com/ojosama/chatservice/application/service/ChatRoomService.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/application/service/ChatRoomService.java
@@ -15,6 +15,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -42,8 +43,11 @@ public class ChatRoomService {
                 .category(command.category())
                 .schedule(new ChatRoomSchedule(command.scheduledOpenAt(), command.scheduledCloseAt()))
                 .build();
-
-        return ChatRoomResult.from(chatRoomRepository.save(chatRoom));
+        try {
+            return ChatRoomResult.from(chatRoomRepository.save(chatRoom));
+        } catch (DataIntegrityViolationException e) {
+            throw new ChatException(ChatErrorCode.CHAT_ROOM_ALREADY_EXISTS);
+        }
     }
 
     @Transactional(readOnly = true)

--- a/chat-service/src/main/java/com/ojosama/chatservice/domain/model/ChatRoom.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/domain/model/ChatRoom.java
@@ -33,6 +33,9 @@ public class ChatRoom extends BaseEntity {
     @Column(nullable = false, unique = true, columnDefinition = "uuid")
     private UUID eventId;
 
+    @Column(nullable = false)
+    private String eventName;
+
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private EventCategory category;
@@ -54,11 +57,12 @@ public class ChatRoom extends BaseEntity {
     private UUID changedBy;
 
     @Builder
-    private ChatRoom(UUID eventId, EventCategory category, ChatRoomSchedule schedule) {
-        if (eventId == null || category == null || schedule == null) {
+    private ChatRoom(UUID eventId, String eventName, EventCategory category, ChatRoomSchedule schedule) {
+        if (eventId == null || eventName == null || eventName.isBlank() || category == null || schedule == null) {
             throw new ChatException(CommonErrorCode.INVALID_REQUEST);
         }
         this.eventId = eventId;
+        this.eventName = eventName;
         this.category = category;
         this.status = ChatRoomStatus.SCHEDULED;
         this.schedule = schedule;

--- a/chat-service/src/main/java/com/ojosama/chatservice/domain/model/ChatRoom.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/domain/model/ChatRoom.java
@@ -11,6 +11,7 @@ import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.AccessLevel;
@@ -20,7 +21,10 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.UuidGenerator;
 
 @Entity
-@Table(name = "p_chat_room")
+@Table(name = "p_chat_room",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_chat_room_event_id", columnNames = "event_id")
+        })
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ChatRoom extends BaseEntity {

--- a/chat-service/src/main/java/com/ojosama/chatservice/infrastructure/messaging/kafka/consumer/EventCreatedConsumer.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/infrastructure/messaging/kafka/consumer/EventCreatedConsumer.java
@@ -1,0 +1,75 @@
+package com.ojosama.chatservice.infrastructure.messaging.kafka.consumer;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ojosama.chatservice.application.dto.command.CreateChatRoomCommand;
+import com.ojosama.chatservice.application.service.ChatRoomSchedulePolicy;
+import com.ojosama.chatservice.application.service.ChatRoomService;
+import com.ojosama.chatservice.domain.exception.ChatException;
+import com.ojosama.chatservice.domain.model.ChatRoomSchedule;
+import com.ojosama.chatservice.domain.model.EventCategory;
+import com.ojosama.chatservice.infrastructure.messaging.kafka.dto.EventCreatedEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class EventCreatedConsumer {
+
+    private final ObjectMapper objectMapper;
+    private final ChatRoomService chatRoomService;
+    private final ChatRoomSchedulePolicy chatRoomSchedulePolicy;
+
+    @KafkaListener(topics = "${spring.kafka.topic.event-created}", groupId = "chat-service-group")
+    public void consume(String payload) {
+        EventCreatedEvent event = parse(payload);
+        ChatRoomSchedule schedule = chatRoomSchedulePolicy.calculate(event.eventStartAt(), event.eventEndAt());
+        EventCategory category = parseCategory(event.categoryCode());
+
+        try {
+            chatRoomService.createChatRoom(
+                    new CreateChatRoomCommand(
+                            event.eventId(),
+                            category,
+                            schedule.getScheduledOpenAt(),
+                            schedule.getScheduledCloseAt()
+                    )
+            );
+            log.info("행사 이벤트로 채팅방을 자동 생성했습니다. eventId={}, categoryCode={}",
+                    event.eventId(), event.categoryCode());
+        } catch (ChatException e) {
+            if (HttpStatus.CONFLICT.equals(e.getStatus())) {
+                log.info("채팅방이 이미 존재해서 이벤트를 건너뜁니다. eventId={}", event.eventId());
+                return;
+            }
+            throw e;
+        } catch (RuntimeException e) {
+            log.error("행사 이벤트로 채팅방 자동 생성에 실패했습니다. eventId={}, payload={}",
+                    event.eventId(), payload, e);
+            throw e;
+        }
+    }
+
+    private EventCreatedEvent parse(String payload) {
+        try {
+            return objectMapper.readValue(payload, EventCreatedEvent.class);
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException("행사 생성 이벤트 페이로드 파싱에 실패했습니다.", e);
+        }
+    }
+
+    private EventCategory parseCategory(String categoryCode) {
+        if (categoryCode == null || categoryCode.isBlank()) {
+            throw new IllegalArgumentException("카테고리 코드는 비어 있을 수 없습니다.");
+        }
+        try {
+            return EventCategory.valueOf(categoryCode.trim().toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("지원하지 않는 카테고리 코드입니다: " + categoryCode, e);
+        }
+    }
+}

--- a/chat-service/src/main/java/com/ojosama/chatservice/infrastructure/messaging/kafka/consumer/EventCreatedConsumer.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/infrastructure/messaging/kafka/consumer/EventCreatedConsumer.java
@@ -9,8 +9,12 @@ import com.ojosama.chatservice.domain.exception.ChatException;
 import com.ojosama.chatservice.domain.model.ChatRoomSchedule;
 import com.ojosama.chatservice.domain.model.EventCategory;
 import com.ojosama.chatservice.infrastructure.messaging.kafka.dto.EventCreatedEvent;
+import com.ojosama.common.kafka.domain.EventType;
+import com.ojosama.common.kafka.domain.IdempotentEventHandler;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.springframework.http.HttpStatus;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
@@ -20,15 +24,47 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class EventCreatedConsumer {
 
+    private static final String CONSUMER_GROUP = "chat-service-group";
+    private static final String EVENT_TYPE = EventType.EVENT_CREATED.getValue();
+
     private final ObjectMapper objectMapper;
+    private final IdempotentEventHandler idempotentHandler;
     private final ChatRoomService chatRoomService;
     private final ChatRoomSchedulePolicy chatRoomSchedulePolicy;
 
-    @KafkaListener(topics = "${spring.kafka.topic.event-created}", groupId = "chat-service-group")
-    public void consume(String payload) {
+    @KafkaListener(
+            topics = "${spring.kafka.topic.event-created}",
+            groupId = CONSUMER_GROUP,
+            containerFactory = "kafkaListenerContainerFactory"
+    )
+    public void onMessage(ConsumerRecord<String, String> record) {
+        UUID messageKey;
+        EventCreatedEvent event;
+
         try {
-            EventCreatedEvent event = parse(payload);
-            ChatRoomSchedule schedule = chatRoomSchedulePolicy.calculate(event.eventStartAt(), event.eventEndAt());
+            messageKey = UUID.fromString(record.key());
+            event = parse(record.value());
+            idempotentHandler.handle(
+                    messageKey,
+                    CONSUMER_GROUP,
+                    record.topic(),
+                    EVENT_TYPE,
+                    () -> dispatch(event)
+            );
+            log.info("행사 생성 메시지 처리를 완료했습니다. key={}, topic={}", record.key(), record.topic());
+        } catch (RuntimeException e) {
+            log.error("행사 이벤트로 채팅방 자동 생성에 실패했습니다. key={}, payload={}",
+                    record.key(), record.value(), e);
+            throw e;
+        }
+    }
+
+    private void dispatch(EventCreatedEvent event) {
+        try {
+            ChatRoomSchedule schedule = chatRoomSchedulePolicy.calculate(
+                    event.eventStartAt(),
+                    event.eventEndAt()
+            );
             EventCategory category = parseCategory(event.categoryCode());
 
             chatRoomService.createChatRoom(
@@ -44,12 +80,9 @@ public class EventCreatedConsumer {
                     event.eventId(), event.eventName(), event.categoryCode());
         } catch (ChatException e) {
             if (HttpStatus.CONFLICT.equals(e.getStatus())) {
-                log.info("채팅방이 이미 존재해서 이벤트를 건너뜁니다.");
+                log.info("채팅방이 이미 존재해서 이벤트를 건너뜁니다. eventId={}", event.eventId());
                 return;
             }
-            throw e;
-        } catch (RuntimeException e) {
-            log.error("행사 이벤트로 채팅방 자동 생성에 실패했습니다. payload={}", payload, e);
             throw e;
         }
     }

--- a/chat-service/src/main/java/com/ojosama/chatservice/infrastructure/messaging/kafka/consumer/EventCreatedConsumer.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/infrastructure/messaging/kafka/consumer/EventCreatedConsumer.java
@@ -26,11 +26,11 @@ public class EventCreatedConsumer {
 
     @KafkaListener(topics = "${spring.kafka.topic.event-created}", groupId = "chat-service-group")
     public void consume(String payload) {
-        EventCreatedEvent event = parse(payload);
-        ChatRoomSchedule schedule = chatRoomSchedulePolicy.calculate(event.eventStartAt(), event.eventEndAt());
-        EventCategory category = parseCategory(event.categoryCode());
-
         try {
+            EventCreatedEvent event = parse(payload);
+            ChatRoomSchedule schedule = chatRoomSchedulePolicy.calculate(event.eventStartAt(), event.eventEndAt());
+            EventCategory category = parseCategory(event.categoryCode());
+
             chatRoomService.createChatRoom(
                     new CreateChatRoomCommand(
                             event.eventId(),
@@ -44,13 +44,12 @@ public class EventCreatedConsumer {
                     event.eventId(), event.eventName(), event.categoryCode());
         } catch (ChatException e) {
             if (HttpStatus.CONFLICT.equals(e.getStatus())) {
-                log.info("채팅방이 이미 존재해서 이벤트를 건너뜁니다. eventId={}", event.eventId());
+                log.info("채팅방이 이미 존재해서 이벤트를 건너뜁니다.");
                 return;
             }
             throw e;
         } catch (RuntimeException e) {
-            log.error("행사 이벤트로 채팅방 자동 생성에 실패했습니다. eventId={}, payload={}",
-                    event.eventId(), payload, e);
+            log.error("행사 이벤트로 채팅방 자동 생성에 실패했습니다. payload={}", payload, e);
             throw e;
         }
     }

--- a/chat-service/src/main/java/com/ojosama/chatservice/infrastructure/messaging/kafka/consumer/EventCreatedConsumer.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/infrastructure/messaging/kafka/consumer/EventCreatedConsumer.java
@@ -34,13 +34,14 @@ public class EventCreatedConsumer {
             chatRoomService.createChatRoom(
                     new CreateChatRoomCommand(
                             event.eventId(),
+                            event.eventName(),
                             category,
                             schedule.getScheduledOpenAt(),
                             schedule.getScheduledCloseAt()
                     )
             );
-            log.info("행사 이벤트로 채팅방을 자동 생성했습니다. eventId={}, categoryCode={}",
-                    event.eventId(), event.categoryCode());
+            log.info("행사 이벤트로 채팅방을 자동 생성했습니다. eventId={}, eventName={}, categoryCode={}",
+                    event.eventId(), event.eventName(), event.categoryCode());
         } catch (ChatException e) {
             if (HttpStatus.CONFLICT.equals(e.getStatus())) {
                 log.info("채팅방이 이미 존재해서 이벤트를 건너뜁니다. eventId={}", event.eventId());

--- a/chat-service/src/main/java/com/ojosama/chatservice/infrastructure/messaging/kafka/dto/EventCreatedEvent.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/infrastructure/messaging/kafka/dto/EventCreatedEvent.java
@@ -1,0 +1,16 @@
+package com.ojosama.chatservice.infrastructure.messaging.kafka.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record EventCreatedEvent(
+        UUID eventId,
+        String eventName,
+        UUID categoryId,
+        String categoryCode,
+        LocalDateTime eventStartAt,
+        LocalDateTime eventEndAt
+) {
+}

--- a/chat-service/src/main/java/com/ojosama/chatservice/presentation/controller/ChatRoomController.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/presentation/controller/ChatRoomController.java
@@ -48,6 +48,7 @@ public class ChatRoomController {
         ChatRoomResult result = chatRoomService.createChatRoom(
                 new CreateChatRoomCommand(
                         request.eventId(),
+                        request.eventName(),
                         request.category(),
                         request.scheduledOpenAt(),
                         request.scheduledCloseAt()

--- a/chat-service/src/main/java/com/ojosama/chatservice/presentation/controller/InternalChatRoomController.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/presentation/controller/InternalChatRoomController.java
@@ -1,0 +1,32 @@
+package com.ojosama.chatservice.presentation.controller;
+
+import com.ojosama.chatservice.application.dto.query.FindChatRoomByEventIdQuery;
+import com.ojosama.chatservice.application.dto.result.ChatRoomSummaryResult;
+import com.ojosama.chatservice.application.service.ChatRoomService;
+import com.ojosama.chatservice.presentation.dto.response.ChatRoomSummaryResponse;
+import com.ojosama.common.response.ApiResponse;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/internal/v1/chat/rooms")
+public class InternalChatRoomController {
+
+    private final ChatRoomService chatRoomService;
+
+    @GetMapping("/event/{eventId}")
+    public ResponseEntity<ApiResponse<ChatRoomSummaryResponse>> getChatRoomSummaryByEventId(
+            @PathVariable UUID eventId
+    ) {
+        ChatRoomSummaryResult result = chatRoomService.getChatRoomSummaryByEventId(
+                new FindChatRoomByEventIdQuery(eventId)
+        );
+        return ResponseEntity.ok(ApiResponse.success(ChatRoomSummaryResponse.from(result)));
+    }
+}

--- a/chat-service/src/main/java/com/ojosama/chatservice/presentation/dto/request/CreateChatRoomRequest.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/presentation/dto/request/CreateChatRoomRequest.java
@@ -1,12 +1,14 @@
 package com.ojosama.chatservice.presentation.dto.request;
 
 import com.ojosama.chatservice.domain.model.EventCategory;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
 public record CreateChatRoomRequest(
         @NotNull UUID eventId,
+        @NotBlank String eventName,
         @NotNull EventCategory category,
         @NotNull LocalDateTime scheduledOpenAt,
         @NotNull LocalDateTime scheduledCloseAt

--- a/chat-service/src/main/java/com/ojosama/chatservice/presentation/dto/response/ChatRoomResponse.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/presentation/dto/response/ChatRoomResponse.java
@@ -9,6 +9,7 @@ import java.util.UUID;
 public record ChatRoomResponse(
         UUID chatRoomId,
         UUID eventId,
+        String eventName,
         EventCategory category,
         ChatRoomStatus status,
         LocalDateTime scheduledOpenAt,
@@ -20,6 +21,7 @@ public record ChatRoomResponse(
         return new ChatRoomResponse(
                 result.chatRoomId(),
                 result.eventId(),
+                result.eventName(),
                 result.category(),
                 result.status(),
                 result.scheduledOpenAt(),

--- a/chat-service/src/main/java/com/ojosama/chatservice/presentation/dto/response/ChatRoomSummaryResponse.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/presentation/dto/response/ChatRoomSummaryResponse.java
@@ -1,0 +1,28 @@
+package com.ojosama.chatservice.presentation.dto.response;
+
+import com.ojosama.chatservice.application.dto.result.ChatRoomSummaryResult;
+import com.ojosama.chatservice.domain.model.ChatRoomStatus;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record ChatRoomSummaryResponse(
+        boolean chatRoomExists,
+        UUID chatRoomId,
+        ChatRoomStatus chatRoomStatus,
+        LocalDateTime scheduledOpenAt,
+        LocalDateTime scheduledCloseAt,
+        LocalDateTime openedAt,
+        LocalDateTime closedAt
+) {
+    public static ChatRoomSummaryResponse from(ChatRoomSummaryResult result) {
+        return new ChatRoomSummaryResponse(
+                result.chatRoomExists(),
+                result.chatRoomId(),
+                result.chatRoomStatus(),
+                result.scheduledOpenAt(),
+                result.scheduledCloseAt(),
+                result.openedAt(),
+                result.closedAt()
+        );
+    }
+}

--- a/chat-service/src/test/resources/application.yml
+++ b/chat-service/src/test/resources/application.yml
@@ -2,6 +2,7 @@ spring:
   config:
     import: ""   # test 실행시 config server 무시
   kafka:
+    bootstrap-servers: localhost:9092
     consumer:
       group-id: chat-service-group
     topic:

--- a/chat-service/src/test/resources/application.yml
+++ b/chat-service/src/test/resources/application.yml
@@ -1,6 +1,11 @@
 spring:
   config:
     import: ""   # test 실행시 config server 무시
+  kafka:
+    consumer:
+      group-id: chat-service-group
+    topic:
+      event-created: event.info.created
   datasource:
     url: jdbc:h2:mem:testdb;INIT=CREATE SCHEMA IF NOT EXISTS chat_schema
     driver-class-name: org.h2.Driver

--- a/common/src/main/java/com/ojosama/common/kafka/domain/EventType.java
+++ b/common/src/main/java/com/ojosama/common/kafka/domain/EventType.java
@@ -16,7 +16,8 @@ public enum EventType {
     COMMENT_CREATED("CommentCreated"),
     COMMENT_UPDATED("CommentUpdated"),
     POST_REPORTED("PostReported"),
-    COMMENT_REPORTED("CommentReported");
+    COMMENT_REPORTED("CommentReported"),
+    EVENT_CREATED("EventCreated");
 
     private final String value;
 

--- a/common/src/main/java/com/ojosama/common/kafka/domain/IdempotentEventHandler.java
+++ b/common/src/main/java/com/ojosama/common/kafka/domain/IdempotentEventHandler.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 //컨슈머의 멱등 처리 헬퍼
 //messageKey 중복 체크 — 이미 있으면 SKIP.
@@ -15,6 +16,7 @@ import org.springframework.stereotype.Component;
 @Component
 @RequiredArgsConstructor
 @Slf4j
+@Transactional(noRollbackFor = DataIntegrityViolationException.class)
 public class IdempotentEventHandler {
 
     private final InboxRepository inboxRepository;
@@ -33,11 +35,12 @@ public class IdempotentEventHandler {
 
         try {
             inboxRepository.save(InboxMessage.of(messageKey, consumerGroup, topic, eventType));
-
-            businessLogic.run();
         } catch (DataIntegrityViolationException e) {
             // 동시 처리 중 다른 컨슈머가 먼저 inbox에 기록한 경우 (드물지만 가능)
             log.debug("inbox 동시 INSERT 충돌. 다른 컨슈머가 처리 완료한 것으로 간주. key={}", messageKey);
+            return;
         }
+
+        businessLogic.run();
     }
 }

--- a/config-server/Dockerfile
+++ b/config-server/Dockerfile
@@ -1,0 +1,26 @@
+# 1단계 - 빌드
+FROM gradle:8.8-jdk21 AS build
+WORKDIR /app
+
+COPY build.gradle settings.gradle ./
+COPY gradle ./gradle
+COPY config-server ./config-server
+
+RUN gradle :config-server:bootJar -x test --no-daemon
+
+# 2단계 - 실행
+FROM eclipse-temurin:21-jre
+WORKDIR /app
+
+RUN addgroup --system appgroup \
+    && adduser --system --ingroup appgroup appuser
+
+COPY --from=build /app/config-server/build/libs/*.jar app.jar
+
+RUN chown appuser:appgroup /app/app.jar
+
+USER appuser
+
+EXPOSE 8888
+
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/config-server/build.gradle
+++ b/config-server/build.gradle
@@ -19,5 +19,5 @@ dependencyManagement {
     }
 }
 
-bootJar { enabled = false }
-jar { enabled = true }
+bootJar { enabled = true }
+jar { enabled = false }

--- a/config-server/src/main/resources/application.yaml
+++ b/config-server/src/main/resources/application.yaml
@@ -34,7 +34,7 @@ management:
 eureka:
   client:
     service-url:
-      defaultZone: http://localhost:8761/eureka/
+      defaultZone: ${EUREKA_SERVER_URL:http://localhost:8761/eureka/}
   instance:
     instance-id:
       ${spring.cloud.client.hostname}:${spring.application.instance_id:${random.value}}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,6 +79,28 @@ services:
     networks:
       - festie-network
 
+  # ============ config-server ============
+  config-server:
+    build:
+      context: .
+      dockerfile: config-server/Dockerfile
+    container_name: festie-config
+    restart: unless-stopped
+    ports:
+      - "8888:8888"
+    networks:
+      - festie-network
+    depends_on:
+      eureka-server:
+        condition: service_healthy
+    environment:
+      CONFIG_USERNAME: ${CONFIG_USERNAME:-test}
+      CONFIG_PASSWORD: ${CONFIG_PASSWORD:-test}
+      CONFIG_URL: ${CONFIG_URL}
+      GIT_USERNAME: ${GIT_USERNAME}
+      GIT_TOKEN: ${GIT_TOKEN}
+      EUREKA_SERVER_URL: http://eureka-server:8761/eureka/
+
   # ============ eureka-server ============
   eureka-server:
     build:
@@ -113,6 +135,8 @@ services:
         condition: service_healthy
       kafka:
         condition: service_healthy
+      config-server:
+        condition: service_started
       eureka-server:
         condition: service_healthy
     environment:


### PR DESCRIPTION
## 🔗 Issue Number
- close #65

## 📝 작업 내역

- Kafka 기반 행사 생성 이벤트 수신용 `EventCreatedEvent` DTO 추가
- `EventCreatedConsumer` 구현
- 행사 시작/종료 시각을 기반으로 채팅방 스케줄 계산하는 `ChatRoomSchedulePolicy` 연결
- Kafka 이벤트 수신 시 `ChatRoomService.createChatRoom()`으로 채팅방 자동 생성
- `eventId` 중복 수신 시 중복 생성되지 않도록 멱등 처리
- 채팅방 생성 시 `eventName`을 스냅샷으로 저장하도록 반영
- 행사 상세조회 연동용 내부 채팅방 요약 API 추가 💡

## 💡 PR 특이사항

- 채팅방 생성 중복은 `eventId` 기준으로 방지
- 행사 상세조회 화면에서 채팅방 상태를 붙일 수 있도록 `/internal` 조회 API를 함께 추가
- 테스트 환경에서도 Kafka consumer가 뜨도록 설정값을 보강함

## 추가
카프카 공통모듈 사용법에 따라 구조 변경
1. ConsumerRecord<String, String>를 record로 받아
2. **record.key()** 에서 messageKey를 꺼내고
3. **record.value()** 를 EventCreatedEvent로 역직렬화(파싱) -> 실제 채팅방에 쓰이는 dto 로 변경해 파싱 -> **event = parse(record.value());**
4. IdempotentEventHandler.handle(...) 안에 채팅방 생성 로직 
5. () -> dispatch(event)
6. 해당 () -> dispatch(event) 안에있는 로직이 기존 코드와 유사.(채팅방 생성로직)
7. ChatException(CONFLICT)는 중복 생성->skip

IdempotentEventHandler.java
inbox 중복 저장만 따로 잡고, 그 뒤에 비즈니스 로직을 실행하도록 분리
이렇게 해야 중복 inbox 처리와 실제 비즈니스 처리가 섞이지 않는다고함


+++
테스트 확인 완료
임의로 이벤트를 넣음(행사 생성 카프카 이벤트) -> 행사생성시에 자동으로 채팅방 생성확인, 스케쥴링에 따라서 자동으로 상태 변경하는것도 확인 
하면서 수정 필요하거나 추가가 필요한 컨피그 설정도 변경했습니다.

Uploading 화면 기록 2026-04-28 오후 6.19.15.mov…



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * Kafka 이벤트 수신으로 채팅방 자동 생성 기능 추가
  * 채팅방에 이벤트 이름 필드 표시 및 생성 시 필수 입력으로 반영
  * 이벤트 ID로 채팅방 존재/요약을 조회하는 내부 API 및 요약 응답 추가

* **버그 수정**
  * 중복 이벤트 기반 채팅방 생성 시 충돌을 명확히 처리하여 적절히 응답

* **테스트/설정**
  * 테스트 환경에 Kafka 설정 및 관련 의존성 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->