### PR TITLE
[FEATURE] post-service crud

### DIFF
--- a/common/src/main/java/com/ojosama/common/kafka/domain/OutboxEventPublisher.java
+++ b/common/src/main/java/com/ojosama/common/kafka/domain/OutboxEventPublisher.java
@@ -3,6 +3,7 @@ package com.ojosama.common.kafka.domain;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.UUID;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -22,6 +23,7 @@ public class OutboxEventPublisher {
             EventType eventType,
             String topic,
             Object payload) {
+        Objects.requireNonNull(eventType, "eventType must not be null");
         String json;
         try {
             json = objectMapper.writeValueAsString(payload);

--- a/common/src/main/java/com/ojosama/common/kafka/domain/OutboxEventPublisher.java
+++ b/common/src/main/java/com/ojosama/common/kafka/domain/OutboxEventPublisher.java
@@ -19,7 +19,7 @@ public class OutboxEventPublisher {
     public void publish(
             String aggregateType,
             UUID aggregateId,
-            String eventType,
+            EventType eventType,
             String topic,
             Object payload) {
         String json;
@@ -30,7 +30,7 @@ public class OutboxEventPublisher {
                     "이벤트 페이로드 직렬화 실패: " + eventType, e);
         }
         OutboxMessage message = OutboxMessage.create(
-                aggregateType, aggregateId, eventType, topic, json);
+                aggregateType, aggregateId, eventType.getValue(), topic, json);
         outboxRepository.save(message);
     }
 }

