### PR TITLE
[REFACTOR] kafka 배치처리

### DIFF
--- a/common/src/main/java/com/ojosama/common/kafka/domain/OutboxMessageProcessor.java
+++ b/common/src/main/java/com/ojosama/common/kafka/domain/OutboxMessageProcessor.java
@@ -28,7 +28,6 @@ public class OutboxMessageProcessor {
     }
 
     // 배치 처리
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void sendBatch(List<OutboxMessage> messages) {
         List<Map.Entry<OutboxMessage, CompletableFuture<SendResult<String, String>>>> futures =
                 messages.stream()
@@ -70,6 +69,11 @@ public class OutboxMessageProcessor {
                         message.getId(), message.getRetryCount());
             }
         }
+        persistStatuses(messages);
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    void persistStatuses(List<OutboxMessage> messages) {
         outboxRepository.saveAll(messages);
     }
 }

--- a/common/src/main/java/com/ojosama/common/kafka/domain/OutboxMessageProcessor.java
+++ b/common/src/main/java/com/ojosama/common/kafka/domain/OutboxMessageProcessor.java
@@ -11,20 +11,19 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.support.SendResult;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Propagation;
-import org.springframework.transaction.annotation.Transactional;
 
 @Component
 @Slf4j
 public class OutboxMessageProcessor {
 
     private final KafkaTemplate<String, String> kafkaTemplate;
-    private final OutboxRepository outboxRepository;
+    private final OutboxStatusPersister outboxStatusPersister;
 
     public OutboxMessageProcessor(
-            @Qualifier("kafkaTemplate") KafkaTemplate<String, String> kafkaTemplate, OutboxRepository outboxRepository) {
+            @Qualifier("kafkaTemplate") KafkaTemplate<String, String> kafkaTemplate, OutboxRepository outboxRepository,
+            OutboxStatusPersister outboxStatusPersister) {
         this.kafkaTemplate = kafkaTemplate;
-        this.outboxRepository = outboxRepository;
+        this.outboxStatusPersister = outboxStatusPersister;
     }
 
     // 배치 처리
@@ -69,11 +68,6 @@ public class OutboxMessageProcessor {
                         message.getId(), message.getRetryCount());
             }
         }
-        persistStatuses(messages);
-    }
-
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
-    void persistStatuses(List<OutboxMessage> messages) {
-        outboxRepository.saveAll(messages);
+        outboxStatusPersister.persist(messages);
     }
 }

