### PR TITLE
[FEATURE] chat-service WebSocket 채팅, WS 에러 응답

### DIFF
--- a/chat-service/build.gradle
+++ b/chat-service/build.gradle
@@ -15,6 +15,9 @@ dependencies {
 
     implementation 'org.springframework.kafka:spring-kafka'
 
+    // 웹소켓
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
+
     // zipkin 테스트용 추가
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     runtimeOnly 'org.postgresql:postgresql'

--- a/chat-service/src/main/java/com/ojosama/chatservice/config/SecurityConfig.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/config/SecurityConfig.java
@@ -1,0 +1,35 @@
+package com.ojosama.chatservice.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        return http
+                .csrf(AbstractHttpConfigurer::disable)
+                .sessionManagement(session ->
+                        session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                )
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/", "/index.html", "/ws-test.html").permitAll()
+                        .requestMatchers("/favicon.ico", "/error").permitAll()
+                        .requestMatchers("/css/**", "/js/**", "/images/**", "/webjars/**").permitAll()
+                        .requestMatchers("/ws", "/ws/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/actuator/health").permitAll()
+                        .requestMatchers("/v1/chat/**").permitAll()
+                        .requestMatchers("/internal/v1/chat/**").permitAll()
+                        .anyRequest().authenticated()
+                )
+                .build();
+    }
+}

--- a/chat-service/src/main/java/com/ojosama/chatservice/config/WebSocketConfig.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/config/WebSocketConfig.java
@@ -1,5 +1,6 @@
 package com.ojosama.chatservice.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
@@ -10,13 +11,21 @@ import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerCo
 @EnableWebSocketMessageBroker
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
+    private final String[] allowedOriginPatterns;
+
+    public WebSocketConfig(
+            @Value("${app.websocket.allowed-origin-patterns:http://localhost:*,http://127.0.0.1:*}") String[] allowedOriginPatterns
+    ) {
+        this.allowedOriginPatterns = allowedOriginPatterns;
+    }
+
     /* 클라이언트가 웹 소켓 서버에 연결하는데 사용할 웹 소켓 엔드포인트 등록
      * /ws: 클라이언트가 최초 연결하는 주소
      * */
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         registry.addEndpoint("/ws")
-                .setAllowedOriginPatterns("*")
+                .setAllowedOriginPatterns(allowedOriginPatterns)
                 .withSockJS();
     }
 

--- a/chat-service/src/main/java/com/ojosama/chatservice/config/WebSocketConfig.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/config/WebSocketConfig.java
@@ -23,10 +23,13 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     /* 한 클라이언트에서 다른 클라이언트로 메시지를 라우팅하는데 사용될 메시지 브로커
      * /app: 클라이언트가 서버로 보내는 prefix
      * /topic: 서버가 구독자들에게 뿌리는 prefix
+     * /queue: 서버 -> 1명(개인)에게 보내는 주소에 주로 사용
+     * /user: “개인 주소”라는 뜻의 prefix
      * */
     @Override
     public void configureMessageBroker(MessageBrokerRegistry config) {
-        config.enableSimpleBroker("/topic");
+        config.enableSimpleBroker("/topic", "/queue");
         config.setApplicationDestinationPrefixes("/app");
+        config.setUserDestinationPrefix("/user");
     }
 }

--- a/chat-service/src/main/java/com/ojosama/chatservice/config/WebSocketConfig.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/config/WebSocketConfig.java
@@ -1,0 +1,32 @@
+package com.ojosama.chatservice.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    /* 클라이언트가 웹 소켓 서버에 연결하는데 사용할 웹 소켓 엔드포인트 등록
+     * /ws: 클라이언트가 최초 연결하는 주소
+     * */
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/ws")
+                .setAllowedOriginPatterns("*")
+                .withSockJS();
+    }
+
+    /* 한 클라이언트에서 다른 클라이언트로 메시지를 라우팅하는데 사용될 메시지 브로커
+     * /app: 클라이언트가 서버로 보내는 prefix
+     * /topic: 서버가 구독자들에게 뿌리는 prefix
+     * */
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry config) {
+        config.enableSimpleBroker("/topic");
+        config.setApplicationDestinationPrefixes("/app");
+    }
+}