--- a/community-service/build.gradle
+++ b/community-service/build.gradle
@@ -4,12 +4,13 @@ ext {
 
 dependencies {
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
-    implementation 'org.springframework.boot:spring-boot-starter-web'
-    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     // Spring Cloud Config Client
     implementation 'org.springframework.cloud:spring-cloud-starter-config'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     runtimeOnly 'org.postgresql:postgresql'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     implementation project(':common')
 }
 

--- a/community-service/src/main/java/com/ojosama/common/domain/exception/CommunityErrorCode.java
+++ b/community-service/src/main/java/com/ojosama/common/domain/exception/CommunityErrorCode.java
@@ -8,8 +8,8 @@ import org.springframework.http.HttpStatus;
 public enum CommunityErrorCode implements ErrorCode {
     INVALID_CONTENT(HttpStatus.BAD_REQUEST, "본문은 비어있을 수 없습니다."),
     CONTENT_TOO_SHORT(HttpStatus.BAD_REQUEST, "본문은 최소 2자 이상이어야 합니다."),
+    CONTENT_TOO_LONG(HttpStatus.BAD_REQUEST, "본문은 4000자 이하여야 합니다."),
     BANNED_WORD_DETECTED(HttpStatus.BAD_REQUEST, "금지어가 포함되어 있습니다.");
-
     private final HttpStatus status;
     private final String message;
 

--- a/community-service/src/main/java/com/ojosama/common/domain/model/Content.java
+++ b/community-service/src/main/java/com/ojosama/common/domain/model/Content.java
@@ -25,9 +25,6 @@ public class Content {
     @Column(columnDefinition = "TEXT", name = "content")
     private String value;
 
-    //별도의 상수 클래스나 DB, Config 파일에서 관리하는 게 좋다.
-    private static final List<String> BANNED_WORDS = List.of("금지어1", "금지어2", "나쁜말");
-
     public Content(String value) {
         validate(value); // 생성 시점에 검증
         this.value = value;
@@ -44,6 +41,9 @@ public class Content {
         if (value.trim().length() < 2) {
             throw new CommunityException(CommunityErrorCode.CONTENT_TOO_SHORT);
         }
+        if (value.length() > 4000) {
+            throw new CommunityException(CommunityErrorCode.CONTENT_TOO_LONG);
+        }
 
         String normalized = value.replaceAll("[^ㄱ-ㅎㅏ-ㅣ가-힣a-zA-Z0-9]", "");
 
@@ -52,5 +52,10 @@ public class Content {
                 throw new CommunityException(CommunityErrorCode.BANNED_WORD_DETECTED);
             }
         }
+    }
+    //게시글이 BLOCKED 처리됐을 때 응답에서 마스킹용으로 사용.
+    //실제 DB 값은 유지하고 조회 시점에만 마스킹된 값을 노출한다.
+    public static String maskedText() {
+        return "차단된 게시물입니다.";
     }
 }

--- a/community-service/src/main/java/com/ojosama/post/application/dto/command/CreatePostCommand.java
+++ b/community-service/src/main/java/com/ojosama/post/application/dto/command/CreatePostCommand.java
@@ -1,0 +1,11 @@
+package com.ojosama.post.application.dto.command;
+
+import java.util.UUID;
+
+public record CreatePostCommand(
+        UUID userId,
+        UUID categoryId,
+        String title,
+        String content
+) {
+}

--- a/community-service/src/main/java/com/ojosama/post/application/dto/command/DeletePostCommand.java
+++ b/community-service/src/main/java/com/ojosama/post/application/dto/command/DeletePostCommand.java
@@ -1,0 +1,10 @@
+package com.ojosama.post.application.dto.command;
+
+import java.util.UUID;
+
+public record DeletePostCommand(
+        UUID postId,
+        UUID requesterId,
+        boolean isAdmin
+) {
+}

--- a/community-service/src/main/java/com/ojosama/post/application/dto/command/UpdatePostCommand.java
+++ b/community-service/src/main/java/com/ojosama/post/application/dto/command/UpdatePostCommand.java
@@ -1,0 +1,12 @@
+package com.ojosama.post.application.dto.command;
+
+import java.util.UUID;
+
+public record UpdatePostCommand(
+        UUID postId,
+        UUID requesterId,
+        UUID categoryId,
+        String title,
+        String content
+) {
+}

--- a/community-service/src/main/java/com/ojosama/post/application/dto/result/PostResult.java
+++ b/community-service/src/main/java/com/ojosama/post/application/dto/result/PostResult.java
@@ -1,0 +1,39 @@
+package com.ojosama.post.application.dto.result;
+
+import com.ojosama.common.domain.model.Content;
+import com.ojosama.post.domain.model.Post;
+import com.ojosama.post.domain.model.PostStatus;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+//Application Service → Presentation Layer 반환용 결과 객체.
+public record PostResult(
+        UUID id,
+        UUID userId,
+        UUID categoryId,
+        String title,
+        Content content,
+        int viewCount,
+        int likeCount,
+        int commentCount,
+        PostStatus status,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+    public static PostResult from(Post post) {
+        return new PostResult(
+                post.getId(),
+                post.getUserId(),
+                post.getCategoryId(),
+                post.getTitle(),
+                post.getContent(),
+                post.getViewCount(),
+                post.getLikeCount(),
+                post.getCommentCount(),
+                post.getStatus(),
+                post.getCreatedAt(),
+                post.getUpdatedAt()
+        );
+    }
+}
+

--- a/community-service/src/main/java/com/ojosama/post/application/dto/result/PostResult.java
+++ b/community-service/src/main/java/com/ojosama/post/application/dto/result/PostResult.java
@@ -1,6 +1,5 @@
 package com.ojosama.post.application.dto.result;
 
-import com.ojosama.common.domain.model.Content;
 import com.ojosama.post.domain.model.Post;
 import com.ojosama.post.domain.model.PostStatus;
 import java.time.LocalDateTime;
@@ -12,7 +11,7 @@ public record PostResult(
         UUID userId,
         UUID categoryId,
         String title,
-        Content content,
+        String content,
         int viewCount,
         int likeCount,
         int commentCount,
@@ -26,7 +25,7 @@ public record PostResult(
                 post.getUserId(),
                 post.getCategoryId(),
                 post.getTitle(),
-                post.getContent(),
+                post.getContent().getValue(),
                 post.getViewCount(),
                 post.getLikeCount(),
                 post.getCommentCount(),

--- a/community-service/src/main/java/com/ojosama/post/application/query/PostListQuery.java
+++ b/community-service/src/main/java/com/ojosama/post/application/query/PostListQuery.java
@@ -1,0 +1,24 @@
+package com.ojosama.post.application.query;
+
+import java.util.UUID;
+import org.springframework.data.domain.Pageable;
+
+//게시글 목록 조회 쿼리
+public record PostListQuery(
+        UUID categoryId,
+        UUID userId,
+        Pageable pageable
+) {
+    public static PostListQuery all(Pageable pageable) {
+        return new PostListQuery(null, null, pageable);
+    }
+
+    public static PostListQuery byCategory(UUID categoryId, Pageable pageable) {
+        return new PostListQuery(categoryId, null, pageable);
+    }
+
+    public static PostListQuery byUser(UUID userId, Pageable pageable) {
+        return new PostListQuery(null, userId, pageable);
+    }
+}
+

--- a/community-service/src/main/java/com/ojosama/post/application/service/PostLikeService.java
+++ b/community-service/src/main/java/com/ojosama/post/application/service/PostLikeService.java
@@ -35,8 +35,10 @@ public class PostLikeService {
                             .build();
             postLikeRepository.save(like);
         } catch (DataIntegrityViolationException e) {
-            // 동시 INSERT 경합 — 다른 트랜잭션이 먼저 INSERT한 경우
-            throw new PostException(PostErrorCode.ALREADY_LIKED);
+            if (isDuplicateLikeViolation(e)) {
+                throw new PostException(PostErrorCode.ALREADY_LIKED);
+            }
+            throw e; //중복 키 위반만 선별해서 변환하고 나머지는 그대로 전파해야 원인 파악이 가능합니다.
         }
 
         postRepository.incrementLikeCount(postId);
@@ -62,5 +64,10 @@ public class PostLikeService {
         if (post.isBlocked()) {
             throw new PostException(PostErrorCode.POST_BLOCKED);
         }
+    }
+
+    private boolean isDuplicateLikeViolation(DataIntegrityViolationException e) {
+        String message = e.getMostSpecificCause().getMessage();
+        return message != null && message.contains("user_id");
     }
 }

--- a/community-service/src/main/java/com/ojosama/post/application/service/PostLikeService.java
+++ b/community-service/src/main/java/com/ojosama/post/application/service/PostLikeService.java
@@ -1,0 +1,66 @@
+package com.ojosama.post.application.service;
+
+import com.ojosama.post.domain.exception.PostErrorCode;
+import com.ojosama.post.domain.exception.PostException;
+import com.ojosama.post.domain.model.Post;
+import com.ojosama.post.domain.model.PostLike;
+import com.ojosama.post.domain.repository.PostLikeRepository;
+import com.ojosama.post.domain.repository.PostRepository;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PostLikeService {
+
+    private final PostRepository postRepository;
+    private final PostLikeRepository postLikeRepository;
+
+    @Transactional
+    public void like(UUID postId, UUID userId) {
+        validatePostAlive(postId);
+
+        if (postLikeRepository.existsByPostIdAndUserId(postId, userId)) {
+            throw new PostException(PostErrorCode.ALREADY_LIKED);
+        }
+
+        try {
+            PostLike like = PostLike.builder()
+                            .id(UUID.randomUUID())
+                            .postId(postId)
+                            .userId(userId)
+                            .build();
+            postLikeRepository.save(like);
+        } catch (DataIntegrityViolationException e) {
+            // 동시 INSERT 경합 — 다른 트랜잭션이 먼저 INSERT한 경우
+            throw new PostException(PostErrorCode.ALREADY_LIKED);
+        }
+
+        postRepository.incrementLikeCount(postId);
+    }
+
+    @Transactional
+    public void unlike(UUID postId, UUID userId){
+        validatePostAlive(postId);
+
+        int deleted = postLikeRepository.deleteByPostIdAndUserId(postId, userId);
+        if (deleted == 0) {
+            throw new PostException(PostErrorCode.NOT_LIKED);
+        }
+        postRepository.decrementLikeCount(postId);
+    }
+
+    private void validatePostAlive(UUID postId) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new PostException(PostErrorCode.POST_NOT_FOUND));
+        if (post.getDeletedAt() != null) {
+            throw new PostException(PostErrorCode.POST_NOT_FOUND);
+        }
+        if (post.isBlocked()) {
+            throw new PostException(PostErrorCode.POST_BLOCKED);
+        }
+    }
+}

--- a/community-service/src/main/java/com/ojosama/post/application/service/PostService.java
+++ b/community-service/src/main/java/com/ojosama/post/application/service/PostService.java
@@ -98,9 +98,10 @@ public class PostService {
         if (post.isBlocked()) {
             return PostResult.from(post);
         }
-        // 본문 수정 트랜잭션과 분리하기 위해 별도 native UPDATE
-        postRepository.incrementViewCount(postId);
-        // viewCount는 native UPDATE로 +1 됐으나 영속 객체엔 반영 안 됐으니 +1 보정해서 반환
+        int affected = postRepository.incrementViewCount(postId);
+        if (affected == 0) {
+            throw new PostException(PostErrorCode.POST_NOT_FOUND);
+        }
         return adjustViewCountForResponse(post, 1);
     }
 

--- a/community-service/src/main/java/com/ojosama/post/application/service/PostService.java
+++ b/community-service/src/main/java/com/ojosama/post/application/service/PostService.java
@@ -4,6 +4,7 @@ import com.ojosama.common.domain.model.Content;
 import com.ojosama.common.kafka.domain.EventType;
 import com.ojosama.common.kafka.domain.OutboxEventPublisher;
 import com.ojosama.post.application.dto.command.CreatePostCommand;
+import com.ojosama.post.application.dto.command.DeletePostCommand;
 import com.ojosama.post.application.dto.command.UpdatePostCommand;
 import com.ojosama.post.application.dto.result.PostResult;
 import com.ojosama.post.domain.event.payload.PostCreatedEvent;
@@ -75,6 +76,15 @@ public class PostService {
                 )
         );
         return PostResult.from(post);
