### PR TITLE
[FEATURE] 메시지 CRUD 및 내부 조회 API 추가

### DIFF
--- a/chat-service/src/main/java/com/ojosama/chatservice/application/dto/command/CreateMessageCommand.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/application/dto/command/CreateMessageCommand.java
@@ -5,6 +5,7 @@ import java.util.UUID;
 public record CreateMessageCommand(
         UUID chatRoomId,
         UUID userId,
+        String writerNickname,
         String content
 ) {
 }

--- a/chat-service/src/main/java/com/ojosama/chatservice/application/dto/command/CreateMessageCommand.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/application/dto/command/CreateMessageCommand.java
@@ -1,0 +1,10 @@
+package com.ojosama.chatservice.application.dto.command;
+
+import java.util.UUID;
+
+public record CreateMessageCommand(
+        UUID chatRoomId,
+        UUID userId,
+        String content
+) {
+}

--- a/chat-service/src/main/java/com/ojosama/chatservice/application/dto/command/DeleteMessageCommand.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/application/dto/command/DeleteMessageCommand.java
@@ -1,0 +1,9 @@
+package com.ojosama.chatservice.application.dto.command;
+
+import java.util.UUID;
+
+public record DeleteMessageCommand(
+        UUID messageId,
+        UUID userId
+) {
+}

--- a/chat-service/src/main/java/com/ojosama/chatservice/application/dto/query/FindMessageQuery.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/application/dto/query/FindMessageQuery.java
@@ -1,0 +1,8 @@
+package com.ojosama.chatservice.application.dto.query;
+
+import java.util.UUID;
+
+public record FindMessageQuery(
+        UUID messageId
+) {
+}

--- a/chat-service/src/main/java/com/ojosama/chatservice/application/dto/query/FindMessagesByChatRoomQuery.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/application/dto/query/FindMessagesByChatRoomQuery.java
@@ -1,0 +1,10 @@
+package com.ojosama.chatservice.application.dto.query;
+
+import java.util.UUID;
+
+public record FindMessagesByChatRoomQuery(
+        UUID chatRoomId,
+        int page,
+        int size
+) {
+}

--- a/chat-service/src/main/java/com/ojosama/chatservice/application/dto/result/MessageResult.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/application/dto/result/MessageResult.java
@@ -1,0 +1,26 @@
+package com.ojosama.chatservice.application.dto.result;
+
+import com.ojosama.chatservice.domain.model.Message;
+import com.ojosama.chatservice.domain.model.MessageStatus;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record MessageResult(
+        UUID messageId,
+        UUID chatRoomId,
+        UUID userId,
+        String content,
+        MessageStatus status,
+        LocalDateTime createdAt
+) {
+    public static MessageResult from(Message message) {
+        return new MessageResult(
+                message.getId(),
+                message.getChatRoomId(),
+                message.getUserId(),
+                message.getContent(),
+                message.getStatus(),
+                message.getCreatedAt()
+        );
+    }
+}