--- a/chat-service/src/main/java/com/ojosama/chatservice/presentation/controller/MessageWsController.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/presentation/controller/MessageWsController.java
@@ -3,14 +3,22 @@ package com.ojosama.chatservice.presentation.controller;
 import com.ojosama.chatservice.application.dto.command.CreateMessageCommand;
 import com.ojosama.chatservice.application.dto.result.MessageResult;
 import com.ojosama.chatservice.application.service.MessageService;
+import com.ojosama.chatservice.domain.exception.ChatException;
 import com.ojosama.chatservice.presentation.dto.request.SendMessageWsRequest;
 import com.ojosama.chatservice.presentation.dto.response.MessageWsResponse;
+import com.ojosama.chatservice.presentation.dto.response.WebSocketErrorResponse;
+import com.ojosama.common.exception.CommonErrorCode;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.handler.annotation.MessageExceptionHandler;
 import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.support.MethodArgumentNotValidException;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.messaging.simp.annotation.SendToUser;
 import org.springframework.stereotype.Controller;
 
+@Slf4j
 @Controller
 @RequiredArgsConstructor
 public class MessageWsController {
@@ -35,6 +43,32 @@ public class MessageWsController {
         messagingTemplate.convertAndSend(
                 ROOM_TOPIC_PREFIX + request.chatRoomId() + ROOM_TOPIC_SUFFIX,
                 MessageWsResponse.from(result)
+        );
+    }
+
+    @MessageExceptionHandler(ChatException.class)
+    @SendToUser("/queue/errors")
+    public WebSocketErrorResponse handleChatException(ChatException e) {
+        log.warn("웹소켓 비즈니스 예외: status={}, message={}", e.getStatus().value(), e.getMessage());
+        return WebSocketErrorResponse.of(e.getStatus().value(), e.getMessage());
+    }
+
+    @MessageExceptionHandler(MethodArgumentNotValidException.class)
+    @SendToUser("/queue/errors")
+    public WebSocketErrorResponse handleValidationException(MethodArgumentNotValidException e) {
+        return WebSocketErrorResponse.of(
+                CommonErrorCode.VALIDATION_ERROR.getStatus().value(),
+                CommonErrorCode.VALIDATION_ERROR.getMessage()
+        );
+    }
+
+    @MessageExceptionHandler(Exception.class)
+    @SendToUser("/queue/errors")
+    public WebSocketErrorResponse handleUnexpectedException(Exception e) {
+        log.error("웹소켓 메시지 처리 중 예외가 발생했습니다.", e);
+        return WebSocketErrorResponse.of(
+                CommonErrorCode.UNEXPECTED_ERROR.getStatus().value(),
+                CommonErrorCode.UNEXPECTED_ERROR.getMessage()
         );
     }
 }

--- a/chat-service/src/main/java/com/ojosama/chatservice/presentation/controller/MessageWsController.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/presentation/controller/MessageWsController.java
@@ -1,0 +1,40 @@
+package com.ojosama.chatservice.presentation.controller;
+
+import com.ojosama.chatservice.application.dto.command.CreateMessageCommand;
+import com.ojosama.chatservice.application.dto.result.MessageResult;
+import com.ojosama.chatservice.application.service.MessageService;
+import com.ojosama.chatservice.presentation.dto.request.SendMessageWsRequest;
+import com.ojosama.chatservice.presentation.dto.response.MessageWsResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Controller;
+
+@Controller
+@RequiredArgsConstructor
+public class MessageWsController {
+
+    private static final String ROOM_TOPIC_PREFIX = "/topic/rooms/";
+    private static final String ROOM_TOPIC_SUFFIX = "/messages";
+
+    private final MessageService messageService;
+    private final SimpMessagingTemplate messagingTemplate;
+
+    @MessageMapping("/chat.send")
+    public void sendMessage(@Valid SendMessageWsRequest request) {
+        MessageResult result = messageService.createMessage(
+                new CreateMessageCommand(
+                        request.chatRoomId(),
+                        request.userId(),
+                        request.writerNickname(),
+                        request.content()
+                )
+        );
+
+        messagingTemplate.convertAndSend(
+                ROOM_TOPIC_PREFIX + request.chatRoomId() + ROOM_TOPIC_SUFFIX,
+                MessageWsResponse.from(result)
+        );
+    }
+}