+    }
+
+    @Transactional
+    public void delete(DeletePostCommand cmd) {
+        Post post = loadAlive(cmd.postId());
+        if( !cmd.isAdmin() && !post.isOwnedBy(cmd.requesterId())){
+            throw new PostException(PostErrorCode.POST_ACCESS_DENIED);
+        }
+        post.deleted();
     }
 
     private Post loadAlive(UUID postId) {

--- a/community-service/src/main/java/com/ojosama/post/application/service/PostService.java
+++ b/community-service/src/main/java/com/ojosama/post/application/service/PostService.java
@@ -87,7 +87,7 @@ public class PostService {
         if( !cmd.isAdmin() && !post.isOwnedBy(cmd.requesterId())){
             throw new PostException(PostErrorCode.POST_ACCESS_DENIED);
         }
-        post.deleted();
+        post.deleted(cmd.requesterId());
     }
 
     @Transactional

--- a/community-service/src/main/java/com/ojosama/post/application/service/PostService.java
+++ b/community-service/src/main/java/com/ojosama/post/application/service/PostService.java
@@ -7,15 +7,18 @@ import com.ojosama.post.application.dto.command.CreatePostCommand;
 import com.ojosama.post.application.dto.command.DeletePostCommand;
 import com.ojosama.post.application.dto.command.UpdatePostCommand;
 import com.ojosama.post.application.dto.result.PostResult;
+import com.ojosama.post.application.query.PostListQuery;
 import com.ojosama.post.domain.event.payload.PostCreatedEvent;
 import com.ojosama.post.domain.event.payload.PostUpdateEvent;
 import com.ojosama.post.domain.exception.PostErrorCode;
 import com.ojosama.post.domain.exception.PostException;
 import com.ojosama.post.domain.model.Post;
+import com.ojosama.post.domain.model.PostStatus;
 import com.ojosama.post.domain.repository.PostRepository;
 import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -99,6 +102,21 @@ public class PostService {
         postRepository.incrementViewCount(postId);
         // viewCount는 native UPDATE로 +1 됐으나 영속 객체엔 반영 안 됐으니 +1 보정해서 반환
         return adjustViewCountForResponse(post, 1);
+    }
+
+    public Page<PostResult> list(PostListQuery query) {
+        Page<Post> posts;
+        if (query.categoryId() != null) {
+            posts = postRepository.findByCategoryIdAndDeletedAtIsNullAndStatusNot(
+                    query.categoryId(), PostStatus.BLOCKED, query.pageable());
+        } else if (query.userId() != null) {
+            posts = postRepository.findByUserIdAndDeletedAtIsNullAndStatusNot(
+                    query.userId(), PostStatus.BLOCKED, query.pageable());
+        } else {
+            posts = postRepository.findByDeletedAtIsNullAndStatusNot(
+                    PostStatus.BLOCKED, query.pageable());
+        }
+        return posts.map(PostResult::from);
     }
 
     private Post loadAlive(UUID postId) {

--- a/community-service/src/main/java/com/ojosama/post/application/service/PostService.java
+++ b/community-service/src/main/java/com/ojosama/post/application/service/PostService.java
@@ -1,0 +1,54 @@
+package com.ojosama.post.application.service;
+
+import com.ojosama.common.domain.model.Content;
+import com.ojosama.common.kafka.domain.EventType;
+import com.ojosama.common.kafka.domain.OutboxEventPublisher;
+import com.ojosama.post.application.dto.command.CreatePostCommand;
+import com.ojosama.post.application.dto.result.PostResult;
+import com.ojosama.post.domain.event.payload.PostCreatedEvent;
+import com.ojosama.post.domain.model.Post;
+import com.ojosama.post.domain.repository.PostRepository;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PostService {
+    private static final String AGGREGATE_TYPE = "POST";
+
+    private final PostRepository postRepository;
+    private final OutboxEventPublisher outbox;
+
+    @Transactional
+    public PostResult create(CreatePostCommand cmd){
+        UUID id = UUID.randomUUID();
+        Post post = Post.create(
+                id,
+                cmd.userId(),
+                cmd.categoryId(),
+                cmd.title(),
+                new Content(cmd.content())
+        );
+        postRepository.save(post);
+
+        outbox.publish(
+                AGGREGATE_TYPE, post.getId(),
+                String.valueOf(EventType.POST_CREATED), "community.post.created.v1",
+                new PostCreatedEvent(
+                        post.getId(),
+                        post.getUserId(),
+                        post.getCategoryId(),
+                        post.getTitle(),
+                        post.getContent().getValue(),
+                        LocalDateTime.now()
+                )
+        );
+        return PostResult.from(post);
+    }
+
+
+}

--- a/community-service/src/main/java/com/ojosama/post/application/service/PostService.java
+++ b/community-service/src/main/java/com/ojosama/post/application/service/PostService.java
@@ -87,6 +87,20 @@ public class PostService {
         post.deleted();
     }
 
+    @Transactional
+    public PostResult getDetail(UUID postId) {
+        Post post = loadAlive(postId);
+        // BLOCKED 게시글도 200으로 응답한다 (PostResponse에서 마스킹 처리).
+        // 단, 조회수는 증가시키지 않음 — 차단된 게시글에 어뷰징성 조회수 발생 방지.
+        if (post.isBlocked()) {
+            return PostResult.from(post);
+        }
+        // 본문 수정 트랜잭션과 분리하기 위해 별도 native UPDATE
+        postRepository.incrementViewCount(postId);
+        // viewCount는 native UPDATE로 +1 됐으나 영속 객체엔 반영 안 됐으니 +1 보정해서 반환
+        return adjustViewCountForResponse(post, 1);
+    }
+
     private Post loadAlive(UUID postId) {
         Post post = postRepository.findById(postId).orElseThrow(
                 ()-> new PostException(PostErrorCode.POST_NOT_FOUND));
@@ -94,6 +108,22 @@ public class PostService {
             throw new PostException(PostErrorCode.POST_NOT_FOUND);
         }
         return post;
+    }
+
+    private PostResult adjustViewCountForResponse(Post post, int delta) {
+        return new PostResult(
+                post.getId(),
+                post.getUserId(),
+                post.getCategoryId(),
+                post.getTitle(),
+                post.getContent() != null ? post.getContent().getValue() : null,
+                post.getViewCount() + delta,
+                post.getLikeCount(),
+                post.getCommentCount(),
+                post.getStatus(),
+                post.getCreatedAt(),
+                post.getUpdatedAt()
+        );
     }
 
 

--- a/community-service/src/main/java/com/ojosama/post/application/service/PostService.java
+++ b/community-service/src/main/java/com/ojosama/post/application/service/PostService.java
@@ -45,7 +45,7 @@ public class PostService {
 
         outbox.publish(
                 AGGREGATE_TYPE, post.getId(),
-                String.valueOf(EventType.POST_CREATED), "community.post.created.v1",
+                EventType.POST_CREATED, "community.post.created.v1",
                 new PostCreatedEvent(
                         post.getId(),
                         post.getUserId(),
@@ -68,7 +68,7 @@ public class PostService {
 
         outbox.publish(
                 AGGREGATE_TYPE, post.getId(),
-                String.valueOf(EventType.POST_UPDATED), "community.post.updated.v1",
+                EventType.POST_UPDATED, "community.post.updated.v1",
                 new PostUpdateEvent(
                         post.getId(),
                         post.getUserId(),

--- a/community-service/src/main/java/com/ojosama/post/application/service/PostService.java
+++ b/community-service/src/main/java/com/ojosama/post/application/service/PostService.java
@@ -4,8 +4,12 @@ import com.ojosama.common.domain.model.Content;
 import com.ojosama.common.kafka.domain.EventType;
 import com.ojosama.common.kafka.domain.OutboxEventPublisher;
 import com.ojosama.post.application.dto.command.CreatePostCommand;
+import com.ojosama.post.application.dto.command.UpdatePostCommand;
 import com.ojosama.post.application.dto.result.PostResult;
 import com.ojosama.post.domain.event.payload.PostCreatedEvent;
+import com.ojosama.post.domain.event.payload.PostUpdateEvent;
+import com.ojosama.post.domain.exception.PostErrorCode;
+import com.ojosama.post.domain.exception.PostException;
 import com.ojosama.post.domain.model.Post;
 import com.ojosama.post.domain.repository.PostRepository;
 import java.time.LocalDateTime;
@@ -48,6 +52,38 @@ public class PostService {
                 )
         );
         return PostResult.from(post);
+    }
+
+    @Transactional
+    public PostResult update(UpdatePostCommand cmd){
+        Post post = loadAlive(cmd.postId());
+        if (!post.isOwnedBy(cmd.requesterId())){
+            throw new PostException(PostErrorCode.POST_ACCESS_DENIED);
+        }
+        post.update(cmd.title(), new Content(cmd.content()), cmd.categoryId());
+
+        outbox.publish(
+                AGGREGATE_TYPE, post.getId(),
+                String.valueOf(EventType.POST_UPDATED), "community.post.updated.v1",
+                new PostUpdateEvent(
+                        post.getId(),
+                        post.getUserId(),
+                        post.getCategoryId(),
+                        post.getTitle(),
+                        post.getContent().getValue(),
+                        LocalDateTime.now()
+                )
+        );
+        return PostResult.from(post);
+    }
+
+    private Post loadAlive(UUID postId) {
+        Post post = postRepository.findById(postId).orElseThrow(
+                ()-> new PostException(PostErrorCode.POST_NOT_FOUND));
+        if(post.getDeletedAt() != null) {
+            throw new PostException(PostErrorCode.POST_NOT_FOUND);
+        }
+        return post;
     }
 
 

--- a/community-service/src/main/java/com/ojosama/post/domain/event/payload/PostCreatedEvent.java
+++ b/community-service/src/main/java/com/ojosama/post/domain/event/payload/PostCreatedEvent.java
@@ -1,0 +1,20 @@
+package com.ojosama.post.domain.event.payload;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+//게시글 생성 시 발행 — AI 서비스가 부적절 검증을 위해 수신. Domain Event
+//Post가 만들어지면 무조건 이 스티커(Event)가 생긴다는 규칙을 틀(도메인)안에 넣어놓기 위해 domain계층에 존재.
+//게시글이 생성됨이라는 비즈니스 언어의 일부
+// Post.create()가 호출되는 시점에 어떤 정보가 핵심인지 정의하는 것은 도메인의 권한. 따라서 PostCreatedEvent는 도메인 객체의 상태 변경을 가장 잘 대변하는 도메인의 파생물
+//계층형 아키텍처의 의존성 방향 application -> domain(의존없음)
+public record PostCreatedEvent(
+        UUID postId,
+        UUID userId,
+        UUID categoryId,
+        String title,
+        String content,
+        LocalDateTime occurredAt
+) {
+}
+

--- a/community-service/src/main/java/com/ojosama/post/domain/event/payload/PostUpdateEvent.java
+++ b/community-service/src/main/java/com/ojosama/post/domain/event/payload/PostUpdateEvent.java
@@ -1,0 +1,14 @@
+package com.ojosama.post.domain.event.payload;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record PostUpdateEvent(
+        UUID postId,
+        UUID userId,
+        UUID categoryId,
+        String title,
+        String content,
+        LocalDateTime occurredAt
+) {
+}

--- a/community-service/src/main/java/com/ojosama/post/domain/exception/PostErrorCode.java
+++ b/community-service/src/main/java/com/ojosama/post/domain/exception/PostErrorCode.java
@@ -8,10 +8,16 @@ import org.springframework.http.HttpStatus;
 public enum PostErrorCode implements ErrorCode {
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 게시글입니다."),
     POST_ACCESS_DENIED(HttpStatus.FORBIDDEN, "게시글에 대한 권한이 없습니다."),
+    POST_BLOCKED(HttpStatus.FORBIDDEN, "차단된 게시글입니다."),
+
     INVALID_POST_TITLE(HttpStatus.BAD_REQUEST, "게시글 제목이 올바르지 않습니다."),
     INVALID_CATEGORY(HttpStatus.BAD_REQUEST, "카테고리 이름이 올바르지 않습니다."),
+
     LIKE_COUNT_CANNOT_BE_NEGATIVE(HttpStatus.BAD_REQUEST, "좋아요 수는 0 미만이 될 수 없습니다."),
-    COMMENT_COUNT_CANNOT_BE_NEGATIVE(HttpStatus.BAD_REQUEST, "댓글 수는 0 미만이 될 수 없습니다.");
+    COMMENT_COUNT_CANNOT_BE_NEGATIVE(HttpStatus.BAD_REQUEST, "댓글 수는 0 미만이 될 수 없습니다."),
+
+    ALREADY_LIKED(HttpStatus.CONFLICT, "이미 좋아요한 게시글입니다."),
+    NOT_LIKED(HttpStatus.CONFLICT, "좋아요하지 않은 게시글입니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/community-service/src/main/java/com/ojosama/post/domain/model/Post.java
+++ b/community-service/src/main/java/com/ojosama/post/domain/model/Post.java
@@ -1,6 +1,6 @@
 package com.ojosama.post.domain.model;
 
-import com.ojosama.common.audit.BaseEntity;
+import com.ojosama.common.audit.BaseUserEntity;
 import com.ojosama.common.domain.model.Content;
 import com.ojosama.post.domain.exception.PostErrorCode;
 import com.ojosama.post.domain.exception.PostException;
@@ -30,7 +30,7 @@ import lombok.NoArgsConstructor;
 )
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Post extends BaseEntity {
+public class Post extends BaseUserEntity {
 
     private static final int MAX_TITLE_LENGTH = 200;
 

--- a/community-service/src/main/java/com/ojosama/post/domain/model/Post.java
+++ b/community-service/src/main/java/com/ojosama/post/domain/model/Post.java
@@ -1,6 +1,5 @@
 package com.ojosama.post.domain.model;
 
-import com.ojosama.category.domain.model.Category;
 import com.ojosama.common.audit.BaseEntity;
 import com.ojosama.common.domain.model.Content;
 import com.ojosama.post.domain.exception.PostErrorCode;
@@ -10,96 +9,128 @@ import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Index;
 import jakarta.persistence.Table;
+import jakarta.persistence.Version;
+import java.util.Objects;
 import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "p_post")
+@Table(
+        name = "p_post",
+        indexes = {
+                @Index(name = "idx_post_user", columnList = "user_id"),
+                @Index(name = "idx_post_category", columnList = "category_id"),
+                @Index(name = "idx_post_status_created", columnList = "status, created_at")
+        }
+)
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Post extends BaseEntity {
 
+    private static final int MAX_TITLE_LENGTH = 200;
+
     @Id
     private UUID id;
 
-    @Column(nullable = false)
-    private UUID userId; // 작성자 서비스 참조
+    @Column(name = "user_id", nullable = false)
+    private UUID userId;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "category_id", nullable = false)
-    private Category category;
+    @Column(name = "category_id", nullable = false)
+    private UUID categoryId;
 
-    @Column(nullable = false)
+    @Column(nullable = false, length = MAX_TITLE_LENGTH)
     private String title;
 
     @Embedded
     private Content content;
 
+    /**
+     * 조회 응답용 캐시 카운터. 실제 증감은 native UPDATE로 처리되며,
+     * JPA dirty checking으로 변경하지 않는다.
+     */
+    @Column(nullable = false)
     private int viewCount = 0;
+
+    @Column(nullable = false)
     private int likeCount = 0;
+
+    @Column(nullable = false)
     private int commentCount = 0;
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
+    @Column(nullable = false, length = 20)
     private PostStatus status = PostStatus.UNVERIFIED;
 
-    public void update(String title, Content content, Category category) {
-        if (title == null || title.isBlank()) {
-            throw new PostException(PostErrorCode.INVALID_POST_TITLE);
-        }
-        if (category == null) {
-            throw new PostException(PostErrorCode.INVALID_CATEGORY);
-        }
+    /** 본문/제목/카테고리/상태 변경 시에만 영향. 카운터는 native UPDATE라 무관. */
+    @Version
+    private Long version;
+
+    // ── 생성 ─────────────────────────────────────────────────
+    public static Post create(UUID id, UUID userId, UUID categoryId, String title, Content content) {
+        validateTitle(title);
+        Objects.requireNonNull(userId, "userId must not be null");
+        Objects.requireNonNull(categoryId, "categoryId must not be null");
+        Objects.requireNonNull(content, "content must not be null");
+
+        Post post = new Post();
+        post.id = Objects.requireNonNull(id, "id must not be null");
+        post.userId = userId;
+        post.categoryId = categoryId;
+        post.title = title;
+        post.content = content;
+        post.status = PostStatus.UNVERIFIED;
+        return post;
+    }
+
+    // ── 수정 ─────────────────────────────────────────────────
+    /**
+     * 게시글 본문 수정. 상태는 UNVERIFIED로 리셋하지 않으며,
+     * 본문 수정 시점에는 그대로 유지하고 AI 재검증 이벤트만 발행한다.
+     * (사용자 피드백: CLEAN 게시글이 잠시 안 보이는 부작용 방지)
+     */
+    public void update(String title, Content content, UUID categoryId) {
+        validateTitle(title);
+        Objects.requireNonNull(categoryId, "categoryId must not be null");
+        Objects.requireNonNull(content, "content must not be null");
+
         this.title = title;
         this.content = content;
-        this.category = category;
+        this.categoryId = categoryId;
     }
 
-    public void increaseLikeCount() {
-        this.likeCount++;
-    }
-
-    public void decreaseLikeCount() {
-        if (this.likeCount <= 0) {
-            throw new PostException(PostErrorCode.LIKE_COUNT_CANNOT_BE_NEGATIVE);
-        }
-        this.likeCount--;
-    }
-
-    // ── 조회수 ───────────────────────────────────────────────
-    public void increaseViewCount() {
-        this.viewCount++;
-    }
-
-    // ── 댓글수 ───────────────────────────────────────────────
-    public void increaseCommentCount() {
-        this.commentCount++;
-    }
-
-    public void decreaseCommentCount() {
-        if (this.commentCount <= 0) {
-            throw new PostException(PostErrorCode.COMMENT_COUNT_CANNOT_BE_NEGATIVE);
-        }
-        this.commentCount--;
-    }
-
-    // ── 상태 변경 ─────────────────────────────────────────────
+    // ── 상태 전이 ─────────────────────────────────────────────
     public void markAsClean() {
         this.status = PostStatus.CLEAN;
     }
 
-    public void report() {
-        this.status = PostStatus.REPORTED;
-    }
-
+    /**
+     * 게시글 차단. AI 부적절 판정 또는 관리자 차단 또는 작성자 블랙리스트 처리 시 호출.
+     */
     public void block() {
         this.status = PostStatus.BLOCKED;
+    }
+
+    public boolean isBlocked() {
+        return this.status == PostStatus.BLOCKED;
+    }
+
+    // ── 인가 헬퍼 ─────────────────────────────────────────────
+    public boolean isOwnedBy(UUID userId) {
+        return this.userId.equals(userId);
+    }
+
+    // ── 내부 검증 ─────────────────────────────────────────────
+    private static void validateTitle(String title) {
+        if (title == null || title.isBlank()) {
+            throw new PostException(PostErrorCode.INVALID_POST_TITLE);
+        }
+        if (title.length() > MAX_TITLE_LENGTH) {
+            throw new PostException(PostErrorCode.INVALID_POST_TITLE);
+        }
     }
 }

--- a/community-service/src/main/java/com/ojosama/post/domain/repository/PostLikeRepository.java
+++ b/community-service/src/main/java/com/ojosama/post/domain/repository/PostLikeRepository.java
@@ -4,12 +4,16 @@ import com.ojosama.post.domain.model.PostLike;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface PostLikeRepository extends JpaRepository<PostLike, UUID> {
 
     // 좋아요 중복 체크용
     boolean existsByPostIdAndUserId(UUID postId, UUID userId);
 
-    // 좋아요 취소용
-    Optional<PostLike> findByPostIdAndUserId(UUID postId, UUID userId);
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("DELETE FROM PostLike pl WHERE pl.postId = :postId AND pl.userId = :userId")
+    int deleteByPostIdAndUserId(@Param("postId") UUID postId, @Param("userId") UUID userId);
 }

--- a/community-service/src/main/java/com/ojosama/post/domain/repository/PostRepository.java
+++ b/community-service/src/main/java/com/ojosama/post/domain/repository/PostRepository.java
@@ -1,8 +1,11 @@
 package com.ojosama.post.domain.repository;
 
 import com.ojosama.post.domain.model.Post;
+import com.ojosama.post.domain.model.PostStatus;
 import java.util.List;
 import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -22,4 +25,18 @@ public interface PostRepository extends JpaRepository<Post, UUID> {
     @Query("UPDATE Post p SET p.viewCount = p.viewCount + 1 WHERE p.id = :id")
     int incrementViewCount(@Param("id") UUID id);
 
+    /** 특정 유저가 쓴 게시글 (소프트 삭제/BLOCKED 제외). */
+    Page<Post> findByUserIdAndDeletedAtIsNullAndStatusNot(
+            UUID userId, PostStatus excludedStatus, Pageable pageable);
+//    @Query("SELECT p FROM Post p WHERE p.userId = :userId " +
+//            "AND p.deletedAt IS NULL AND p.status != 'BLOCKED'")
+//    Page<Post> findActivePostsByUserId(UUID userId, Pageable pageable);
+
+    /** 카테고리별 게시글 (소프트 삭제/BLOCKED 제외). */
+    Page<Post> findByCategoryIdAndDeletedAtIsNullAndStatusNot(
+            UUID categoryId, PostStatus excludedStatus, Pageable pageable);
+
+    /** 전체 목록 (소프트 삭제/BLOCKED 제외). */
+    Page<Post> findByDeletedAtIsNullAndStatusNot(
+            PostStatus excludedStatus, Pageable pageable);
 }

--- a/community-service/src/main/java/com/ojosama/post/domain/repository/PostRepository.java
+++ b/community-service/src/main/java/com/ojosama/post/domain/repository/PostRepository.java
@@ -4,6 +4,9 @@ import com.ojosama.post.domain.model.Post;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface PostRepository extends JpaRepository<Post, UUID> {
 
@@ -12,4 +15,11 @@ public interface PostRepository extends JpaRepository<Post, UUID> {
 
     // 카테고리별 게시글 목록
     List<Post> findByCategoryIdAndDeletedAtIsNull(UUID categoryId);
+
+    //조회수 증가. MVP는 매 조회마다 호출
+    //추후 Redis INCR + 주기 flush로 마이그레이션 예정
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("UPDATE Post p SET p.viewCount = p.viewCount + 1 WHERE p.id = :id")
+    int incrementViewCount(@Param("id") UUID id);
+
 }

--- a/community-service/src/main/java/com/ojosama/post/domain/repository/PostRepository.java
+++ b/community-service/src/main/java/com/ojosama/post/domain/repository/PostRepository.java
@@ -13,12 +13,6 @@ import org.springframework.data.repository.query.Param;
 
 public interface PostRepository extends JpaRepository<Post, UUID> {
 
-    // 특정 유저의 게시글 목록
-    List<Post> findByUserIdAndDeletedAtIsNull(UUID userId);
-
-    // 카테고리별 게시글 목록
-    List<Post> findByCategoryIdAndDeletedAtIsNull(UUID categoryId);
-
     //조회수 증가. MVP는 매 조회마다 호출
     //추후 Redis INCR + 주기 flush로 마이그레이션 예정
     @Modifying(clearAutomatically = true, flushAutomatically = true)
@@ -39,4 +33,21 @@ public interface PostRepository extends JpaRepository<Post, UUID> {
     /** 전체 목록 (소프트 삭제/BLOCKED 제외). */
     Page<Post> findByDeletedAtIsNullAndStatusNot(
             PostStatus excludedStatus, Pageable pageable);
+
+    /**
+     * 좋아요 수 증가. PostLike INSERT 성공 시 함께 호출.
+     * 동시 요청에도 DB가 원자적으로 처리하므로 충돌하지 않는다.
+     */
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("UPDATE Post p SET p.likeCount = p.likeCount + 1 WHERE p.id = :id")
+    int incrementLikeCount(@Param("id") UUID id);
+
+    /**
+     * 좋아요 수 감소. WHERE 조건에 {@code likeCount > 0}을 포함하여 음수 방지.
+     *
+     * @return 영향받은 행 수. 0이면 likeCount가 이미 0이거나 게시글이 없는 상태.
+     */
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("UPDATE Post p SET p.likeCount = p.likeCount - 1 WHERE p.id = :id AND p.likeCount > 0")
+    int decrementLikeCount(@Param("id") UUID id);
 }

--- a/community-service/src/main/java/com/ojosama/post/presesntation/controller/PostController.java
+++ b/community-service/src/main/java/com/ojosama/post/presesntation/controller/PostController.java
@@ -2,6 +2,7 @@ package com.ojosama.post.presesntation.controller;
 
 import com.ojosama.common.response.ApiResponse;
 import com.ojosama.post.application.dto.command.CreatePostCommand;
+import com.ojosama.post.application.dto.command.DeletePostCommand;
 import com.ojosama.post.application.dto.command.UpdatePostCommand;
 import com.ojosama.post.application.dto.result.PostResult;
 import com.ojosama.post.application.service.PostService;
@@ -12,6 +13,7 @@ import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -40,6 +42,13 @@ public class PostController {
         PostResult result = postService.update(new UpdatePostCommand(
                 postId, UUID.randomUUID(), req.categoryId(), req.title(), req.content()));
         return ApiResponse.success(PostResponse.from(result));
+    }
+
+    @DeleteMapping("/{postId}")
+    public ApiResponse<Void> delete(
+            @PathVariable UUID postId) {
+        postService.delete(new DeletePostCommand(postId, UUID.randomUUID(), true)); //인가 완료 후 수정'
+        return ApiResponse.deleted();
     }
 
 

--- a/community-service/src/main/java/com/ojosama/post/presesntation/controller/PostController.java
+++ b/community-service/src/main/java/com/ojosama/post/presesntation/controller/PostController.java
@@ -14,6 +14,7 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -49,6 +50,12 @@ public class PostController {
             @PathVariable UUID postId) {
         postService.delete(new DeletePostCommand(postId, UUID.randomUUID(), true)); //인가 완료 후 수정'
         return ApiResponse.deleted();
+    }
+
+    @GetMapping("/{postId}")
+    public ApiResponse<PostResponse> getDetail(@PathVariable UUID postId) {
+        PostResult result = postService.getDetail(postId);
+        return ApiResponse.success(PostResponse.from(result));
     }
 
 

--- a/community-service/src/main/java/com/ojosama/post/presesntation/controller/PostController.java
+++ b/community-service/src/main/java/com/ojosama/post/presesntation/controller/PostController.java
@@ -1,0 +1,31 @@
+package com.ojosama.post.presesntation.controller;
+
+import com.ojosama.common.response.ApiResponse;
+import com.ojosama.post.application.dto.command.CreatePostCommand;
+import com.ojosama.post.application.dto.result.PostResult;
+import com.ojosama.post.application.service.PostService;
+import com.ojosama.post.presesntation.dto.request.CreatePostRequest;
+import com.ojosama.post.presesntation.dto.response.PostResponse;
+import jakarta.validation.Valid;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("v1/posts")
+@RequiredArgsConstructor
+public class PostController {
+    private final PostService postService;
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public ApiResponse<PostResponse> create(@Valid @RequestBody CreatePostRequest req){
+        PostResult result = postService.create(new CreatePostCommand(UUID.randomUUID(), req.categoryId(), req.title(), req.content()));
+        return ApiResponse.created(PostResponse.from(result));
+    }
+}

--- a/community-service/src/main/java/com/ojosama/post/presesntation/controller/PostController.java
+++ b/community-service/src/main/java/com/ojosama/post/presesntation/controller/PostController.java
@@ -2,14 +2,18 @@ package com.ojosama.post.presesntation.controller;
 
 import com.ojosama.common.response.ApiResponse;
 import com.ojosama.post.application.dto.command.CreatePostCommand;
+import com.ojosama.post.application.dto.command.UpdatePostCommand;
 import com.ojosama.post.application.dto.result.PostResult;
 import com.ojosama.post.application.service.PostService;
 import com.ojosama.post.presesntation.dto.request.CreatePostRequest;
+import com.ojosama.post.presesntation.dto.request.UpdatePostRequest;
 import com.ojosama.post.presesntation.dto.response.PostResponse;
 import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -28,4 +32,15 @@ public class PostController {
         PostResult result = postService.create(new CreatePostCommand(UUID.randomUUID(), req.categoryId(), req.title(), req.content()));
         return ApiResponse.created(PostResponse.from(result));
     }
+
+    @PatchMapping("/{postId}")
+    public ApiResponse<PostResponse> update(
+            @PathVariable UUID postId,
+            @Valid @RequestBody UpdatePostRequest req) {
+        PostResult result = postService.update(new UpdatePostCommand(
+                postId, UUID.randomUUID(), req.categoryId(), req.title(), req.content()));
+        return ApiResponse.success(PostResponse.from(result));
+    }
+
+
 }

--- a/community-service/src/main/java/com/ojosama/post/presesntation/controller/PostController.java
+++ b/community-service/src/main/java/com/ojosama/post/presesntation/controller/PostController.java
@@ -7,6 +7,7 @@ import com.ojosama.post.application.dto.command.UpdatePostCommand;
 import com.ojosama.post.application.dto.result.PostResult;
 import com.ojosama.post.application.query.PostListQuery;
 import com.ojosama.post.application.service.PostService;
+import com.ojosama.post.application.service.PostLikeService;
 import com.ojosama.post.presesntation.dto.request.CreatePostRequest;
 import com.ojosama.post.presesntation.dto.request.UpdatePostRequest;
 import com.ojosama.post.presesntation.dto.response.PostResponse;
@@ -33,6 +34,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class PostController {
     private final PostService postService;
+    private final PostLikeService postLikeService;
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
@@ -80,4 +82,17 @@ public class PostController {
         return ApiResponse.success(page.map(PostResponse::from));
     }
 
+    @PostMapping("/{postId}/likes")
+    public ApiResponse<Void> like(
+            @PathVariable UUID postId) {
+        postLikeService.like(postId, UUID.randomUUID());
+        return ApiResponse.success();
+    }
+
+    @DeleteMapping("/{postId}/likes")
+    public ApiResponse<Void> unlike(
+            @PathVariable UUID postId) {
+        postLikeService.unlike(postId, UUID.randomUUID());
+        return ApiResponse.success();
+    }
 }

--- a/community-service/src/main/java/com/ojosama/post/presesntation/controller/PostController.java
+++ b/community-service/src/main/java/com/ojosama/post/presesntation/controller/PostController.java
@@ -5,6 +5,7 @@ import com.ojosama.post.application.dto.command.CreatePostCommand;
 import com.ojosama.post.application.dto.command.DeletePostCommand;
 import com.ojosama.post.application.dto.command.UpdatePostCommand;
 import com.ojosama.post.application.dto.result.PostResult;
+import com.ojosama.post.application.query.PostListQuery;
 import com.ojosama.post.application.service.PostService;
 import com.ojosama.post.presesntation.dto.request.CreatePostRequest;
 import com.ojosama.post.presesntation.dto.request.UpdatePostRequest;
@@ -12,6 +13,9 @@ import com.ojosama.post.presesntation.dto.response.PostResponse;
 import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -20,6 +24,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -58,5 +63,21 @@ public class PostController {
         return ApiResponse.success(PostResponse.from(result));
     }
 
+    @GetMapping
+    public ApiResponse<Page<PostResponse>> list(
+            @RequestParam(required = false) UUID categoryId,
+            @RequestParam(required = false) UUID userId,
+            @PageableDefault(size = 20, sort = "createdAt") Pageable pageable) {
+        PostListQuery query;
+        if (categoryId != null) {
+            query = PostListQuery.byCategory(categoryId, pageable);
+        } else if (userId != null) {
+            query = PostListQuery.byUser(userId, pageable);
+        } else {
+            query = PostListQuery.all(pageable);
+        }
+        Page<PostResult> page = postService.list(query);
+        return ApiResponse.success(page.map(PostResponse::from));
+    }
 
 }

--- a/community-service/src/main/java/com/ojosama/post/presesntation/dto/request/CreatePostRequest.java
+++ b/community-service/src/main/java/com/ojosama/post/presesntation/dto/request/CreatePostRequest.java
@@ -3,7 +3,7 @@ package com.ojosama.post.presesntation.dto.request;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import java.util.UUID;
-import org.antlr.v4.runtime.misc.NotNull;
+import jakarta.validation.constraints.NotNull;
 
 public record CreatePostRequest(
         @NotNull UUID categoryId,

--- a/community-service/src/main/java/com/ojosama/post/presesntation/dto/request/CreatePostRequest.java
+++ b/community-service/src/main/java/com/ojosama/post/presesntation/dto/request/CreatePostRequest.java
@@ -1,0 +1,13 @@
+package com.ojosama.post.presesntation.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import java.util.UUID;
+import org.antlr.v4.runtime.misc.NotNull;
+
+public record CreatePostRequest(
+        @NotNull UUID categoryId,
+        @NotBlank @Size(max = 200) String title,
+        @NotBlank String content
+) {
+}

--- a/community-service/src/main/java/com/ojosama/post/presesntation/dto/request/UpdatePostRequest.java
+++ b/community-service/src/main/java/com/ojosama/post/presesntation/dto/request/UpdatePostRequest.java
@@ -1,0 +1,13 @@
+package com.ojosama.post.presesntation.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.util.UUID;
+
+public record UpdatePostRequest(
+        @NotNull UUID categoryId,
+        @NotBlank @Size(max = 200) String title,
+        @NotBlank String content
+) {
+}

--- a/community-service/src/main/java/com/ojosama/post/presesntation/dto/response/PostResponse.java
+++ b/community-service/src/main/java/com/ojosama/post/presesntation/dto/response/PostResponse.java
@@ -1,0 +1,38 @@
+package com.ojosama.post.presesntation.dto.response;
+
+import com.ojosama.common.domain.model.Content;
+import com.ojosama.post.application.dto.result.PostResult;
+import com.ojosama.post.domain.model.PostStatus;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record PostResponse(
+        UUID id,
+        UUID userId,
+        UUID categoryId,
+        String title,
+        String content,
+        int viewCount,
+        int likeCount,
+        int commentCount,
+        PostStatus status,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+    public static PostResponse from(PostResult r) {
+        boolean blocked = r.status() == PostStatus.BLOCKED;
+        return new PostResponse(
+                r.id(),
+                r.userId(),
+                r.categoryId(),
+                blocked ? Content.maskedText() : r.title(),
+                blocked ? Content.maskedText() : r.content().getValue(),
+                r.viewCount(),
+                r.likeCount(),
+                r.commentCount(),
+                r.status(),
+                r.createdAt(),
+                r.updatedAt()
+        );
+    }
+}

--- a/community-service/src/main/java/com/ojosama/post/presesntation/dto/response/PostResponse.java
+++ b/community-service/src/main/java/com/ojosama/post/presesntation/dto/response/PostResponse.java
@@ -26,7 +26,7 @@ public record PostResponse(
                 r.userId(),
                 r.categoryId(),
                 blocked ? Content.maskedText() : r.title(),
-                blocked ? Content.maskedText() : r.content().getValue(),
+                blocked ? Content.maskedText() : r.content(),
                 r.viewCount(),
                 r.likeCount(),
                 r.commentCount(),


### PR DESCRIPTION
## 🔗 Issue Number
- close #53 

## 📝 작업 내역

- post creat 관련 구현
- post update 관련 구현
- post delete 관련 구현
- post 카테고리별 목록 조회
- post 단건 조회/조회수 증가
- post like 관련 구현

## 💡 PR 특이사항

- 게시글 단건 조회시 댓글도 함께 보여주는 것은 프론트엔드에서 GET /v1/posts/{postId}게시글, GET /v1/posts/{postId}/comments댓글 을 불러와서 보여주는 것이 msa에 더 적합하지않을까 생각해서 적용해봤습니다.
원래는, 게시글에서 feignclient로 댓글을 불러오고, 게시글 서버에서 전체를 보여주는 것으로 이야기 나누었었습니다!
의견 있으시면 말씀해주세요!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 게시물 생성·수정·삭제·상세 조회 및 카테고리/사용자 필터 지원 목록(페이징) 제공
  * 게시물 좋아요·좋아요 취소 API 추가 및 좋아요/조회수 원자적 갱신 반영
  * 차단된 게시물은 제목·본문 마스킹 처리 및 조회수 증가 제한
  * 본문 길이 검증 추가(4000자 이하)

* **Chores**
  * 검증 관련 라이브러리 의존성 추가 및 아웃박스 이벤트 발행 타입 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->