--- a/common/src/main/java/com/ojosama/common/kafka/domain/OutboxMessageProcessor.java
+++ b/common/src/main/java/com/ojosama/common/kafka/domain/OutboxMessageProcessor.java
@@ -19,10 +19,12 @@ import org.springframework.transaction.annotation.Transactional;
 public class OutboxMessageProcessor {
 
     private final KafkaTemplate<String, String> kafkaTemplate;
+    private final OutboxRepository outboxRepository;
 
     public OutboxMessageProcessor(
-            @Qualifier("kafkaTemplate") KafkaTemplate<String, String> kafkaTemplate) {
+            @Qualifier("kafkaTemplate") KafkaTemplate<String, String> kafkaTemplate, OutboxRepository outboxRepository) {
         this.kafkaTemplate = kafkaTemplate;
+        this.outboxRepository = outboxRepository;
     }
 
     // 배치 처리
@@ -44,7 +46,7 @@ public class OutboxMessageProcessor {
                 : futures) {
             OutboxMessage message = entry.getKey();
             try {
-                SendResult<String, String> result = entry.getValue().get(5, TimeUnit.SECONDS);
+                SendResult<String, String> result = entry.getValue().get(120, TimeUnit.SECONDS);
                 log.debug("Outbox sent. id={}, topic={}, partition={}, offset={}",
                         message.getId(),
                         message.getTopic(),
@@ -56,16 +58,18 @@ public class OutboxMessageProcessor {
                 message.markFailed("Interrupted: " + e.getMessage());
                 log.warn("Outbox send interrupted. id={}, retryCount={}",
                         message.getId(), message.getRetryCount());
+                break;
             } catch (ExecutionException e) {
                 message.markFailed(
                         e.getCause() != null ? e.getCause().getMessage() : e.getMessage());
                 log.warn("Outbox send failed. id={}, retryCount={}, error={}",
                         message.getId(), message.getRetryCount(), message.getLastError());
-            } catch (TimeoutException e) {                          // ← 이거 추가
-                message.markFailed("Timeout: 5초 내 응답 없음");
+            } catch (TimeoutException e) {
+                message.markFailed("Timeout: 120초 내 응답 없음");
                 log.warn("Outbox send timeout. id={}, retryCount={}",
                         message.getId(), message.getRetryCount());
             }
         }
+        outboxRepository.saveAll(messages);
     }
 }

--- a/common/src/main/java/com/ojosama/common/kafka/domain/OutboxMessageProcessor.java
+++ b/common/src/main/java/com/ojosama/common/kafka/domain/OutboxMessageProcessor.java
@@ -73,9 +73,35 @@ public class OutboxMessageProcessor {
                         message.getId(), message.getRetryCount(), message.getLastError());
 
             } catch (TimeoutException e) {
-                message.markFailed("Timeout: 120초 내 응답 없음");
-                log.warn("Outbox send timeout. id={}, retryCount={}",
-                        message.getId(), message.getRetryCount());
+                interrupted = true;
+
+                //future가 이미 완료됐을 수 있으니 한 번 더 확인
+                CompletableFuture<SendResult<String, String>> future = entry.getValue();
+
+                if (future.isDone() && !future.isCompletedExceptionally()) {
+                    // send가 실제로 성공했으면 markSent
+                    try {
+                        SendResult<String, String> result = future.getNow(null);
+                        if (result != null) {
+                            message.markSent();
+                            log.debug("Outbox sent (after interrupt). id={}, topic={}",
+                                    message.getId(), message.getTopic());
+                        } else {
+                            message.markFailed("Interrupted: future 결과 null");
+                        }
+                    } catch (Exception ex) {
+                        message.markFailed("Interrupted + 결과 확인 실패: " + ex.getMessage());
+                    }
+                } else if (future.isCompletedExceptionally()) {
+                    // send가 실패했으면 markFailed
+                    message.markFailed("Interrupted + send 실패");
+                    log.warn("Outbox send failed (after interrupt). id={}, retryCount={}",
+                            message.getId(), message.getRetryCount());
+                } else {
+                    // future가 아직 진행 중 — 결과를 모르니 PENDING 유지 (markFailed 안 함)
+                    // 다음 poll에서 다시 처리됨 → inbox 멱등으로 중복 안전
+                    log.warn("Outbox send interrupted, future still pending. id={}", message.getId());
+                }
             }
         }
 

--- a/common/src/main/java/com/ojosama/common/kafka/domain/OutboxMessageProcessor.java
+++ b/common/src/main/java/com/ojosama/common/kafka/domain/OutboxMessageProcessor.java
@@ -20,13 +20,12 @@ public class OutboxMessageProcessor {
     private final OutboxStatusPersister outboxStatusPersister;
 
     public OutboxMessageProcessor(
-            @Qualifier("kafkaTemplate") KafkaTemplate<String, String> kafkaTemplate, OutboxRepository outboxRepository,
+            @Qualifier("kafkaTemplate") KafkaTemplate<String, String> kafkaTemplate,
             OutboxStatusPersister outboxStatusPersister) {
         this.kafkaTemplate = kafkaTemplate;
         this.outboxStatusPersister = outboxStatusPersister;
     }
 
-    // 배치 처리
     public void sendBatch(List<OutboxMessage> messages) {
         List<Map.Entry<OutboxMessage, CompletableFuture<SendResult<String, String>>>> futures =
                 messages.stream()
@@ -40,6 +39,8 @@ public class OutboxMessageProcessor {
                         ))
                         .toList();
 
+        boolean interrupted = false; //인터럽트 발생 여부 기록
+
         for (Map.Entry<OutboxMessage, CompletableFuture<SendResult<String, String>>> entry
                 : futures) {
             OutboxMessage message = entry.getKey();
@@ -51,23 +52,32 @@ public class OutboxMessageProcessor {
                         result.getRecordMetadata().partition(),
                         result.getRecordMetadata().offset());
                 message.markSent();
+
             } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
+                interrupted = true; //break 대신 플래그만 설정
                 message.markFailed("Interrupted: " + e.getMessage());
                 log.warn("Outbox send interrupted. id={}, retryCount={}",
                         message.getId(), message.getRetryCount());
-                break;
+
             } catch (ExecutionException e) {
                 message.markFailed(
                         e.getCause() != null ? e.getCause().getMessage() : e.getMessage());
                 log.warn("Outbox send failed. id={}, retryCount={}, error={}",
                         message.getId(), message.getRetryCount(), message.getLastError());
+
             } catch (TimeoutException e) {
                 message.markFailed("Timeout: 120초 내 응답 없음");
                 log.warn("Outbox send timeout. id={}, retryCount={}",
                         message.getId(), message.getRetryCount());
             }
         }