--- a/chat-service/src/main/java/com/ojosama/chatservice/presentation/dto/request/SendMessageWsRequest.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/presentation/dto/request/SendMessageWsRequest.java
@@ -1,0 +1,13 @@
+package com.ojosama.chatservice.presentation.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.util.UUID;
+
+public record SendMessageWsRequest(
+        @NotNull UUID chatRoomId,
+        @NotNull UUID userId,
+        @NotBlank String writerNickname,
+        @NotBlank String content
+) {
+}

--- a/chat-service/src/main/java/com/ojosama/chatservice/presentation/dto/response/MessageWsResponse.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/presentation/dto/response/MessageWsResponse.java
@@ -1,0 +1,28 @@
+package com.ojosama.chatservice.presentation.dto.response;
+
+import com.ojosama.chatservice.application.dto.result.MessageResult;
+import com.ojosama.chatservice.domain.model.MessageStatus;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record MessageWsResponse(
+        UUID messageId,
+        UUID chatRoomId,
+        UUID userId,
+        String writerNickname,
+        String content,
+        MessageStatus status,
+        LocalDateTime createdAt
+) {
+    public static MessageWsResponse from(MessageResult result) {
+        return new MessageWsResponse(
+                result.messageId(),
+                result.chatRoomId(),
+                result.userId(),
+                result.writerNickname(),
+                result.content(),
+                result.status(),
+                result.createdAt()
+        );
+    }
+}

--- a/chat-service/src/main/java/com/ojosama/chatservice/presentation/dto/response/WebSocketErrorResponse.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/presentation/dto/response/WebSocketErrorResponse.java
@@ -1,0 +1,13 @@
+package com.ojosama.chatservice.presentation.dto.response;
+
+import java.time.LocalDateTime;
+
+public record WebSocketErrorResponse(
+        int status,
+        String message,
+        LocalDateTime timestamp
+) {
+    public static WebSocketErrorResponse of(int status, String message) {
+        return new WebSocketErrorResponse(status, message, LocalDateTime.now());
+    }
+}

--- a/chat-service/src/main/resources/static/ws-test.html
+++ b/chat-service/src/main/resources/static/ws-test.html
@@ -52,6 +52,11 @@
                 log("[RECV] " + message.body);
             });
             log("[SUBSCRIBE] " + topic);
+
+            stompClient.subscribe("/user/queue/errors", (message) => {
+                log("[WS-ERROR] " + message.body);
+            });
+            log("[SUBSCRIBE] /user/queue/errors");
         }, (err) => {
             log("[ERROR] " + err);
         });

