### PR TITLE
[FEATURE] calendar service crud

### DIFF
--- a/calendar-service/build.gradle
+++ b/calendar-service/build.gradle
@@ -1,5 +1,5 @@
 ext {
-	set('springCloudVersion', "2025.0.1")
+    set('springCloudVersion', "2025.0.1")
 }
 
 dependencies {
@@ -22,6 +22,11 @@ dependencies {
     // Kafka (event.cancelled 소비)
     implementation 'org.springframework.kafka:spring-kafka'
 
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
     // Swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.16'
 
@@ -29,10 +34,24 @@ dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
+def querydslDir = "src/main/generated"
+
+sourceSets {
+    main.java.srcDirs += [querydslDir]
+}
+
+tasks.withType(JavaCompile).configureEach {
+    options.getGeneratedSourceOutputDirectory().set(file(querydslDir))
+}
+
+clean {
+    delete file(querydslDir)
+}
+
 dependencyManagement {
-	imports {
-		mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
-	}
+    imports {
+        mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+    }
 }
 
 bootJar { enabled = true }

--- a/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/application/CalendarService.java
+++ b/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/application/CalendarService.java
@@ -28,7 +28,7 @@ public class CalendarService {
 
     public CalendarResponseDto createCalendar(CreateCalendarCommand command) {
 
-        Optional<Calendar> exists = calendarRepository.findByEventInfoEventScheduleIdAndUserId(
+        Optional<Calendar> exists = calendarRepository.findByEventInfo_EventScheduleIdAndUserId(
                 command.eventScheduleId(),
                 command.userId());
 

--- a/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/application/CalendarService.java
+++ b/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/application/CalendarService.java
@@ -5,6 +5,7 @@ import com.ojosama.calendarservice.calendar.application.dto.result.CalendarResul
 import com.ojosama.calendarservice.calendar.domain.exception.CalendarErrorCode;
 import com.ojosama.calendarservice.calendar.domain.exception.CalendarException;
 import com.ojosama.calendarservice.calendar.domain.model.Calendar;
+import com.ojosama.calendarservice.calendar.domain.model.EventInfo;
 import com.ojosama.calendarservice.calendar.domain.repository.CalendarRepository;
 import com.ojosama.calendarservice.calendar.presentaion.dto.CalendarResponseDto;
 import java.time.LocalDateTime;
@@ -43,11 +44,12 @@ public class CalendarService {
         // TODO : event-service에서 feign으로 eventScheduleId로 startDate 복사
         LocalDateTime eventStart = LocalDateTime.now();
 
-        // TODO : event-service에서 eventId값으로 ticketing시간 복사
+        // TODO : event-service에서 eventId값으로 ticketing시간, 행사이름 복사
         LocalDateTime ticketingDate = LocalDateTime.now();
+        String eventName = "행사";
 
-        Calendar calendar = Calendar.create(command.userId(), command.eventScheduleId(), eventStart, command.memo(),
-                ticketingDate);
+        Calendar calendar = Calendar.create(command.userId(), command.memo(),
+                EventInfo.of(command.eventId(), eventName, command.eventScheduleId(), eventStart, ticketingDate));
 
         try {
             calendarRepository.saveAndFlush(calendar);

--- a/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/application/CalendarService.java
+++ b/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/application/CalendarService.java
@@ -28,7 +28,8 @@ public class CalendarService {
 
     public CalendarResponseDto createCalendar(CreateCalendarCommand command) {
 
-        Optional<Calendar> exists = calendarRepository.findByEventScheduleIdAndUserId(command.eventScheduleId(),
+        Optional<Calendar> exists = calendarRepository.findByEventInfoEventScheduleIdAndUserId(
+                command.eventScheduleId(),
                 command.userId());
 
         if (exists.isPresent()) {
@@ -49,7 +50,7 @@ public class CalendarService {
         String eventName = "행사";
 
         Calendar calendar = Calendar.create(command.userId(), command.memo(),
-                EventInfo.of(command.eventId(), eventName, command.eventScheduleId(), eventStart, ticketingDate));
+                new EventInfo(command.eventId(), eventName, command.eventScheduleId(), eventStart, ticketingDate));
 
         try {
             calendarRepository.saveAndFlush(calendar);

--- a/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/application/CalendarService.java
+++ b/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/application/CalendarService.java
@@ -14,7 +14,6 @@ import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -28,17 +27,11 @@ public class CalendarService {
 
     public CalendarResponseDto createCalendar(CreateCalendarCommand command) {
 
-        Optional<Calendar> exists = calendarRepository.findByEventInfo_EventScheduleIdAndUserId(
+        Optional<Calendar> exists = calendarRepository.findByEventInfo_EventScheduleIdAndUserIdAndDeletedAtIsNull(
                 command.eventScheduleId(),
                 command.userId());
 
         if (exists.isPresent()) {
-            Calendar calendar = exists.get();
-            if (calendar.getDeletedAt() != null) {
-                calendar.restore();
-                calendar.updateMemo(command.memo());
-                return CalendarResponseDto.from(CalendarResult.from(calendar));
-            }
             throw new CalendarException(CalendarErrorCode.EXISTS_CALENDAR);
         }
 
@@ -52,11 +45,7 @@ public class CalendarService {
         Calendar calendar = Calendar.create(command.userId(), command.memo(),
                 new EventInfo(command.eventId(), eventName, command.eventScheduleId(), eventStart, ticketingDate));
 
-        try {
-            calendarRepository.saveAndFlush(calendar);
-        } catch (DataIntegrityViolationException e) {
-            throw new CalendarException(CalendarErrorCode.EXISTS_CALENDAR);
-        }
+        calendarRepository.save(calendar);
 
         return CalendarResponseDto.from(CalendarResult.from(calendar));
     }

--- a/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/application/CalendarService.java
+++ b/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/application/CalendarService.java
@@ -13,6 +13,7 @@ import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -48,7 +49,11 @@ public class CalendarService {
         Calendar calendar = Calendar.create(command.userId(), command.eventScheduleId(), eventStart, command.memo(),
                 ticketingDate);
 
-        calendarRepository.save(calendar);
+        try {
+            calendarRepository.saveAndFlush(calendar);
+        } catch (DataIntegrityViolationException e) {
+            throw new CalendarException(CalendarErrorCode.EXISTS_CALENDAR);
+        }
 
         return CalendarResponseDto.from(CalendarResult.from(calendar));
     }

--- a/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/application/CalendarService.java
+++ b/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/application/CalendarService.java
@@ -1,0 +1,89 @@
+package com.ojosama.calendarservice.calendar.application;
+
+import com.ojosama.calendarservice.calendar.application.dto.command.CreateCalendarCommand;
+import com.ojosama.calendarservice.calendar.application.dto.result.CalendarResult;
+import com.ojosama.calendarservice.calendar.domain.exception.CalendarErrorCode;
+import com.ojosama.calendarservice.calendar.domain.exception.CalendarException;
+import com.ojosama.calendarservice.calendar.domain.model.Calendar;
+import com.ojosama.calendarservice.calendar.domain.repository.CalendarRepository;
+import com.ojosama.calendarservice.calendar.presentaion.dto.CalendarResponseDto;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional
+public class CalendarService {
+
+    private final CalendarRepository calendarRepository;
+
+    public CalendarResponseDto createCalendar(CreateCalendarCommand command) {
+
+        Optional<Calendar> exists = calendarRepository.findByEventScheduleIdAndUserId(command.eventScheduleId(),
+                command.userId());
+
+        if (exists.isPresent()) {
+            Calendar calendar = exists.get();
+            if (calendar.getDeletedAt() != null) {
+                calendar.restore();
+                calendar.updateMemo(command.memo());
+                return CalendarResponseDto.from(CalendarResult.from(calendar));
+            }
+            throw new CalendarException(CalendarErrorCode.EXISTS_CALENDAR);
+        }
+
+        // TODO : event-service에서 feign으로 eventScheduleId로 startDate 복사
+        LocalDateTime eventStart = LocalDateTime.now();
+
+        // TODO : event-service에서 eventId값으로 ticketing시간 복사
+        LocalDateTime ticketingDate = LocalDateTime.now();
+
+        Calendar calendar = Calendar.create(command.userId(), command.eventScheduleId(), eventStart, command.memo(),
+                ticketingDate);
+
+        calendarRepository.save(calendar);
+
+        return CalendarResponseDto.from(CalendarResult.from(calendar));
+    }
+
+    @Transactional(readOnly = true)
+    public CalendarResponseDto getCalendar(UUID calendarId, UUID userId) {
+        Calendar calendar = validateCalendarAlive(calendarId, userId);
+
+        return CalendarResponseDto.from(CalendarResult.from(calendar));
+    }
+
+    @Transactional(readOnly = true)
+    public List<CalendarResponseDto> getCalendars(UUID userId, int year, int month) {
+        List<Calendar> calendars = calendarRepository.findByUserIdAndYearMonth(userId, year, month);
+        return calendars.stream()
+                .map(calendar -> CalendarResponseDto.from(CalendarResult.from(calendar)))
+                .toList();
+    }
+
+    public CalendarResponseDto updateCalendarMemo(UUID calendarId, String memo, UUID userId) {
+        Calendar calendar = validateCalendarAlive(calendarId, userId);
+
+        calendar.updateMemo(memo);
+        return CalendarResponseDto.from(CalendarResult.from(calendar));
+    }
+
+    public void deleteCalendar(UUID calendarId, UUID userId) {
+        Calendar calendar = validateCalendarAlive(calendarId, userId);
+
+        calendar.deleted(userId);
+    }
+
+    private Calendar validateCalendarAlive(UUID calendarId, UUID userId) {
+
+        return calendarRepository.findByIdAndUserIdAndDeletedAtIsNull(calendarId, userId).orElseThrow(() ->
+                new CalendarException(CalendarErrorCode.CALENDAR_NOT_FOUND));
+    }
+}

--- a/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/application/dto/command/CreateCalendarCommand.java
+++ b/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/application/dto/command/CreateCalendarCommand.java
@@ -1,6 +1,5 @@
 package com.ojosama.calendarservice.calendar.application.dto.command;
 
-import com.ojosama.calendarservice.calendar.presentaion.dto.CreateCalendarRequestDto;
 import java.util.UUID;
 import lombok.Builder;
 
@@ -11,13 +10,4 @@ public record CreateCalendarCommand(
         UUID userId,
         UUID eventId
 ) {
-    public static CreateCalendarCommand of(CreateCalendarRequestDto dto, UUID userId) {
-        return CreateCalendarCommand.builder()
-                .eventScheduleId(dto.eventScheduleId())
-                .userId(userId)
-                .memo(dto.memo())
-                .eventId(dto.eventId())
-                .build();
-    }
-
 }

--- a/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/application/dto/command/CreateCalendarCommand.java
+++ b/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/application/dto/command/CreateCalendarCommand.java
@@ -1,0 +1,21 @@
+package com.ojosama.calendarservice.calendar.application.dto.command;
+
+import com.ojosama.calendarservice.calendar.presentaion.dto.CreateCalendarRequestDto;
+import java.util.UUID;
+import lombok.Builder;
+
+@Builder
+public record CreateCalendarCommand(
+        UUID eventScheduleId,
+        String memo,
+        UUID userId
+) {
+    public static CreateCalendarCommand of(CreateCalendarRequestDto dto, UUID userId) {
+        return CreateCalendarCommand.builder()
+                .eventScheduleId(dto.eventScheduleId())
+                .userId(userId)
+                .memo(dto.memo())
+                .build();
+    }
+
+}

--- a/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/application/dto/command/CreateCalendarCommand.java
+++ b/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/application/dto/command/CreateCalendarCommand.java
@@ -8,13 +8,15 @@ import lombok.Builder;
 public record CreateCalendarCommand(
         UUID eventScheduleId,
         String memo,
-        UUID userId
+        UUID userId,
+        UUID eventId
 ) {
     public static CreateCalendarCommand of(CreateCalendarRequestDto dto, UUID userId) {
         return CreateCalendarCommand.builder()
                 .eventScheduleId(dto.eventScheduleId())
                 .userId(userId)
                 .memo(dto.memo())
+                .eventId(dto.eventId())
                 .build();
     }
 

--- a/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/application/dto/result/CalendarResult.java
+++ b/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/application/dto/result/CalendarResult.java
@@ -11,15 +11,19 @@ public record CalendarResult(
         UUID eventScheduleId,
         LocalDateTime eventDate,
         LocalDateTime ticketingDate,
-        String memo
+        String memo,
+        String eventName,
+        UUID eventId
 ) {
     public static CalendarResult from(Calendar calendar) {
         return CalendarResult.builder()
                 .id(calendar.getId())
-                .eventScheduleId(calendar.getEventScheduleId())
-                .eventDate(calendar.getEventDate())
-                .ticketingDate(calendar.getEventTicketingDate())
+                .eventScheduleId(calendar.getEventInfo().getEventScheduleId())
+                .eventDate(calendar.getEventInfo().getEventDate())
+                .ticketingDate(calendar.getEventInfo().getEventTicketingDate())
                 .memo(calendar.getMemo())
+                .eventName(calendar.getEventInfo().getEventName())
+                .eventId(calendar.getEventInfo().getEventId())
                 .build();
     }
 }

--- a/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/application/dto/result/CalendarResult.java
+++ b/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/application/dto/result/CalendarResult.java
@@ -1,0 +1,25 @@
+package com.ojosama.calendarservice.calendar.application.dto.result;
+
+import com.ojosama.calendarservice.calendar.domain.model.Calendar;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.Builder;
+
+@Builder
+public record CalendarResult(
+        UUID id,
+        UUID eventScheduleId,
+        LocalDateTime eventDate,
+        LocalDateTime ticketingDate,
+        String memo
+) {
+    public static CalendarResult from(Calendar calendar) {
+        return CalendarResult.builder()
+                .id(calendar.getId())
+                .eventScheduleId(calendar.getEventScheduleId())
+                .eventDate(calendar.getEventDate())
+                .ticketingDate(calendar.getEventTicketingDate())
+                .memo(calendar.getMemo())
+                .build();
+    }
+}

--- a/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/common/config/QueryDslConfig.java
+++ b/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/common/config/QueryDslConfig.java
@@ -1,0 +1,21 @@
+package com.ojosama.calendarservice.calendar.common.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+
+    private final EntityManager entityManager;
+
+    public QueryDslConfig(EntityManager entityManager) {
+        this.entityManager = entityManager;
+    }
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/domain/exception/CalendarErrorCode.java
+++ b/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/domain/exception/CalendarErrorCode.java
@@ -11,7 +11,9 @@ public enum CalendarErrorCode implements ErrorCode {
     CALENDAR_ACCESS_DENIED(HttpStatus.FORBIDDEN, "다른 사용자의 일정은 수정할 수 없습니다."),
     CALENDAR_DELETE_DENIED(HttpStatus.FORBIDDEN, "다른 사용자의 일정은 삭제할 수 없습니다."),
     EVENT_SCHEDULE_NOT_FOUND(HttpStatus.NOT_FOUND, "요청하신 행사 일정을 찾을 수 없습니다."),
-    INVALID_INPUT(HttpStatus.BAD_REQUEST, "입력값이 올바르지 않습니다.");
+    INVALID_INPUT(HttpStatus.BAD_REQUEST, "입력값이 올바르지 않습니다."),
+
+    EXISTS_CALENDAR(HttpStatus.NOT_FOUND, "존재하는 일정입니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/domain/exception/CalendarErrorCode.java
+++ b/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/domain/exception/CalendarErrorCode.java
@@ -13,7 +13,7 @@ public enum CalendarErrorCode implements ErrorCode {
     EVENT_SCHEDULE_NOT_FOUND(HttpStatus.NOT_FOUND, "요청하신 행사 일정을 찾을 수 없습니다."),
     INVALID_INPUT(HttpStatus.BAD_REQUEST, "입력값이 올바르지 않습니다."),
 
-    EXISTS_CALENDAR(HttpStatus.NOT_FOUND, "존재하는 일정입니다.");
+    EXISTS_CALENDAR(HttpStatus.CONFLICT, "이미 존재하는 일정입니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/domain/model/Calendar.java
+++ b/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/domain/model/Calendar.java
@@ -10,6 +10,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Index;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.AccessLevel;
@@ -23,6 +24,11 @@ import lombok.NoArgsConstructor;
         indexes = {
                 @Index(name = "idx_calendar_user_deleted", columnList = "user_id,deleted_at"),
                 @Index(name = "idx_calendar_user_eventdate_deleted", columnList = "user_id,event_date,deleted_at")
+        },
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_calendar_user_eventschedule_id",
+                        columnNames = {"user_id", "event_schedule_id"})
         }
 )
 @Getter

--- a/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/domain/model/Calendar.java
+++ b/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/domain/model/Calendar.java
@@ -42,11 +42,15 @@ public class Calendar extends BaseUserEntity {
     @Column(name = "event_date", nullable = false)
     private LocalDateTime eventDate;
 
+    @Column(name = "event_ticketing_date")
+    private LocalDateTime eventTicketingDate;
+
     @Column(name = "memo", length = 1000)
     private String memo;
 
     @Builder(access = AccessLevel.PRIVATE)
-    private Calendar(UUID userId, UUID eventScheduleId, LocalDateTime eventDate, String memo) {
+    private Calendar(UUID userId, UUID eventScheduleId, LocalDateTime eventDate, String memo,
+                     LocalDateTime eventTicketingDate) {
         validateUserId(userId);
         validateEventScheduleId(eventScheduleId);
         validateEventDate(eventDate);
@@ -55,14 +59,17 @@ public class Calendar extends BaseUserEntity {
         this.eventScheduleId = eventScheduleId;
         this.eventDate = eventDate;
         this.memo = memo;
+        this.eventTicketingDate = eventTicketingDate;
     }
 
-    public static Calendar create(UUID userId, UUID eventScheduleId, LocalDateTime eventDate, String memo) {
+    public static Calendar create(UUID userId, UUID eventScheduleId, LocalDateTime eventDate, String memo,
+                                  LocalDateTime eventTicketingDate) {
         return Calendar.builder()
                 .userId(userId)
                 .eventScheduleId(eventScheduleId)
                 .eventDate(eventDate)
                 .memo(memo)
+                .eventTicketingDate(eventTicketingDate)
                 .build();
     }
 

--- a/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/domain/model/Calendar.java
+++ b/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/domain/model/Calendar.java
@@ -4,6 +4,7 @@ import com.ojosama.calendarservice.calendar.domain.exception.CalendarErrorCode;
 import com.ojosama.calendarservice.calendar.domain.exception.CalendarException;
 import com.ojosama.common.audit.BaseUserEntity;
 import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -11,7 +12,6 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Index;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
-import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -42,40 +42,26 @@ public class Calendar extends BaseUserEntity {
     @Column(name = "user_id", nullable = false)
     private UUID userId;
 
-    @Column(name = "event_schedule_id", nullable = false)
-    private UUID eventScheduleId;
-
-    @Column(name = "event_date", nullable = false)
-    private LocalDateTime eventDate;
-
-    @Column(name = "event_ticketing_date")
-    private LocalDateTime eventTicketingDate;
+    @Embedded
+    private EventInfo eventInfo;
 
     @Column(name = "memo", length = 1000)
     private String memo;
 
     @Builder(access = AccessLevel.PRIVATE)
-    private Calendar(UUID userId, UUID eventScheduleId, LocalDateTime eventDate, String memo,
-                     LocalDateTime eventTicketingDate) {
+    private Calendar(UUID userId, EventInfo eventInfo, String memo) {
         validateUserId(userId);
-        validateEventScheduleId(eventScheduleId);
-        validateEventDate(eventDate);
         validateMemo(memo);
         this.userId = userId;
-        this.eventScheduleId = eventScheduleId;
-        this.eventDate = eventDate;
+        this.eventInfo = eventInfo;
         this.memo = memo;
-        this.eventTicketingDate = eventTicketingDate;
     }
 
-    public static Calendar create(UUID userId, UUID eventScheduleId, LocalDateTime eventDate, String memo,
-                                  LocalDateTime eventTicketingDate) {
+    public static Calendar create(UUID userId, String memo, EventInfo eventInfo) {
         return Calendar.builder()
                 .userId(userId)
-                .eventScheduleId(eventScheduleId)
-                .eventDate(eventDate)
+                .eventInfo(eventInfo)
                 .memo(memo)
-                .eventTicketingDate(eventTicketingDate)
                 .build();
     }
 
@@ -86,18 +72,6 @@ public class Calendar extends BaseUserEntity {
 
     private void validateUserId(UUID userId) {
         if (userId == null) {
-            throw new CalendarException(CalendarErrorCode.INVALID_INPUT);
-        }
-    }
-
-    private void validateEventScheduleId(UUID eventScheduleId) {
-        if (eventScheduleId == null) {
-            throw new CalendarException(CalendarErrorCode.INVALID_INPUT);
-        }
-    }
-
-    private void validateEventDate(LocalDateTime eventDate) {
-        if (eventDate == null) {
             throw new CalendarException(CalendarErrorCode.INVALID_INPUT);
         }
     }

--- a/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/domain/model/EventInfo.java
+++ b/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/domain/model/EventInfo.java
@@ -7,7 +7,6 @@ import jakarta.persistence.Embeddable;
 import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.AccessLevel;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -31,29 +30,17 @@ public class EventInfo {
     @Column(name = "event_ticketing_date")
     private LocalDateTime eventTicketingDate;
 
-    @Builder
-    private EventInfo(UUID eventId, String eventName, UUID eventScheduleId, LocalDateTime eventDate,
-                      LocalDateTime eventTicketingDate) {
-        validateEventDate(eventDate);
-        validateEventScheduleId(eventScheduleId);
-        validateEventName(eventName);
+    public EventInfo(UUID eventId, String eventName, UUID eventScheduleId, LocalDateTime eventDate,
+                     LocalDateTime eventTicketingDate) {
         validateEventId(eventId);
+        validateEventName(eventName);
+        validateEventScheduleId(eventScheduleId);
+        validateEventDate(eventDate);
         this.eventId = eventId;
         this.eventName = eventName;
         this.eventScheduleId = eventScheduleId;
         this.eventDate = eventDate;
         this.eventTicketingDate = eventTicketingDate;
-    }
-
-    public static EventInfo of(UUID eventId, String eventName, UUID eventScheduleId, LocalDateTime eventDate,
-                               LocalDateTime eventTicketingDate) {
-        return EventInfo.builder()
-                .eventId(eventId)
-                .eventName(eventName)
-                .eventScheduleId(eventScheduleId)
-                .eventDate(eventDate)
-                .eventTicketingDate(eventTicketingDate)
-                .build();
     }
 
     private void validateEventId(UUID eventId) {

--- a/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/domain/model/EventInfo.java
+++ b/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/domain/model/EventInfo.java
@@ -1,0 +1,82 @@
+package com.ojosama.calendarservice.calendar.domain.model;
+
+import com.ojosama.calendarservice.calendar.domain.exception.CalendarErrorCode;
+import com.ojosama.calendarservice.calendar.domain.exception.CalendarException;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class EventInfo {
+
+    @Column(name = "event_id", nullable = false)
+    private UUID eventId;
+
+    @Column(name = "event_name", nullable = false)
+    private String eventName;
+
+    @Column(name = "event_schedule_id", nullable = false)
+    private UUID eventScheduleId;
+
+    @Column(name = "event_date", nullable = false)
+    private LocalDateTime eventDate;
+
+    @Column(name = "event_ticketing_date")
+    private LocalDateTime eventTicketingDate;
+
+    @Builder
+    private EventInfo(UUID eventId, String eventName, UUID eventScheduleId, LocalDateTime eventDate,
+                      LocalDateTime eventTicketingDate) {
+        validateEventDate(eventDate);
+        validateEventScheduleId(eventScheduleId);
+        validateEventName(eventName);
+        validateEventId(eventId);
+        this.eventId = eventId;
+        this.eventName = eventName;
+        this.eventScheduleId = eventScheduleId;
+        this.eventDate = eventDate;
+        this.eventTicketingDate = eventTicketingDate;
+    }
+
+    public static EventInfo of(UUID eventId, String eventName, UUID eventScheduleId, LocalDateTime eventDate,
+                               LocalDateTime eventTicketingDate) {
+        return EventInfo.builder()
+                .eventId(eventId)
+                .eventName(eventName)
+                .eventScheduleId(eventScheduleId)
+                .eventDate(eventDate)
+                .eventTicketingDate(eventTicketingDate)
+                .build();
+    }
+
+    private void validateEventId(UUID eventId) {
+        if (eventId == null) {
+            throw new CalendarException(CalendarErrorCode.INVALID_INPUT);
+        }
+    }
+
+    private void validateEventName(String eventName) {
+        if (eventName == null || eventName.isBlank()) {
+            throw new CalendarException(CalendarErrorCode.INVALID_INPUT);
+        }
+    }
+
+    private void validateEventScheduleId(UUID eventScheduleId) {
+        if (eventScheduleId == null) {
+            throw new CalendarException(CalendarErrorCode.INVALID_INPUT);
+        }
+    }
+
+    private void validateEventDate(LocalDateTime eventDate) {
+        if (eventDate == null) {
+            throw new CalendarException(CalendarErrorCode.INVALID_INPUT);
+        }
+    }
+}

--- a/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/domain/repository/CalendarRepository.java
+++ b/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/domain/repository/CalendarRepository.java
@@ -11,7 +11,7 @@ public interface CalendarRepository {
 
     List<Calendar> findByUserIdAndYearMonth(UUID userId, int year, int month);
 
-    Optional<Calendar> findByEventInfo_EventScheduleIdAndUserId(UUID scheduleId, UUID userId);
+    Optional<Calendar> findByEventInfo_EventScheduleIdAndUserIdAndDeletedAtIsNull(UUID scheduleId, UUID userId);
 
-    void saveAndFlush(Calendar calendar);
+    void save(Calendar calendar);
 }

--- a/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/domain/repository/CalendarRepository.java
+++ b/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/domain/repository/CalendarRepository.java
@@ -11,7 +11,7 @@ public interface CalendarRepository {
 
     List<Calendar> findByUserIdAndYearMonth(UUID userId, int year, int month);
 
-    Optional<Calendar> findByEventInfoEventScheduleIdAndUserId(UUID scheduleId, UUID userId);
+    Optional<Calendar> findByEventInfo_EventScheduleIdAndUserId(UUID scheduleId, UUID userId);
 
     void saveAndFlush(Calendar calendar);
 }

--- a/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/domain/repository/CalendarRepository.java
+++ b/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/domain/repository/CalendarRepository.java
@@ -7,11 +7,11 @@ import java.util.UUID;
 
 public interface CalendarRepository {
 
-    void save(Calendar calendar);
-
     Optional<Calendar> findByIdAndUserIdAndDeletedAtIsNull(UUID id, UUID userId);
 
     List<Calendar> findByUserIdAndYearMonth(UUID userId, int year, int month);
 
     Optional<Calendar> findByEventScheduleIdAndUserId(UUID scheduleId, UUID userId);
+
+    void saveAndFlush(Calendar calendar);
 }

--- a/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/domain/repository/CalendarRepository.java
+++ b/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/domain/repository/CalendarRepository.java
@@ -11,7 +11,7 @@ public interface CalendarRepository {
 
     List<Calendar> findByUserIdAndYearMonth(UUID userId, int year, int month);
 
-    Optional<Calendar> findByEventScheduleIdAndUserId(UUID scheduleId, UUID userId);
+    Optional<Calendar> findByEventInfoEventScheduleIdAndUserId(UUID scheduleId, UUID userId);
 
     void saveAndFlush(Calendar calendar);
 }

--- a/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/domain/repository/CalendarRepository.java
+++ b/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/domain/repository/CalendarRepository.java
@@ -1,20 +1,17 @@
 package com.ojosama.calendarservice.calendar.domain.repository;
 
 import com.ojosama.calendarservice.calendar.domain.model.Calendar;
-import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 
 public interface CalendarRepository {
 
-    Calendar save(Calendar calendar);
+    void save(Calendar calendar);
 
-    Optional<Calendar> findByIdAndDeletedAtIsNull(UUID id);
+    Optional<Calendar> findByIdAndUserIdAndDeletedAtIsNull(UUID id, UUID userId);
 
-    Page<Calendar> findByUserIdAndDeletedAtIsNull(UUID userId, Pageable pageable);
+    List<Calendar> findByUserIdAndYearMonth(UUID userId, int year, int month);
 
-    Page<Calendar> findByUserIdAndEventDateBetweenAndDeletedAtIsNull(
-            UUID userId, LocalDateTime start, LocalDateTime end, Pageable pageable);
+    Optional<Calendar> findByEventScheduleIdAndUserId(UUID scheduleId, UUID userId);
 }

--- a/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/infrastructure/config/QueryDslConfig.java
+++ b/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/infrastructure/config/QueryDslConfig.java
@@ -1,4 +1,4 @@
-package com.ojosama.calendarservice.calendar.common.config;
+package com.ojosama.calendarservice.calendar.infrastructure.config;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;

--- a/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/infrastructure/persistence/CalendarRepositoryCustom.java
+++ b/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/infrastructure/persistence/CalendarRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.ojosama.calendarservice.calendar.infrastructure.persistence;
+
+import com.ojosama.calendarservice.calendar.domain.model.Calendar;
+import java.util.List;
+import java.util.UUID;
+
+public interface CalendarRepositoryCustom {
+
+    List<Calendar> findByUserIdAndYearMonth(UUID userId, int year, int month);
+}

--- a/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/infrastructure/persistence/CalendarRepositoryCustomImpl.java
+++ b/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/infrastructure/persistence/CalendarRepositoryCustomImpl.java
@@ -7,7 +7,9 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
 
+@Repository
 @RequiredArgsConstructor
 public class CalendarRepositoryCustomImpl implements CalendarRepositoryCustom {
 

--- a/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/infrastructure/persistence/CalendarRepositoryCustomImpl.java
+++ b/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/infrastructure/persistence/CalendarRepositoryCustomImpl.java
@@ -1,0 +1,33 @@
+package com.ojosama.calendarservice.calendar.infrastructure.persistence;
+
+import com.ojosama.calendarservice.calendar.domain.model.Calendar;
+import com.ojosama.calendarservice.calendar.domain.model.QCalendar;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class CalendarRepositoryCustomImpl implements CalendarRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+    private final QCalendar qCalendar = QCalendar.calendar;
+
+    @Override
+    public List<Calendar> findByUserIdAndYearMonth(UUID userId, int year, int month) {
+        // 해당 월 1일
+        LocalDateTime start = LocalDateTime.of(year, month, 1, 0, 0);
+        // 다음달 1일
+        LocalDateTime end = start.plusMonths(1);
+
+        return queryFactory
+                .selectFrom(qCalendar)
+                .where(
+                        qCalendar.userId.eq(userId),
+                        qCalendar.eventInfo.eventDate.goe(start), // event_date >= start
+                        qCalendar.eventInfo.eventDate.lt(end), // event_date < end
+                        qCalendar.deletedAt.isNull()
+                ).fetch();
+    }
+}

--- a/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/infrastructure/persistence/CalendarRepositoryImpl.java
+++ b/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/infrastructure/persistence/CalendarRepositoryImpl.java
@@ -19,13 +19,13 @@ public class CalendarRepositoryImpl implements CalendarRepository {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public void save(Calendar calendar) {
-        jpaCalendarRepository.save(calendar);
+    public void saveAndFlush(Calendar calendar) {
+        jpaCalendarRepository.saveAndFlush(calendar);
     }
 
     @Override
     public Optional<Calendar> findByIdAndUserIdAndDeletedAtIsNull(UUID id, UUID userId) {
-        return jpaCalendarRepository.findByIdAndDeletedAtIsNull(id);
+        return jpaCalendarRepository.findByIdAndUserIdAndDeletedAtIsNull(id, userId);
     }
 
     @Override

--- a/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/infrastructure/persistence/CalendarRepositoryImpl.java
+++ b/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/infrastructure/persistence/CalendarRepositoryImpl.java
@@ -15,8 +15,8 @@ public class CalendarRepositoryImpl implements CalendarRepository {
     private final JpaCalendarRepository jpaCalendarRepository;
 
     @Override
-    public void saveAndFlush(Calendar calendar) {
-        jpaCalendarRepository.saveAndFlush(calendar);
+    public void save(Calendar calendar) {
+        jpaCalendarRepository.save(calendar);
     }
 
     @Override
@@ -25,8 +25,8 @@ public class CalendarRepositoryImpl implements CalendarRepository {
     }
 
     @Override
-    public Optional<Calendar> findByEventInfo_EventScheduleIdAndUserId(UUID scheduleId, UUID userId) {
-        return jpaCalendarRepository.findByEventInfo_EventScheduleIdAndUserId(scheduleId, userId);
+    public Optional<Calendar> findByEventInfo_EventScheduleIdAndUserIdAndDeletedAtIsNull(UUID scheduleId, UUID userId) {
+        return jpaCalendarRepository.findByEventInfo_EventScheduleIdAndUserIdAndDeletedAtIsNull(scheduleId, userId);
     }
 
     @Override

--- a/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/infrastructure/persistence/CalendarRepositoryImpl.java
+++ b/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/infrastructure/persistence/CalendarRepositoryImpl.java
@@ -41,8 +41,8 @@ public class CalendarRepositoryImpl implements CalendarRepository {
                 .selectFrom(qCalendar)
                 .where(
                         qCalendar.userId.eq(userId),
-                        qCalendar.eventDate.goe(start), // event_date >= start
-                        qCalendar.eventDate.lt(end), // event_date < end
+                        qCalendar.eventInfo.eventDate.goe(start), // event_date >= start
+                        qCalendar.eventInfo.eventDate.lt(end), // event_date < end
                         qCalendar.deletedAt.isNull()
                 ).fetch();
     }

--- a/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/infrastructure/persistence/CalendarRepositoryImpl.java
+++ b/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/infrastructure/persistence/CalendarRepositoryImpl.java
@@ -1,10 +1,7 @@
 package com.ojosama.calendarservice.calendar.infrastructure.persistence;
 
 import com.ojosama.calendarservice.calendar.domain.model.Calendar;
-import com.ojosama.calendarservice.calendar.domain.model.QCalendar;
 import com.ojosama.calendarservice.calendar.domain.repository.CalendarRepository;
-import com.querydsl.jpa.impl.JPAQueryFactory;
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -16,7 +13,6 @@ import org.springframework.stereotype.Repository;
 public class CalendarRepositoryImpl implements CalendarRepository {
 
     private final JpaCalendarRepository jpaCalendarRepository;
-    private final JPAQueryFactory queryFactory;
 
     @Override
     public void saveAndFlush(Calendar calendar) {
@@ -29,26 +25,12 @@ public class CalendarRepositoryImpl implements CalendarRepository {
     }
 
     @Override
-    public List<Calendar> findByUserIdAndYearMonth(UUID userId, int year, int month) {
-        QCalendar qCalendar = QCalendar.calendar;
-
-        // 해당 월 1일
-        LocalDateTime start = LocalDateTime.of(year, month, 1, 0, 0);
-        // 다음달 1일
-        LocalDateTime end = start.plusMonths(1);
-
-        return queryFactory
-                .selectFrom(qCalendar)
-                .where(
-                        qCalendar.userId.eq(userId),
-                        qCalendar.eventInfo.eventDate.goe(start), // event_date >= start
-                        qCalendar.eventInfo.eventDate.lt(end), // event_date < end
-                        qCalendar.deletedAt.isNull()
-                ).fetch();
+    public Optional<Calendar> findByEventInfoEventScheduleIdAndUserId(UUID scheduleId, UUID userId) {
+        return jpaCalendarRepository.findByEventInfo_EventScheduleIdAndUserId(scheduleId, userId);
     }
 
     @Override
-    public Optional<Calendar> findByEventScheduleIdAndUserId(UUID scheduleId, UUID userId) {
-        return jpaCalendarRepository.findByEventScheduleIdAndUserId(scheduleId, userId);
+    public List<Calendar> findByUserIdAndYearMonth(UUID userId, int year, int month) {
+        return jpaCalendarRepository.findByUserIdAndYearMonth(userId, year, month);
     }
 }

--- a/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/infrastructure/persistence/CalendarRepositoryImpl.java
+++ b/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/infrastructure/persistence/CalendarRepositoryImpl.java
@@ -1,13 +1,14 @@
 package com.ojosama.calendarservice.calendar.infrastructure.persistence;
 
 import com.ojosama.calendarservice.calendar.domain.model.Calendar;
+import com.ojosama.calendarservice.calendar.domain.model.QCalendar;
 import com.ojosama.calendarservice.calendar.domain.repository.CalendarRepository;
+import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -15,25 +16,39 @@ import org.springframework.stereotype.Repository;
 public class CalendarRepositoryImpl implements CalendarRepository {
 
     private final JpaCalendarRepository jpaCalendarRepository;
+    private final JPAQueryFactory queryFactory;
 
     @Override
-    public Calendar save(Calendar calendar) {
-        return jpaCalendarRepository.save(calendar);
+    public void save(Calendar calendar) {
+        jpaCalendarRepository.save(calendar);
     }
 
     @Override
-    public Optional<Calendar> findByIdAndDeletedAtIsNull(UUID id) {
+    public Optional<Calendar> findByIdAndUserIdAndDeletedAtIsNull(UUID id, UUID userId) {
         return jpaCalendarRepository.findByIdAndDeletedAtIsNull(id);
     }
 
     @Override
-    public Page<Calendar> findByUserIdAndDeletedAtIsNull(UUID userId, Pageable pageable) {
-        return jpaCalendarRepository.findByUserIdAndDeletedAtIsNull(userId, pageable);
+    public List<Calendar> findByUserIdAndYearMonth(UUID userId, int year, int month) {
+        QCalendar qCalendar = QCalendar.calendar;
+
+        // 해당 월 1일
+        LocalDateTime start = LocalDateTime.of(year, month, 1, 0, 0);
+        // 다음달 1일
+        LocalDateTime end = start.plusMonths(1);
+
+        return queryFactory
+                .selectFrom(qCalendar)
+                .where(
+                        qCalendar.userId.eq(userId),
+                        qCalendar.eventDate.goe(start), // event_date >= start
+                        qCalendar.eventDate.lt(end), // event_date < end
+                        qCalendar.deletedAt.isNull()
+                ).fetch();
     }
 
     @Override
-    public Page<Calendar> findByUserIdAndEventDateBetweenAndDeletedAtIsNull(
-            UUID userId, LocalDateTime start, LocalDateTime end, Pageable pageable) {
-        return jpaCalendarRepository.findByUserIdAndEventDateBetweenAndDeletedAtIsNull(userId, start, end, pageable);
+    public Optional<Calendar> findByEventScheduleIdAndUserId(UUID scheduleId, UUID userId) {
+        return jpaCalendarRepository.findByEventScheduleIdAndUserId(scheduleId, userId);
     }
 }

--- a/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/infrastructure/persistence/CalendarRepositoryImpl.java
+++ b/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/infrastructure/persistence/CalendarRepositoryImpl.java
@@ -25,7 +25,7 @@ public class CalendarRepositoryImpl implements CalendarRepository {
     }
 
     @Override
-    public Optional<Calendar> findByEventInfoEventScheduleIdAndUserId(UUID scheduleId, UUID userId) {
+    public Optional<Calendar> findByEventInfo_EventScheduleIdAndUserId(UUID scheduleId, UUID userId) {
         return jpaCalendarRepository.findByEventInfo_EventScheduleIdAndUserId(scheduleId, userId);
     }
 

--- a/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/infrastructure/persistence/JpaCalendarRepository.java
+++ b/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/infrastructure/persistence/JpaCalendarRepository.java
@@ -1,19 +1,13 @@
 package com.ojosama.calendarservice.calendar.infrastructure.persistence;
 
 import com.ojosama.calendarservice.calendar.domain.model.Calendar;
-import java.time.LocalDateTime;
 import java.util.Optional;
 import java.util.UUID;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface JpaCalendarRepository extends JpaRepository<Calendar, UUID> {
 
     Optional<Calendar> findByIdAndDeletedAtIsNull(UUID id);
 
-    Page<Calendar> findByUserIdAndDeletedAtIsNull(UUID userId, Pageable pageable);
-
-    Page<Calendar> findByUserIdAndEventDateBetweenAndDeletedAtIsNull(
-            UUID userId, LocalDateTime start, LocalDateTime end, Pageable pageable);
+    Optional<Calendar> findByEventScheduleIdAndUserId(UUID eventScheduleId, UUID userId);
 }

--- a/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/infrastructure/persistence/JpaCalendarRepository.java
+++ b/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/infrastructure/persistence/JpaCalendarRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface JpaCalendarRepository extends JpaRepository<Calendar, UUID>, CalendarRepositoryCustom {
 
-    Optional<Calendar> findByEventInfo_EventScheduleIdAndUserId(UUID eventScheduleId, UUID userId);
+    Optional<Calendar> findByEventInfo_EventScheduleIdAndUserIdAndDeletedAtIsNull(UUID eventScheduleId, UUID userId);
 
     Optional<Calendar> findByIdAndUserIdAndDeletedAtIsNull(UUID id, UUID userId);
 }

--- a/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/infrastructure/persistence/JpaCalendarRepository.java
+++ b/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/infrastructure/persistence/JpaCalendarRepository.java
@@ -5,9 +5,9 @@ import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface JpaCalendarRepository extends JpaRepository<Calendar, UUID> {
+public interface JpaCalendarRepository extends JpaRepository<Calendar, UUID>, CalendarRepositoryCustom {
 
-    Optional<Calendar> findByEventScheduleIdAndUserId(UUID eventScheduleId, UUID userId);
+    Optional<Calendar> findByEventInfo_EventScheduleIdAndUserId(UUID eventScheduleId, UUID userId);
 
     Optional<Calendar> findByIdAndUserIdAndDeletedAtIsNull(UUID id, UUID userId);
 }

--- a/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/infrastructure/persistence/JpaCalendarRepository.java
+++ b/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/infrastructure/persistence/JpaCalendarRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface JpaCalendarRepository extends JpaRepository<Calendar, UUID> {
 
-    Optional<Calendar> findByIdAndDeletedAtIsNull(UUID id);
-
     Optional<Calendar> findByEventScheduleIdAndUserId(UUID eventScheduleId, UUID userId);
+
+    Optional<Calendar> findByIdAndUserIdAndDeletedAtIsNull(UUID id, UUID userId);
 }

--- a/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/presentaion/CalendarController.java
+++ b/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/presentaion/CalendarController.java
@@ -1,0 +1,86 @@
+package com.ojosama.calendarservice.calendar.presentaion;
+
+import com.ojosama.calendarservice.calendar.application.CalendarService;
+import com.ojosama.calendarservice.calendar.application.dto.command.CreateCalendarCommand;
+import com.ojosama.calendarservice.calendar.presentaion.dto.CalendarResponseDto;
+import com.ojosama.calendarservice.calendar.presentaion.dto.CreateCalendarRequestDto;
+import com.ojosama.calendarservice.calendar.presentaion.dto.UpdateMemoCalendarRequestDto;
+import com.ojosama.common.response.ApiResponse;
+import jakarta.validation.Valid;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/calendars")
+public class CalendarController {
+
+    private final CalendarService calendarService;
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<CalendarResponseDto>> createCalendar(
+            @Valid @RequestBody CreateCalendarRequestDto requestDto) {
+        // TODO : userId 수정
+        UUID userId = UUID.fromString("bd4e3ba4-55dd-45d4-b1ca-55f38f0c4804");
+
+        CalendarResponseDto dto = calendarService.createCalendar(CreateCalendarCommand.of(requestDto, userId));
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(ApiResponse.created(dto));
+    }
+
+    @GetMapping("/{calendarId}")
+    public ResponseEntity<ApiResponse<CalendarResponseDto>> getCalendar(@PathVariable UUID calendarId) {
+        // TODO : userId 수정
+        UUID userId = UUID.fromString("bd4e3ba4-55dd-45d4-b1ca-55f38f0c4804");
+
+        CalendarResponseDto dto = calendarService.getCalendar(calendarId, userId);
+
+        return ResponseEntity.ok(ApiResponse.success(dto));
+    }
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<CalendarResponseDto>>> getCalendars(@RequestParam("year") int year,
+                                                                               @RequestParam("month") int month) {
+        // TODO : userId 수정
+        UUID userId = UUID.fromString("bd4e3ba4-55dd-45d4-b1ca-55f38f0c4804");
+
+        List<CalendarResponseDto> list = calendarService.getCalendars(userId, year, month);
+
+        return ResponseEntity.ok(ApiResponse.success(list));
+    }
+
+    @PatchMapping("/{calendarId}")
+    public ResponseEntity<ApiResponse<CalendarResponseDto>> updateMemoCalendars(@PathVariable UUID calendarId,
+                                                                                @RequestBody UpdateMemoCalendarRequestDto dto) {
+        // TODO : userId 수정
+        UUID userId = UUID.fromString("bd4e3ba4-55dd-45d4-b1ca-55f38f0c4804");
+
+        CalendarResponseDto responseDto = calendarService.updateCalendarMemo(calendarId, dto.memo(), userId);
+
+        return ResponseEntity.ok(ApiResponse.success(responseDto));
+    }
+
+    @DeleteMapping("/{calendarId}")
+    public ResponseEntity<ApiResponse<Void>> deleteCalendar(@PathVariable UUID calendarId) {
+
+        // TODO : userId 수정
+        UUID userId = UUID.fromString("bd4e3ba4-55dd-45d4-b1ca-55f38f0c4804");
+
+        calendarService.deleteCalendar(calendarId, userId);
+        return ResponseEntity.ok(ApiResponse.deleted());
+    }
+
+}

--- a/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/presentaion/CalendarController.java
+++ b/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/presentaion/CalendarController.java
@@ -7,6 +7,8 @@ import com.ojosama.calendarservice.calendar.presentaion.dto.CreateCalendarReques
 import com.ojosama.calendarservice.calendar.presentaion.dto.UpdateMemoCalendarRequestDto;
 import com.ojosama.common.response.ApiResponse;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -52,8 +54,9 @@ public class CalendarController {
     }
 
     @GetMapping
-    public ResponseEntity<ApiResponse<List<CalendarResponseDto>>> getCalendars(@RequestParam("year") int year,
-                                                                               @RequestParam("month") int month) {
+    public ResponseEntity<ApiResponse<List<CalendarResponseDto>>> getCalendars(
+            @RequestParam("year") @Min(2000) @Max(9999) int year,
+            @RequestParam("month") @Min(1) @Max(12) int month) {
         // TODO : userId 수정
         UUID userId = UUID.fromString("bd4e3ba4-55dd-45d4-b1ca-55f38f0c4804");
 
@@ -62,6 +65,7 @@ public class CalendarController {
         return ResponseEntity.ok(ApiResponse.success(list));
     }
 
+    // TODO : 일정을 바꾸는 ...
     @PatchMapping("/{calendarId}")
     public ResponseEntity<ApiResponse<CalendarResponseDto>> updateMemoCalendars(@PathVariable UUID calendarId,
                                                                                 @RequestBody UpdateMemoCalendarRequestDto dto) {

--- a/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/presentaion/CalendarController.java
+++ b/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/presentaion/CalendarController.java
@@ -1,7 +1,6 @@
 package com.ojosama.calendarservice.calendar.presentaion;
 
 import com.ojosama.calendarservice.calendar.application.CalendarService;
-import com.ojosama.calendarservice.calendar.application.dto.command.CreateCalendarCommand;
 import com.ojosama.calendarservice.calendar.presentaion.dto.CalendarResponseDto;
 import com.ojosama.calendarservice.calendar.presentaion.dto.CreateCalendarRequestDto;
 import com.ojosama.calendarservice.calendar.presentaion.dto.UpdateMemoCalendarRequestDto;
@@ -37,7 +36,7 @@ public class CalendarController {
         // TODO : userId 수정
         UUID userId = UUID.fromString("bd4e3ba4-55dd-45d4-b1ca-55f38f0c4804");
 
-        CalendarResponseDto dto = calendarService.createCalendar(CreateCalendarCommand.of(requestDto, userId));
+        CalendarResponseDto dto = calendarService.createCalendar(requestDto.toCommand(userId));
         return ResponseEntity
                 .status(HttpStatus.CREATED)
                 .body(ApiResponse.created(dto));

--- a/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/presentaion/dto/CalendarResponseDto.java
+++ b/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/presentaion/dto/CalendarResponseDto.java
@@ -1,0 +1,22 @@
+package com.ojosama.calendarservice.calendar.presentaion.dto;
+
+import com.ojosama.calendarservice.calendar.application.dto.result.CalendarResult;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record CalendarResponseDto(
+        UUID id,
+        UUID eventScheduleId,
+        LocalDateTime eventDate,
+        LocalDateTime ticketingDate,
+        String memo
+) {
+    public static CalendarResponseDto from(CalendarResult result) {
+        return new CalendarResponseDto(
+                result.id(),
+                result.eventScheduleId(),
+                result.eventDate(),
+                result.ticketingDate(),
+                result.memo());
+    }
+}

--- a/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/presentaion/dto/CalendarResponseDto.java
+++ b/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/presentaion/dto/CalendarResponseDto.java
@@ -3,20 +3,27 @@ package com.ojosama.calendarservice.calendar.presentaion.dto;
 import com.ojosama.calendarservice.calendar.application.dto.result.CalendarResult;
 import java.time.LocalDateTime;
 import java.util.UUID;
+import lombok.Builder;
 
+@Builder
 public record CalendarResponseDto(
         UUID id,
         UUID eventScheduleId,
         LocalDateTime eventDate,
         LocalDateTime ticketingDate,
-        String memo
+        String memo,
+        String eventName,
+        UUID eventId
 ) {
     public static CalendarResponseDto from(CalendarResult result) {
-        return new CalendarResponseDto(
-                result.id(),
-                result.eventScheduleId(),
-                result.eventDate(),
-                result.ticketingDate(),
-                result.memo());
+        return CalendarResponseDto.builder()
+                .id(result.id())
+                .eventScheduleId(result.eventScheduleId())
+                .eventDate(result.eventDate())
+                .ticketingDate(result.ticketingDate())
+                .memo(result.memo())
+                .eventName(result.eventName())
+                .eventId(result.eventId())
+                .build();
     }
 }

--- a/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/presentaion/dto/CreateCalendarRequestDto.java
+++ b/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/presentaion/dto/CreateCalendarRequestDto.java
@@ -1,5 +1,6 @@
 package com.ojosama.calendarservice.calendar.presentaion.dto;
 
+import com.ojosama.calendarservice.calendar.application.dto.command.CreateCalendarCommand;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.util.UUID;
@@ -12,4 +13,12 @@ public record CreateCalendarRequestDto(
         @NotNull
         UUID eventId
 ) {
+    public CreateCalendarCommand toCommand(UUID userId) {
+        return CreateCalendarCommand.builder()
+                .eventScheduleId(this.eventScheduleId)
+                .memo(this.memo)
+                .eventId(this.eventId)
+                .userId(userId)
+                .build();
+    }
 }

--- a/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/presentaion/dto/CreateCalendarRequestDto.java
+++ b/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/presentaion/dto/CreateCalendarRequestDto.java
@@ -1,11 +1,15 @@
 package com.ojosama.calendarservice.calendar.presentaion.dto;
 
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import java.util.UUID;
 
 public record CreateCalendarRequestDto(
         @NotNull
         UUID eventScheduleId,
-        String memo
+        @Size(max = 1000)
+        String memo,
+        @NotNull
+        UUID eventId
 ) {
 }

--- a/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/presentaion/dto/CreateCalendarRequestDto.java
+++ b/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/presentaion/dto/CreateCalendarRequestDto.java
@@ -1,0 +1,11 @@
+package com.ojosama.calendarservice.calendar.presentaion.dto;
+
+import jakarta.validation.constraints.NotNull;
+import java.util.UUID;
+
+public record CreateCalendarRequestDto(
+        @NotNull
+        UUID eventScheduleId,
+        String memo
+) {
+}

--- a/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/presentaion/dto/UpdateMemoCalendarRequestDto.java
+++ b/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/presentaion/dto/UpdateMemoCalendarRequestDto.java
@@ -1,0 +1,8 @@
+package com.ojosama.calendarservice.calendar.presentaion.dto;
+
+public record UpdateMemoCalendarRequestDto(
+        String memo
+) {
+
+
+}

--- a/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/presentaion/dto/UpdateMemoCalendarRequestDto.java
+++ b/calendar-service/src/main/java/com/ojosama/calendarservice/calendar/presentaion/dto/UpdateMemoCalendarRequestDto.java
@@ -1,6 +1,9 @@
 package com.ojosama.calendarservice.calendar.presentaion.dto;
 
+import jakarta.validation.constraints.Size;
+
 public record UpdateMemoCalendarRequestDto(
+        @Size(max = 1000)
         String memo
 ) {
 

--- a/common/src/main/java/com/ojosama/common/audit/BaseUserEntity.java
+++ b/common/src/main/java/com/ojosama/common/audit/BaseUserEntity.java
@@ -26,4 +26,9 @@ public abstract class BaseUserEntity extends BaseEntity {
         super.deleted();
         this.deletedBy = deletedBy;
     }
+
+    public void restore() {
+        super.undeleted();
+        this.deletedBy = null;
+    }
 }


### PR DESCRIPTION
## 🔗 Issue Number
- close #72

## 📝 작업 내역

- QueryDsl 설정
- 캘린더 crud
- 필요한 에러코드 추가
- 데이터 조회 방식 최적화 (Pagination → List)
  - 기존 Repository의 Page 처리를 삭제하고 List 반환 방식으로 변경
  - 달력 UI를 생각해서 특정 연도와 월을 기준으로 데이터를 조회하도록 수정

## 💡 PR 특이사항

- 아직 feign, kafka 설정은 하지 못했습니다,,
- 캘린더 화면에서는 페이징보다 특정 월의 데이터를 한꺼번에 보여준다고 생각해서 List 형태로 조회를 수정했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 캘린더 REST API를 통한 일정 관리 기능 제공
  * 행사 정보(행사 날짜, 티켓팅 일정) 저장 및 조회 지원
  * 연/월별 캘린더 조회 기능
  * 캘린더 메모 작성 및 수정 가능
  * 일정 삭제 및 복구 지원
<!-- end of auto-generated comment: release notes by coderabbit.ai -->