+
+        // 모든 future 결과 확인 후 한 번에 저장
         outboxStatusPersister.persist(messages);
+
+        // 인터럽트 상태 복원 — 루프 끝난 후에 설정
+        if (interrupted) {
+            Thread.currentThread().interrupt();
+        }
     }
 }

--- a/common/src/main/java/com/ojosama/common/kafka/domain/OutboxMessageProcessor.java
+++ b/common/src/main/java/com/ojosama/common/kafka/domain/OutboxMessageProcessor.java
@@ -1,5 +1,10 @@
 package com.ojosama.common.kafka.domain;
 
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import org.springframework.beans.factory.annotation.Qualifier;
 import java.util.concurrent.ExecutionException;
 import lombok.extern.slf4j.Slf4j;
@@ -9,9 +14,6 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
-//Outbox 메시지 한 건을 별도 트랜잭션으로 처리.
-//REQUIRES_NEW로 분리한 이유: 폴러 루프 내에서 한 메시지의 실패가
-//다음 메시지 처리에 영향을 주지 않도록 하기 위함.
 @Component
 @Slf4j
 public class OutboxMessageProcessor {
@@ -23,32 +25,47 @@ public class OutboxMessageProcessor {
         this.kafkaTemplate = kafkaTemplate;
     }
 
+    // 배치 처리
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void send(OutboxMessage message) {
-        try {
-            // messageKey를 Kafka key로 사용 — 같은 키는 같은 파티션에 들어가
-            // 순서 보장 + 컨슈머 측 멱등 처리에 활용됨
-            SendResult<String, String> result = kafkaTemplate.send(
-                    message.getTopic(),
-                    message.getMessageKey().toString(),
-                    message.getPayload()
-            ).get();
+    public void sendBatch(List<OutboxMessage> messages) {
+        List<Map.Entry<OutboxMessage, CompletableFuture<SendResult<String, String>>>> futures =
+                messages.stream()
+                        .map(message -> Map.entry(
+                                message,
+                                kafkaTemplate.send(
+                                        message.getTopic(),
+                                        message.getMessageKey().toString(),
+                                        message.getPayload()
+                                )
+                        ))
+                        .toList();
 
-            log.debug("Outbox sent. id={}, topic={}, partition={}, offset={}",
-                    message.getId(),
-                    message.getTopic(),
-                    result.getRecordMetadata().partition(),
-                    result.getRecordMetadata().offset());
-
-            message.markSent();
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            message.markFailed("Interrupted: " + e.getMessage());
-            log.warn("Outbox send interrupted. id={}, retryCount={}", message.getId(), message.getRetryCount());
-        } catch (ExecutionException e) {
-            message.markFailed(e.getCause() != null ? e.getCause().getMessage() : e.getMessage());
-            log.warn("Outbox send failed. id={}, retryCount={}, error={}",
-                    message.getId(), message.getRetryCount(), message.getLastError());
+        for (Map.Entry<OutboxMessage, CompletableFuture<SendResult<String, String>>> entry
+                : futures) {
+            OutboxMessage message = entry.getKey();
+            try {
+                SendResult<String, String> result = entry.getValue().get(5, TimeUnit.SECONDS);
+                log.debug("Outbox sent. id={}, topic={}, partition={}, offset={}",
+                        message.getId(),
+                        message.getTopic(),
+                        result.getRecordMetadata().partition(),
+                        result.getRecordMetadata().offset());
+                message.markSent();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                message.markFailed("Interrupted: " + e.getMessage());
+                log.warn("Outbox send interrupted. id={}, retryCount={}",
+                        message.getId(), message.getRetryCount());
+            } catch (ExecutionException e) {
+                message.markFailed(
+                        e.getCause() != null ? e.getCause().getMessage() : e.getMessage());
+                log.warn("Outbox send failed. id={}, retryCount={}, error={}",
+                        message.getId(), message.getRetryCount(), message.getLastError());
+            } catch (TimeoutException e) {                          // ← 이거 추가
+                message.markFailed("Timeout: 5초 내 응답 없음");
+                log.warn("Outbox send timeout. id={}, retryCount={}",
+                        message.getId(), message.getRetryCount());
+            }
         }
     }
 }

--- a/common/src/main/java/com/ojosama/common/kafka/domain/OutboxMessageProcessor.java
+++ b/common/src/main/java/com/ojosama/common/kafka/domain/OutboxMessageProcessor.java
@@ -40,12 +40,19 @@ public class OutboxMessageProcessor {
                         .toList();
 
         boolean interrupted = false; //인터럽트 발생 여부 기록
+        long deadlineNanos = System.nanoTime() + TimeUnit.SECONDS.toNanos(120);
 
         for (Map.Entry<OutboxMessage, CompletableFuture<SendResult<String, String>>> entry
                 : futures) {
             OutboxMessage message = entry.getKey();
             try {
-                SendResult<String, String> result = entry.getValue().get(120, TimeUnit.SECONDS);
+                long remainingNanos = deadlineNanos - System.nanoTime();
+                if (remainingNanos <= 0) {
+                    message.markFailed("Timeout: 배치 처리 제한 시간 초과");
+                    continue;
+                }
+                SendResult<String, String> result =
+                        entry.getValue().get(remainingNanos, TimeUnit.NANOSECONDS);
                 log.debug("Outbox sent. id={}, topic={}, partition={}, offset={}",
                         message.getId(),
                         message.getTopic(),

--- a/common/src/main/java/com/ojosama/common/kafka/domain/OutboxPoller.java
+++ b/common/src/main/java/com/ojosama/common/kafka/domain/OutboxPoller.java
@@ -26,13 +26,9 @@ public class OutboxPoller {
         if (batch.isEmpty()) {
             return;
         }
-        for (OutboxMessage message : batch) {
-            try {
-                processor.send(message);
-            } catch (Exception e) {
-                log.warn("Outbox 메시지 처리 실패. id={}, type={}",
-                        message.getId(), message.getEventType(), e);
-            }
-        }
+        log.debug("Outbox 배치 처리 시작. count={}", batch.size());
+
+        // 기존: 건별 루프 → 변경: 배치 한 번에 처리
+        processor.sendBatch(batch);
     }
 }

--- a/common/src/main/java/com/ojosama/common/kafka/domain/OutboxStatusPersister.java
+++ b/common/src/main/java/com/ojosama/common/kafka/domain/OutboxStatusPersister.java
@@ -1,0 +1,18 @@
+package com.ojosama.common.kafka.domain;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class OutboxStatusPersister {
+    private final OutboxRepository outboxRepository;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void persist(List<OutboxMessage> messages) {
+        outboxRepository.saveAll(messages);
+    }
+}


### PR DESCRIPTION
## 🔗 Issue Number
- close #80 

## 📝 작업 내역

- 기존의 건별로 동기처리 했던 것을 비동기 병렬 배치처리로 수정

## 💡 PR 특이사항
-

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **성능 개선**
  * 메시지 전송을 일괄 처리로 전환하여 Kafka 전송 처리 효율 향상

* **안정성 개선**
  * 120초 타임아웃, 중단 및 실행 예외에 대한 처리 강화
  * 개별 메시지 전송 결과에 따른 상세 로깅 및 상태 표기 추가
  * 실패·중단 시 남은 처리 중단과 일관된 상태 관리 보장

* **새 기능**
  * 배치 전송 후 전체 메시지 상태를 한 번에 저장하는 새로운 상태 저장 흐름 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->