--- a/chat-service/src/main/resources/static/ws-test.html
+++ b/chat-service/src/main/resources/static/ws-test.html
@@ -1,0 +1,77 @@
+<!doctype html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8"/>
+    <title>Chat WS Test</title>
+    <script src="https://cdn.jsdelivr.net/npm/sockjs-client@1/dist/sockjs.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/stompjs@2.3.3/lib/stomp.min.js"></script>
+</head>
+<body>
+<h3>WebSocket Chat Test</h3>
+
+<div>
+    <label>Room ID</label>
+    <input id="roomId" size="40" value="f0111249-116f-4527-afde-b543b2ec8e3a"/>
+</div>
+<div>
+    <label>User ID</label>
+    <input id="userId" size="40" value="11111111-2222-3333-4444-555555555555"/>
+</div>
+<div>
+    <label>Nickname</label>
+    <input id="nickname" value="isubin"/>
+</div>
+<div>
+    <button onclick="connect()">Connect</button>
+    <button onclick="sendMsg()">Send</button>
+</div>
+<div>
+    <input id="content" size="60" placeholder="메시지 입력"/>
+</div>
+
+<pre id="log" style="background:#f5f5f5; padding:12px; height:260px; overflow:auto;"></pre>
+
+<script>
+    let stompClient = null;
+
+    function log(msg) {
+        const el = document.getElementById("log");
+        el.textContent += msg + "\n";
+        el.scrollTop = el.scrollHeight;
+    }
+
+    function connect() {
+        const roomId = document.getElementById("roomId").value;
+        const socket = new SockJS("/ws");
+        stompClient = Stomp.over(socket);
+
+        stompClient.connect({}, () => {
+            log("[CONNECTED]");
+            const topic = `/topic/rooms/${roomId}/messages`;
+            stompClient.subscribe(topic, (message) => {
+                log("[RECV] " + message.body);
+            });
+            log("[SUBSCRIBE] " + topic);
+        }, (err) => {
+            log("[ERROR] " + err);
+        });
+    }
+
+    function sendMsg() {
+        if (!stompClient || !stompClient.connected) {
+            log("먼저 Connect 하세요.");
+            return;
+        }
+        const payload = {
+            chatRoomId: document.getElementById("roomId").value,
+            userId: document.getElementById("userId").value,
+            writerNickname: document.getElementById("nickname").value,
+            content: document.getElementById("content").value
+        };
+        stompClient.send("/app/chat.send", {}, JSON.stringify(payload));
+        log("[SEND] " + JSON.stringify(payload));
+        document.getElementById("content").value = "";
+    }
+</script>
+</body>
+</html>


### PR DESCRIPTION
## 🔗 Issue Number
- close #94 

## 📝 작업 내역
1. WebSocket 채팅 기능 추가
- 클라이언트가 /app/chat.send로 메시지 전송
- 서버가 /topic/rooms/{chatRoomId}/messages로 실시간 브로드캐스트
- 방 상태가 OPEN일 때만 메시지 저장/전송

2. WebSocket 에러 응답
- ChatException, 검증 실패, 예외 상황을 WS 전용 응답으로 통일
- status, message, timestamp
- 클라이언트는 /user/queue/errors 구독으로 에러 수신

3. 브로커/라우팅 설정 보완
- enableSimpleBroker("/topic", "/queue")
- setUserDestinationPrefix("/user")
- 개인 에러 라우팅(/user/queue/errors) 동작 보장

4. 로컬 테스트 페이지 추가
- ws-test.html에서 connect/subscribe/send 및 에러 수신 확인
- OPEN 방 전송 성공, 비OPEN 방 전송 시 WS-ERROR 확인 완료

<img width="1043" height="366" alt="스크린샷 2026-05-01 오전 1 26 19" src="https://github.com/user-attachments/assets/b3d1d950-a122-4f59-bc94-160bee0fd45f" />
[SEND]만 보내지면 안되는것 -> 위의예시는 닫힌 채팅방이어서 에러
[RECV]가 해당 토픽 구독한사람한테 뜨는것
그래서 send 보내면 바로 recv가 같이 뜸


## 💡 PR 특이사항

초기 동작만 구현


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * STOMP-over-WebSocket 기반의 실시간 채팅 송수신 기능이 추가되었습니다.
  * 사용자 대상 에러 피드백 및 메시지 브로드캐스트 기능이 포함된 실시간 메시지 흐름이 도입되었습니다.
  * 인증이 필요한 경로와 공개 경로를 구분한 무상태 보안 설정이 적용되었습니다.

* **문서**
  * WebSocket 연결/전송을 확인할 수 있는 클라이언트 테스트 페이지가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->