--- a/chat-service/src/main/java/com/ojosama/chatservice/application/dto/result/MessageResult.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/application/dto/result/MessageResult.java
@@ -9,6 +9,7 @@ public record MessageResult(
         UUID messageId,
         UUID chatRoomId,
         UUID userId,
+        String writerNickname,
         String content,
         MessageStatus status,
         LocalDateTime createdAt
@@ -18,6 +19,7 @@ public record MessageResult(
                 message.getId(),
                 message.getChatRoomId(),
                 message.getUserId(),
+                message.getWriterNickname(),
                 message.getContent(),
                 message.getStatus(),
                 message.getCreatedAt()

--- a/chat-service/src/main/java/com/ojosama/chatservice/application/dto/result/MessageSliceResult.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/application/dto/result/MessageSliceResult.java
@@ -1,0 +1,9 @@
+package com.ojosama.chatservice.application.dto.result;
+
+import java.util.List;
+
+public record MessageSliceResult(
+        List<MessageResult> messages,
+        boolean hasNext
+) {
+}

--- a/chat-service/src/main/java/com/ojosama/chatservice/application/dto/result/ReportedMessageResult.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/application/dto/result/ReportedMessageResult.java
@@ -1,6 +1,5 @@
 package com.ojosama.chatservice.application.dto.result;
 
-import com.ojosama.chatservice.domain.model.EventCategory;
 import com.ojosama.chatservice.domain.model.Message;
 import com.ojosama.chatservice.domain.model.MessageStatus;
 import java.time.LocalDateTime;
@@ -9,17 +8,17 @@ import java.util.UUID;
 public record ReportedMessageResult(
         UUID messageId,
         UUID chatRoomId,
-        EventCategory categoryName,
+        String category,
         UUID userId,
         String content,
         MessageStatus status,
         LocalDateTime createdAt
 ) {
-    public static ReportedMessageResult from(Message message, EventCategory categoryName) {
+    public static ReportedMessageResult from(Message message, String category) {
         return new ReportedMessageResult(
                 message.getId(),
                 message.getChatRoomId(),
-                categoryName,
+                category,
                 message.getUserId(),
                 message.getContent(),
                 message.getStatus(),

--- a/chat-service/src/main/java/com/ojosama/chatservice/application/dto/result/ReportedMessageResult.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/application/dto/result/ReportedMessageResult.java
@@ -1,0 +1,29 @@
+package com.ojosama.chatservice.application.dto.result;
+
+import com.ojosama.chatservice.domain.model.EventCategory;
+import com.ojosama.chatservice.domain.model.Message;
+import com.ojosama.chatservice.domain.model.MessageStatus;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record ReportedMessageResult(
+        UUID messageId,
+        UUID chatRoomId,
+        EventCategory categoryName,
+        UUID userId,
+        String content,
+        MessageStatus status,
+        LocalDateTime createdAt
+) {
+    public static ReportedMessageResult from(Message message, EventCategory categoryName) {
+        return new ReportedMessageResult(
+                message.getId(),
+                message.getChatRoomId(),
+                categoryName,
+                message.getUserId(),
+                message.getContent(),
+                message.getStatus(),
+                message.getCreatedAt()
+        );
+    }
+}

--- a/chat-service/src/main/java/com/ojosama/chatservice/application/service/MessageService.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/application/service/MessageService.java
@@ -11,6 +11,7 @@ import com.ojosama.chatservice.domain.exception.ChatErrorCode;
 import com.ojosama.chatservice.domain.exception.ChatException;
 import com.ojosama.chatservice.domain.model.ChatRoom;
 import com.ojosama.chatservice.domain.model.Message;
+import com.ojosama.chatservice.domain.model.MessageStatus;
 import com.ojosama.chatservice.domain.repository.ChatRoomRepository;
 import com.ojosama.chatservice.domain.repository.MessageRepository;
 import com.ojosama.common.exception.CommonErrorCode;
@@ -30,6 +31,7 @@ public class MessageService {
 
     private static final int MAX_MESSAGE_CONTENT_LENGTH = 1000;
     private static final int MAX_WRITER_NICKNAME_LENGTH = 50;
+    private static final int MAX_PAGE_SIZE = 100;
 
     private final MessageRepository messageRepository;
     private final ChatRoomRepository chatRoomRepository;
@@ -61,19 +63,28 @@ public class MessageService {
         if (query == null || query.messageId() == null) {
             throw new ChatException(CommonErrorCode.INVALID_REQUEST);
         }
-        return MessageResult.from(findMessage(query.messageId()));
+        Message message = findMessage(query.messageId());
+        if (!message.isVisible()) {
+            throw new ChatException(ChatErrorCode.MESSAGE_NOT_FOUND);
+        }
+        return MessageResult.from(message);
     }
 
     @Transactional(readOnly = true)
     public MessageSliceResult getMessagesByChatRoom(FindMessagesByChatRoomQuery query) {
-        if (query == null || query.chatRoomId() == null || query.page() < 0 || query.size() <= 0) {
+        if (query == null || query.chatRoomId() == null || query.page() < 0
+                || query.size() <= 0 || query.size() > MAX_PAGE_SIZE) {
             throw new ChatException(CommonErrorCode.INVALID_REQUEST);
         }
 
         findChatRoom(query.chatRoomId());
 
         Pageable pageable = PageRequest.of(query.page(), query.size());
-        Slice<Message> messages = messageRepository.findByChatRoomId(query.chatRoomId(), pageable);
+        Slice<Message> messages = messageRepository.findByChatRoomIdAndStatus(
+                query.chatRoomId(),
+                MessageStatus.ACTIVE,
+                pageable
+        );
 
         List<MessageResult> results = messages.getContent().stream()
                 .map(MessageResult::from)
@@ -104,7 +115,7 @@ public class MessageService {
         Message message = findMessage(messageId);
         ChatRoom chatRoom = findChatRoom(message.getChatRoomId());
 
-        return ReportedMessageResult.from(message, chatRoom.getCategory());
+        return ReportedMessageResult.from(message, chatRoom.getCategory().name());
     }
 
     private void validateContent(String content) {

--- a/chat-service/src/main/java/com/ojosama/chatservice/application/service/MessageService.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/application/service/MessageService.java
@@ -29,6 +29,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class MessageService {
 
     private static final int MAX_MESSAGE_CONTENT_LENGTH = 1000;
+    private static final int MAX_WRITER_NICKNAME_LENGTH = 50;
 
     private final MessageRepository messageRepository;
     private final ChatRoomRepository chatRoomRepository;
@@ -37,6 +38,7 @@ public class MessageService {
         if (command == null || command.chatRoomId() == null || command.userId() == null) {
             throw new ChatException(CommonErrorCode.INVALID_REQUEST);
         }
+        validateWriterNickname(command.writerNickname());
         validateContent(command.content());
 
         ChatRoom chatRoom = findChatRoom(command.chatRoomId());
@@ -47,6 +49,7 @@ public class MessageService {
         Message message = Message.builder()
                 .chatRoomId(command.chatRoomId())
                 .userId(command.userId())
+                .writerNickname(command.writerNickname().trim())
                 .content(command.content().trim())
                 .build();
 
@@ -110,6 +113,15 @@ public class MessageService {
         }
         if (content.trim().length() > MAX_MESSAGE_CONTENT_LENGTH) {
             throw new ChatException(ChatErrorCode.MESSAGE_CONTENT_TOO_LONG);
+        }
+    }
+
+    private void validateWriterNickname(String writerNickname) {
+        if (writerNickname == null || writerNickname.isBlank()) {
+            throw new ChatException(ChatErrorCode.MESSAGE_WRITER_NICKNAME_REQUIRED);
+        }
+        if (writerNickname.trim().length() > MAX_WRITER_NICKNAME_LENGTH) {
+            throw new ChatException(ChatErrorCode.MESSAGE_WRITER_NICKNAME_TOO_LONG);
         }
     }
 

--- a/chat-service/src/main/java/com/ojosama/chatservice/application/service/MessageService.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/application/service/MessageService.java
@@ -1,0 +1,125 @@
+package com.ojosama.chatservice.application.service;
+
+import com.ojosama.chatservice.application.dto.command.CreateMessageCommand;
+import com.ojosama.chatservice.application.dto.command.DeleteMessageCommand;
+import com.ojosama.chatservice.application.dto.query.FindMessageQuery;
+import com.ojosama.chatservice.application.dto.query.FindMessagesByChatRoomQuery;
+import com.ojosama.chatservice.application.dto.result.MessageResult;
+import com.ojosama.chatservice.application.dto.result.MessageSliceResult;
+import com.ojosama.chatservice.application.dto.result.ReportedMessageResult;
+import com.ojosama.chatservice.domain.exception.ChatErrorCode;
+import com.ojosama.chatservice.domain.exception.ChatException;
+import com.ojosama.chatservice.domain.model.ChatRoom;
+import com.ojosama.chatservice.domain.model.Message;
+import com.ojosama.chatservice.domain.repository.ChatRoomRepository;
+import com.ojosama.chatservice.domain.repository.MessageRepository;
+import com.ojosama.common.exception.CommonErrorCode;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class MessageService {
+
+    private static final int MAX_MESSAGE_CONTENT_LENGTH = 1000;
+
+    private final MessageRepository messageRepository;
+    private final ChatRoomRepository chatRoomRepository;
+
+    public MessageResult createMessage(CreateMessageCommand command) {
+        if (command == null || command.chatRoomId() == null || command.userId() == null) {
+            throw new ChatException(CommonErrorCode.INVALID_REQUEST);
+        }
+        validateContent(command.content());
+
+        ChatRoom chatRoom = findChatRoom(command.chatRoomId());
+        if (!chatRoom.isOpen()) {
+            throw new ChatException(ChatErrorCode.CHAT_ROOM_NOT_OPEN);
+        }
+
+        Message message = Message.builder()
+                .chatRoomId(command.chatRoomId())
+                .userId(command.userId())
+                .content(command.content().trim())
+                .build();
+
+        return MessageResult.from(messageRepository.save(message));
+    }
+
+    @Transactional(readOnly = true)
+    public MessageResult getMessage(FindMessageQuery query) {
+        if (query == null || query.messageId() == null) {
+            throw new ChatException(CommonErrorCode.INVALID_REQUEST);
+        }
+        return MessageResult.from(findMessage(query.messageId()));
+    }
+
+    @Transactional(readOnly = true)
+    public MessageSliceResult getMessagesByChatRoom(FindMessagesByChatRoomQuery query) {
+        if (query == null || query.chatRoomId() == null || query.page() < 0 || query.size() <= 0) {
+            throw new ChatException(CommonErrorCode.INVALID_REQUEST);
+        }
+
+        findChatRoom(query.chatRoomId());
+
+        Pageable pageable = PageRequest.of(query.page(), query.size());
+        Slice<Message> messages = messageRepository.findByChatRoomId(query.chatRoomId(), pageable);
+
+        List<MessageResult> results = messages.getContent().stream()
+                .map(MessageResult::from)
+                .toList();
+
+        return new MessageSliceResult(results, messages.hasNext());
+    }
+
+    public void deleteMessage(DeleteMessageCommand command) {
+        if (command == null || command.messageId() == null || command.userId() == null) {
+            throw new ChatException(CommonErrorCode.INVALID_REQUEST);
+        }
+
+        Message message = findMessage(command.messageId());
+        if (!command.userId().equals(message.getUserId())) {
+            throw new ChatException(ChatErrorCode.MESSAGE_DELETE_FORBIDDEN);
+        }
+
+        message.delete();
+    }
+
+    @Transactional(readOnly = true)
+    public ReportedMessageResult getReportedMessage(UUID messageId) {
+        if (messageId == null) {
+            throw new ChatException(CommonErrorCode.INVALID_REQUEST);
+        }
+
+        Message message = findMessage(messageId);
+        ChatRoom chatRoom = findChatRoom(message.getChatRoomId());
+
+        return ReportedMessageResult.from(message, chatRoom.getCategory());
+    }
+
+    private void validateContent(String content) {
+        if (content == null || content.isBlank()) {
+            throw new ChatException(ChatErrorCode.MESSAGE_CONTENT_REQUIRED);
+        }
+        if (content.trim().length() > MAX_MESSAGE_CONTENT_LENGTH) {
+            throw new ChatException(ChatErrorCode.MESSAGE_CONTENT_TOO_LONG);
+        }
+    }
+
+    private Message findMessage(UUID messageId) {
+        return messageRepository.findById(messageId)
+                .orElseThrow(() -> new ChatException(ChatErrorCode.MESSAGE_NOT_FOUND));
+    }
+
+    private ChatRoom findChatRoom(UUID chatRoomId) {
+        return chatRoomRepository.findById(chatRoomId)
+                .orElseThrow(() -> new ChatException(ChatErrorCode.CHAT_ROOM_NOT_FOUND));
+    }
+}

--- a/chat-service/src/main/java/com/ojosama/chatservice/domain/exception/ChatErrorCode.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/domain/exception/ChatErrorCode.java
@@ -24,6 +24,8 @@ public enum ChatErrorCode implements ErrorCode {
     MESSAGE_NOT_ACTIVE(HttpStatus.BAD_REQUEST, "ACTIVE 상태에서만 블라인드할 수 있습니다."),
     MESSAGE_CONTENT_REQUIRED(HttpStatus.BAD_REQUEST, "메시지 내용은 필수입니다."),
     MESSAGE_CONTENT_TOO_LONG(HttpStatus.BAD_REQUEST, "메시지 내용이 최대 길이를 초과했습니다."),
+    MESSAGE_WRITER_NICKNAME_REQUIRED(HttpStatus.BAD_REQUEST, "작성자 닉네임은 필수입니다."),
+    MESSAGE_WRITER_NICKNAME_TOO_LONG(HttpStatus.BAD_REQUEST, "작성자 닉네임이 최대 길이를 초과했습니다."),
     MESSAGE_SEND_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "현재 채팅방에는 메시지를 보낼 수 없습니다."),
 
     // Permission

--- a/chat-service/src/main/java/com/ojosama/chatservice/domain/model/Message.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/domain/model/Message.java
@@ -36,6 +36,9 @@ public class Message extends BaseEntity {
     @Column(nullable = false, columnDefinition = "uuid")
     private UUID userId;
 
+    @Column(nullable = false, length = 50)
+    private String writerNickname;
+
     @Column(nullable = false, length = 1000)
     private String content;
 
@@ -50,9 +53,10 @@ public class Message extends BaseEntity {
     private UUID blindedBy;
 
     @Builder
-    private Message(UUID chatRoomId, UUID userId, String content) {
+    private Message(UUID chatRoomId, UUID userId, String writerNickname, String content) {
         this.chatRoomId = chatRoomId;
         this.userId = userId;
+        this.writerNickname = writerNickname;
         this.content = content;
         this.status = MessageStatus.ACTIVE;
     }

--- a/chat-service/src/main/java/com/ojosama/chatservice/domain/repository/MessageRepository.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/domain/repository/MessageRepository.java
@@ -1,6 +1,7 @@
 package com.ojosama.chatservice.domain.repository;
 
 import com.ojosama.chatservice.domain.model.Message;
+import com.ojosama.chatservice.domain.model.MessageStatus;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.domain.Pageable;
@@ -13,6 +14,6 @@ public interface MessageRepository {
     Optional<Message> findById(UUID id);
 
     // 채팅 히스토리 조회 (무한스크롤 - cursor 기반)
-    Slice<Message> findByChatRoomId(UUID chatRoomId, Pageable pageable);
+    Slice<Message> findByChatRoomIdAndStatus(UUID chatRoomId, MessageStatus status, Pageable pageable);
 
 }

--- a/chat-service/src/main/java/com/ojosama/chatservice/infrastructure/persistence/MessageJpaRepository.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/infrastructure/persistence/MessageJpaRepository.java
@@ -1,11 +1,16 @@
 package com.ojosama.chatservice.infrastructure.persistence;
 
 import com.ojosama.chatservice.domain.model.Message;
+import com.ojosama.chatservice.domain.model.MessageStatus;
 import java.util.UUID;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MessageJpaRepository extends JpaRepository<Message, UUID> {
-    Slice<Message> findByChatRoomIdOrderByCreatedAtDescIdDesc(UUID chatRoomId, Pageable pageable);
+    Slice<Message> findByChatRoomIdAndStatusOrderByCreatedAtDescIdDesc(
+            UUID chatRoomId,
+            MessageStatus status,
+            Pageable pageable
+    );
 }

--- a/chat-service/src/main/java/com/ojosama/chatservice/infrastructure/persistence/MessageRepositoryImpl.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/infrastructure/persistence/MessageRepositoryImpl.java
@@ -1,6 +1,7 @@
 package com.ojosama.chatservice.infrastructure.persistence;
 
 import com.ojosama.chatservice.domain.model.Message;
+import com.ojosama.chatservice.domain.model.MessageStatus;
 import com.ojosama.chatservice.domain.repository.MessageRepository;
 import java.util.Optional;
 import java.util.UUID;
@@ -26,7 +27,7 @@ public class MessageRepositoryImpl implements MessageRepository {
     }
 
     @Override
-    public Slice<Message> findByChatRoomId(UUID chatRoomId, Pageable pageable) {
-        return messageJpaRepository.findByChatRoomIdOrderByCreatedAtDescIdDesc(chatRoomId, pageable);
+    public Slice<Message> findByChatRoomIdAndStatus(UUID chatRoomId, MessageStatus status, Pageable pageable) {
+        return messageJpaRepository.findByChatRoomIdAndStatusOrderByCreatedAtDescIdDesc(chatRoomId, status, pageable);
     }
 }

--- a/chat-service/src/main/java/com/ojosama/chatservice/presentation/controller/InternalMessageController.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/presentation/controller/InternalMessageController.java
@@ -1,0 +1,29 @@
+package com.ojosama.chatservice.presentation.controller;
+
+import com.ojosama.chatservice.application.dto.result.ReportedMessageResult;
+import com.ojosama.chatservice.application.service.MessageService;
+import com.ojosama.chatservice.presentation.dto.response.ReportedMessageResponse;
+import com.ojosama.common.response.ApiResponse;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/internal/v1/chat/messages")
+public class InternalMessageController {
+
+    private final MessageService messageService;
+
+    @GetMapping("/{messageId}")
+    public ResponseEntity<ApiResponse<ReportedMessageResponse>> getReportedMessage(
+            @PathVariable UUID messageId
+    ) {
+        ReportedMessageResult result = messageService.getReportedMessage(messageId);
+        return ResponseEntity.ok(ApiResponse.success(ReportedMessageResponse.from(result)));
+    }
+}

--- a/chat-service/src/main/java/com/ojosama/chatservice/presentation/controller/MessageController.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/presentation/controller/MessageController.java
@@ -1,0 +1,75 @@
+package com.ojosama.chatservice.presentation.controller;
+
+import com.ojosama.chatservice.application.dto.command.CreateMessageCommand;
+import com.ojosama.chatservice.application.dto.command.DeleteMessageCommand;
+import com.ojosama.chatservice.application.dto.query.FindMessageQuery;
+import com.ojosama.chatservice.application.dto.query.FindMessagesByChatRoomQuery;
+import com.ojosama.chatservice.application.dto.result.MessageResult;
+import com.ojosama.chatservice.application.dto.result.MessageSliceResult;
+import com.ojosama.chatservice.application.service.MessageService;
+import com.ojosama.chatservice.presentation.dto.request.CreateMessageRequest;
+import com.ojosama.chatservice.presentation.dto.response.MessageResponse;
+import com.ojosama.chatservice.presentation.dto.response.MessageSliceResponse;
+import com.ojosama.common.response.ApiResponse;
+import jakarta.validation.Valid;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/chat")
+public class MessageController {
+
+    private final MessageService messageService;
+
+    @PostMapping("/rooms/{chatRoomId}/messages")
+    public ResponseEntity<ApiResponse<MessageResponse>> createMessage(
+            @PathVariable UUID chatRoomId,
+            @RequestHeader("X-User-Id") UUID userId,
+            @Valid @RequestBody CreateMessageRequest request
+    ) {
+        MessageResult result = messageService.createMessage(
+                new CreateMessageCommand(chatRoomId, userId, request.content())
+        );
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.created(MessageResponse.from(result)));
+    }
+
+    @GetMapping("/messages/{messageId}")
+    public ResponseEntity<ApiResponse<MessageResponse>> getMessage(@PathVariable UUID messageId) {
+        MessageResult result = messageService.getMessage(new FindMessageQuery(messageId));
+        return ResponseEntity.ok(ApiResponse.success(MessageResponse.from(result)));
+    }
+
+    @GetMapping("/rooms/{chatRoomId}/messages")
+    public ResponseEntity<ApiResponse<MessageSliceResponse>> getMessagesByChatRoom(
+            @PathVariable UUID chatRoomId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        MessageSliceResult result = messageService.getMessagesByChatRoom(
+                new FindMessagesByChatRoomQuery(chatRoomId, page, size)
+        );
+        return ResponseEntity.ok(ApiResponse.success(MessageSliceResponse.from(result)));
+    }
+
+    @DeleteMapping("/messages/{messageId}")
+    public ResponseEntity<ApiResponse<Void>> deleteMessage(
+            @PathVariable UUID messageId,
+            @RequestHeader("X-User-Id") UUID userId
+    ) {
+        messageService.deleteMessage(new DeleteMessageCommand(messageId, userId));
+        return ResponseEntity.ok(ApiResponse.deleted());
+    }
+}

--- a/chat-service/src/main/java/com/ojosama/chatservice/presentation/controller/MessageController.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/presentation/controller/MessageController.java
@@ -37,10 +37,11 @@ public class MessageController {
     public ResponseEntity<ApiResponse<MessageResponse>> createMessage(
             @PathVariable UUID chatRoomId,
             @RequestHeader("X-User-Id") UUID userId,
+            @RequestHeader("X-User-Nickname") String writerNickname,
             @Valid @RequestBody CreateMessageRequest request
     ) {
         MessageResult result = messageService.createMessage(
-                new CreateMessageCommand(chatRoomId, userId, request.content())
+                new CreateMessageCommand(chatRoomId, userId, writerNickname, request.content())
         );
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(ApiResponse.created(MessageResponse.from(result)));

--- a/chat-service/src/main/java/com/ojosama/chatservice/presentation/dto/request/CreateMessageRequest.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/presentation/dto/request/CreateMessageRequest.java
@@ -1,0 +1,9 @@
+package com.ojosama.chatservice.presentation.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record CreateMessageRequest(
+        @NotBlank(message = "메시지 내용은 필수입니다.")
+        String content
+) {
+}

--- a/chat-service/src/main/java/com/ojosama/chatservice/presentation/dto/request/CreateMessageRequest.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/presentation/dto/request/CreateMessageRequest.java
@@ -1,9 +1,11 @@
 package com.ojosama.chatservice.presentation.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 
 public record CreateMessageRequest(
         @NotBlank(message = "메시지 내용은 필수입니다.")
+        @Size(max = 1000, message = "메시지 내용이 최대 길이를 초과했습니다.")
         String content
 ) {
 }

--- a/chat-service/src/main/java/com/ojosama/chatservice/presentation/dto/response/MessageResponse.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/presentation/dto/response/MessageResponse.java
@@ -9,6 +9,7 @@ public record MessageResponse(
         UUID messageId,
         UUID chatRoomId,
         UUID userId,
+        String writerNickname,
         String content,
         MessageStatus status,
         LocalDateTime createdAt
@@ -18,6 +19,7 @@ public record MessageResponse(
                 result.messageId(),
                 result.chatRoomId(),
                 result.userId(),
+                result.writerNickname(),
                 result.content(),
                 result.status(),
                 result.createdAt()

--- a/chat-service/src/main/java/com/ojosama/chatservice/presentation/dto/response/MessageResponse.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/presentation/dto/response/MessageResponse.java
@@ -1,0 +1,26 @@
+package com.ojosama.chatservice.presentation.dto.response;
+
+import com.ojosama.chatservice.application.dto.result.MessageResult;
+import com.ojosama.chatservice.domain.model.MessageStatus;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record MessageResponse(
+        UUID messageId,
+        UUID chatRoomId,
+        UUID userId,
+        String content,
+        MessageStatus status,
+        LocalDateTime createdAt
+) {
+    public static MessageResponse from(MessageResult result) {
+        return new MessageResponse(
+                result.messageId(),
+                result.chatRoomId(),
+                result.userId(),
+                result.content(),
+                result.status(),
+                result.createdAt()
+        );
+    }
+}

--- a/chat-service/src/main/java/com/ojosama/chatservice/presentation/dto/response/MessageSliceResponse.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/presentation/dto/response/MessageSliceResponse.java
@@ -1,0 +1,18 @@
+package com.ojosama.chatservice.presentation.dto.response;
+
+import com.ojosama.chatservice.application.dto.result.MessageSliceResult;
+import java.util.List;
+
+public record MessageSliceResponse(
+        List<MessageResponse> messages,
+        boolean hasNext
+) {
+    public static MessageSliceResponse from(MessageSliceResult result) {
+        return new MessageSliceResponse(
+                result.messages().stream()
+                        .map(MessageResponse::from)
+                        .toList(),
+                result.hasNext()
+        );
+    }
+}

--- a/chat-service/src/main/java/com/ojosama/chatservice/presentation/dto/response/ReportedMessageResponse.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/presentation/dto/response/ReportedMessageResponse.java
@@ -1,7 +1,6 @@
 package com.ojosama.chatservice.presentation.dto.response;
 
 import com.ojosama.chatservice.application.dto.result.ReportedMessageResult;
-import com.ojosama.chatservice.domain.model.EventCategory;
 import com.ojosama.chatservice.domain.model.MessageStatus;
 import java.time.LocalDateTime;
 import java.util.UUID;
@@ -9,7 +8,7 @@ import java.util.UUID;
 public record ReportedMessageResponse(
         UUID messageId,
         UUID chatRoomId,
-        EventCategory categoryName,
+        String category,
         UUID userId,
         String content,
         MessageStatus status,
@@ -19,7 +18,7 @@ public record ReportedMessageResponse(
         return new ReportedMessageResponse(
                 result.messageId(),
                 result.chatRoomId(),
-                result.categoryName(),
+                result.category(),
                 result.userId(),
                 result.content(),
                 result.status(),

--- a/chat-service/src/main/java/com/ojosama/chatservice/presentation/dto/response/ReportedMessageResponse.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/presentation/dto/response/ReportedMessageResponse.java
@@ -1,0 +1,29 @@
+package com.ojosama.chatservice.presentation.dto.response;
+
+import com.ojosama.chatservice.application.dto.result.ReportedMessageResult;
+import com.ojosama.chatservice.domain.model.EventCategory;
+import com.ojosama.chatservice.domain.model.MessageStatus;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record ReportedMessageResponse(
+        UUID messageId,
+        UUID chatRoomId,
+        EventCategory categoryName,
+        UUID userId,
+        String content,
+        MessageStatus status,
+        LocalDateTime createdAt
+) {
+    public static ReportedMessageResponse from(ReportedMessageResult result) {
+        return new ReportedMessageResponse(
+                result.messageId(),
+                result.chatRoomId(),
+                result.categoryName(),
+                result.userId(),
+                result.content(),
+                result.status(),
+                result.createdAt()
+        );
+    }
+}


### PR DESCRIPTION
## 🔗 Issue Number
- close #74 

## 📝 작업 내역
**chat-service에 메시지 CRUD 기본 기능을 추가**
- 메시지 생성 기능 추가
- 메시지 단건 조회 기능 추가
- 채팅방별 메시지 목록 조회 기능 추가
- 메시지 삭제 기능 추가
- 신고 서비스 연동용 내부 메시지 조회 API 추가
- 메시지 생성 시 작성자 닉네임 저장

**메시지 생성 시에는 아래 조건을 검증하도록 구현**
- 오픈된 채팅방에서만 메시지 생성 가능
- 메시지 내용 필수 및 최대 길이 검증
- 작성자 닉네임 필수 및 최대 길이 검증
- 메시지 삭제는 현재 본인 메시지만 가능하도록 처리

## 💡 PR 특이사항
-  현재 메시지 생성 시 작성자 정보는 `X-User-Id`, `X-User-Nickname` 헤더로 받음
-> **추후 인증에서 Token에 넣어주면 바꿀예정** (금요일에 전체적으로 인증/인가쪽 리팩토링예정) 
- 메시지 엔티티에는 닉네임을 별도 저장하도록 함
닉네임 변경 시 과거 메시지까지 동기화하지 않고, 작성 당시 표시명을 보존하는 방향

## 리뷰 포인트
- 메시지 생성 시 닉네임을 엔티티에 저장하는 방향으로 설정하고 아까 잠깐 고민 얘기했을때는 유저가 닉네임 변경시 -> (업데이트 이벤트) 발행 -> 수신해서 메시지 정보변경 을 할까싶었는데, 생각해보니까  닉네임 변경할때마다 이벤트 발행하는게 수고스러운것 같기도하고 그냥 어떤 사람이 결정을 못해서 닉네임 이것저것 바꾸는 행위를 할때마다 이벤트날려서 메시지 정보를 바꾸는게 맞을지에 대해서는 살짝 의문이...
- 그래서 생각한게 보통 게임이나 어디서든 닉네임을 바꾸어도? userId=그대로 nickname= old > 닉네임을 new로 바꾸었다쳐도 에전 채팅이나 예전 게시글,댓글을보면 예전닉네임 old로뜨지만 상세정보를 누르면 new로 나오는것처럼(이게아마 스냅샷으로 존재하고 굳이 바꾸게하지않는것같아서) 그래서 그냥 냅두는게어떨까 생각중입니다 !!!!그냥 정책적 측면 고민중.. 그런데 그냥 이상태로 진행할것같습니다!!(닉네임 스냅샷)

## 추후 작업
이번 PR은 메시지 CRUD까지만 했고, 실시간 채팅 전송은 아직 구현하지 않았습니다!
다음 단계에서 진행할 예정 (목요일) -> 인증인가 처리(금요일)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 메시지 작성 기능 추가 (작성자 닉네임 포함)
  * 메시지 조회 기능 추가
  * 채팅방별 메시지 목록 조회 및 페이지 처리 지원
  * 자신이 작성한 메시지 삭제 기능 추가
  * 부적절한 메시지 신고 기능 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->