### PR TITLE
[FEATURE] 찜 서비스 페이징 처리 추가, 행사 변경 이벤트 구독

### DIFF
--- a/favorite-service/build.gradle
+++ b/favorite-service/build.gradle
@@ -16,10 +16,29 @@ dependencies {
 
     runtimeOnly 'org.postgresql:postgresql'
 
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
     testRuntimeOnly 'com.h2database:h2'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.kafka:spring-kafka-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+}
+
+def querydslDir = "src/main/generated"
+
+sourceSets {
+    main.java.srcDirs += [querydslDir]
+}
+
+tasks.withType(JavaCompile).configureEach {
+    options.getGeneratedSourceOutputDirectory().set(file(querydslDir))
+}
+
+clean {
+    delete file(querydslDir)
 }
 
 dependencyManagement {

--- a/favorite-service/src/main/java/com/ojosama/favoriteservice/application/service/FavoriteService.java
+++ b/favorite-service/src/main/java/com/ojosama/favoriteservice/application/service/FavoriteService.java
@@ -76,6 +76,10 @@ public class FavoriteService {
 
     // 이벤트를 통한 행사 변경
     public void updateAllByEventId(UUID eventId, EventUpdatedMessage message) {
+        if (message == null || message.changedFields() == null || message.changedFields().isEmpty()) {
+            throw new FavoriteException(FavoriteErrorCode.INVALID_MESSAGE_PAYLOAD);
+        }
+
         for (var field : message.changedFields()) {
             String fieldName = field.fieldName();
             String after = field.after();

--- a/favorite-service/src/main/java/com/ojosama/favoriteservice/application/service/FavoriteService.java
+++ b/favorite-service/src/main/java/com/ojosama/favoriteservice/application/service/FavoriteService.java
@@ -9,17 +9,24 @@ import com.ojosama.favoriteservice.domain.model.Favorite;
 import com.ojosama.favoriteservice.domain.repository.FavoriteRepository;
 import com.ojosama.favoriteservice.infrastructure.client.EventClient;
 import com.ojosama.favoriteservice.infrastructure.client.dto.EventInfoResponseDto;
+import com.ojosama.favoriteservice.infrastructure.messaging.kafka.dto.EventUpdatedMessage;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 @Transactional
+@Slf4j
 public class FavoriteService {
+
+    private static final UUID system = UUID.fromString("00000000-0000-0000-0000-000000000000");
 
     private final FavoriteRepository favoriteRepository;
     private final EventClient eventClient;
@@ -55,16 +62,24 @@ public class FavoriteService {
         favorite.deleted(userId);
     }
 
-    public List<FavoriteResult> getFavorites(UUID userId) {
-        List<Favorite> favorites = favoriteRepository.findByUserIdAndDeletedAtIsNull(userId);
+    public Page<FavoriteResult> getFavorites(UUID userId, Pageable pageable) {
+        Page<Favorite> favorites = favoriteRepository.findByUserIdAndDeletedAtIsNull(userId, pageable);
 
-        return favorites.stream()
-                .map(FavoriteResult::from)
-                .toList();
+        return favorites.map(FavoriteResult::from);
     }
 
+    // 이벤트를 통한 행사 삭제
     public void deleteAllByEventId(UUID eventId) {
         List<Favorite> favorites = favoriteRepository.findByEventInfo_EventIdAndDeletedAtIsNull(eventId);
-        favorites.forEach(favorite -> favorite.deleted(null));
+        favorites.forEach(favorite -> favorite.deleted(system));
+    }
+
+    // 이벤트를 통한 행사 변경
+    public void updateAllByEventId(UUID eventId, EventUpdatedMessage message) {
+        for (var field : message.changedFields()) {
+            String fieldName = field.fieldName();
+            String after = field.after();
+            favoriteRepository.updateEventInfoBulk(eventId, fieldName, after);
+        }
     }
 }

--- a/favorite-service/src/main/java/com/ojosama/favoriteservice/domain/repository/FavoriteRepository.java
+++ b/favorite-service/src/main/java/com/ojosama/favoriteservice/domain/repository/FavoriteRepository.java
@@ -4,6 +4,8 @@ import com.ojosama.favoriteservice.domain.model.Favorite;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface FavoriteRepository {
 
@@ -13,7 +15,9 @@ public interface FavoriteRepository {
 
     Optional<Favorite> findByIdAndUserIdAndDeletedAtIsNull(UUID favoriteId, UUID userId);
 
-    List<Favorite> findByUserIdAndDeletedAtIsNull(UUID userId);
+    Page<Favorite> findByUserIdAndDeletedAtIsNull(UUID userId, Pageable pageable);
 
     List<Favorite> findByEventInfo_EventIdAndDeletedAtIsNull(UUID eventId);
+
+    void updateEventInfoBulk(UUID eventId, String field, String after);
 }

--- a/favorite-service/src/main/java/com/ojosama/favoriteservice/infrastructure/config/QueryDslConfig.java
+++ b/favorite-service/src/main/java/com/ojosama/favoriteservice/infrastructure/config/QueryDslConfig.java
@@ -1,0 +1,21 @@
+package com.ojosama.favoriteservice.infrastructure.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+
+    private final EntityManager entityManager;
+
+    public QueryDslConfig(EntityManager entityManager) {
+        this.entityManager = entityManager;
+    }
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/favorite-service/src/main/java/com/ojosama/favoriteservice/infrastructure/messaging/kafka/EventUpdatedConsumer.java
+++ b/favorite-service/src/main/java/com/ojosama/favoriteservice/infrastructure/messaging/kafka/EventUpdatedConsumer.java
@@ -1,0 +1,68 @@
+package com.ojosama.favoriteservice.infrastructure.messaging.kafka;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ojosama.common.kafka.domain.EventType;
+import com.ojosama.common.kafka.domain.IdempotentEventHandler;
+import com.ojosama.favoriteservice.application.service.FavoriteService;
+import com.ojosama.favoriteservice.domain.exception.FavoriteErrorCode;
+import com.ojosama.favoriteservice.domain.exception.FavoriteException;
+import com.ojosama.favoriteservice.infrastructure.messaging.kafka.dto.EventUpdatedMessage;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class EventUpdatedConsumer {
+
+    private static final String CONSUMER_GROUP = "favorite-service-group";
+    private static final String EVENT_TYPE = EventType.EVENT_SCHEDULE_CHANGED.getValue();
+
+    private final ObjectMapper objectMapper;
+    private final IdempotentEventHandler idempotentEventHandler;
+    private final FavoriteService favoriteService;
+
+    @KafkaListener(
+            topics = "${spring.kafka.topic.event-updated}",
+            groupId = CONSUMER_GROUP,
+            containerFactory = "kafkaListenerContainerFactory"
+    )
+    public void onMessage(ConsumerRecord<String, String> record) {
+        UUID messageKey;
+        EventUpdatedMessage event;
+
+        try {
+            messageKey = UUID.fromString(record.key());
+            event = parse(record.value());
+
+            if (!messageKey.equals(event.eventId())) {
+                log.error("key값과 messageId 불일치 : {}, {}", messageKey, event.eventId());
+                throw new FavoriteException(FavoriteErrorCode.INVALID_MESSAGE_PAYLOAD);
+            }
+            idempotentEventHandler.handle(
+                    messageKey,
+                    CONSUMER_GROUP,
+                    record.topic(),
+                    EVENT_TYPE,
+                    () -> favoriteService.updateAllByEventId(event.eventId(), event)
+            );
+            log.info("수정 이벤트 성공: {}", record.key());
+        } catch (RuntimeException e) {
+            log.error("수정 이벤트 실패 : {}, {}", record.key(), e.getMessage());
+            throw e;
+        }
+    }
+
+    private EventUpdatedMessage parse(String payload) {
+        try {
+            return objectMapper.readValue(payload, EventUpdatedMessage.class);
+        } catch (JsonProcessingException e) {
+            throw new FavoriteException(FavoriteErrorCode.INVALID_MESSAGE_PAYLOAD);
+        }
+    }
+}

--- a/favorite-service/src/main/java/com/ojosama/favoriteservice/infrastructure/messaging/kafka/dto/EventUpdatedMessage.java
+++ b/favorite-service/src/main/java/com/ojosama/favoriteservice/infrastructure/messaging/kafka/dto/EventUpdatedMessage.java
@@ -6,9 +6,9 @@ import java.util.UUID;
 public record EventUpdatedMessage(
         UUID eventId,
         String eventName,
-        List<ChangedField> changedFields
+        List<FieldChange> changedFields
 ) {
-    public record ChangedField(
+    public record FieldChange(
             String fieldName,
             String before,
             String after

--- a/favorite-service/src/main/java/com/ojosama/favoriteservice/infrastructure/messaging/kafka/dto/EventUpdatedMessage.java
+++ b/favorite-service/src/main/java/com/ojosama/favoriteservice/infrastructure/messaging/kafka/dto/EventUpdatedMessage.java
@@ -1,0 +1,17 @@
+package com.ojosama.favoriteservice.infrastructure.messaging.kafka.dto;
+
+import java.util.List;
+import java.util.UUID;
+
+public record EventUpdatedMessage(
+        UUID eventId,
+        String eventName,
+        List<ChangedField> changedFields
+) {
+    public record ChangedField(
+            String fieldName,
+            String before,
+            String after
+    ) {
+    }
+}

--- a/favorite-service/src/main/java/com/ojosama/favoriteservice/infrastructure/persistence/FavoriteRepositoryCustom.java
+++ b/favorite-service/src/main/java/com/ojosama/favoriteservice/infrastructure/persistence/FavoriteRepositoryCustom.java
@@ -1,0 +1,8 @@
+package com.ojosama.favoriteservice.infrastructure.persistence;
+
+import java.util.UUID;
+
+public interface FavoriteRepositoryCustom {
+
+    void updateEventInfoBulk(UUID eventId, String field, String after);
+}

--- a/favorite-service/src/main/java/com/ojosama/favoriteservice/infrastructure/persistence/FavoriteRepositoryCustomImpl.java
+++ b/favorite-service/src/main/java/com/ojosama/favoriteservice/infrastructure/persistence/FavoriteRepositoryCustomImpl.java
@@ -1,0 +1,42 @@
+package com.ojosama.favoriteservice.infrastructure.persistence;
+
+import com.ojosama.favoriteservice.domain.model.QFavorite;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class FavoriteRepositoryCustomImpl implements FavoriteRepositoryCustom {
+
+    private final JPAQueryFactory jpaQueryFactory;
+    private final EntityManager entityManager;
+    private final QFavorite qFavorite = QFavorite.favorite;
+
+    @Override
+    public void updateEventInfoBulk(UUID eventId, String field, String after) {
+
+        var update = jpaQueryFactory.update(qFavorite);
+
+        boolean isChanged = false;
+
+        if ("name".equals(field)) {
+            update.set(qFavorite.eventInfo.eventName, after);
+            isChanged = true;
+        } else if ("img".equals(field)) {
+            update.set(qFavorite.eventInfo.eventImg, after);
+            isChanged = true;
+        }
+
+        if (isChanged) {
+            update.set(qFavorite.updatedAt, LocalDateTime.now())
+                    .set(qFavorite.updatedBy, UUID.fromString("00000000-0000-0000-0000-000000000000"))
+                    .where(qFavorite.eventInfo.eventId.eq(eventId))
+                    .execute();
+        }
+
+        entityManager.flush();
+        entityManager.clear();
+    }
+}

--- a/favorite-service/src/main/java/com/ojosama/favoriteservice/infrastructure/persistence/FavoriteRepositoryImpl.java
+++ b/favorite-service/src/main/java/com/ojosama/favoriteservice/infrastructure/persistence/FavoriteRepositoryImpl.java
@@ -6,6 +6,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -13,6 +15,7 @@ import org.springframework.stereotype.Repository;
 public class FavoriteRepositoryImpl implements FavoriteRepository {
 
     private final JpaFavoriteRepository jpaFavoriteRepository;
+    private final FavoriteRepositoryCustom favoriteRepositoryCustom;
 
     @Override
     public Favorite save(Favorite favorite) {
@@ -30,8 +33,8 @@ public class FavoriteRepositoryImpl implements FavoriteRepository {
     }
 
     @Override
-    public List<Favorite> findByUserIdAndDeletedAtIsNull(UUID userId) {
-        return jpaFavoriteRepository.findByUserIdAndDeletedAtIsNull(userId);
+    public Page<Favorite> findByUserIdAndDeletedAtIsNull(UUID userId, Pageable pageable) {
+        return jpaFavoriteRepository.findByUserIdAndDeletedAtIsNull(userId, pageable);
     }
 
     @Override
@@ -39,4 +42,8 @@ public class FavoriteRepositoryImpl implements FavoriteRepository {
         return jpaFavoriteRepository.findByEventInfo_EventIdAndDeletedAtIsNull(eventId);
     }
 
+    @Override
+    public void updateEventInfoBulk(UUID eventId, String field, String after) {
+        favoriteRepositoryCustom.updateEventInfoBulk(eventId, field, after);
+    }
 }

--- a/favorite-service/src/main/java/com/ojosama/favoriteservice/infrastructure/persistence/JpaFavoriteRepository.java
+++ b/favorite-service/src/main/java/com/ojosama/favoriteservice/infrastructure/persistence/JpaFavoriteRepository.java
@@ -4,15 +4,17 @@ import com.ojosama.favoriteservice.domain.model.Favorite;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface JpaFavoriteRepository extends JpaRepository<Favorite, UUID> {
+public interface JpaFavoriteRepository extends JpaRepository<Favorite, UUID>, FavoriteRepositoryCustom {
 
     Optional<Favorite> findByIdAndUserIdAndDeletedAtIsNull(UUID favoriteId, UUID userId);
 
     Optional<Favorite> findByEventInfo_EventIdAndUserId(UUID eventId, UUID userId);
 
-    List<Favorite> findByUserIdAndDeletedAtIsNull(UUID userId);
+    Page<Favorite> findByUserIdAndDeletedAtIsNull(UUID userId, Pageable pageable);
 
     List<Favorite> findByEventInfo_EventIdAndDeletedAtIsNull(UUID eventId);
 }

--- a/favorite-service/src/main/java/com/ojosama/favoriteservice/presentation/controller/FavoriteController.java
+++ b/favorite-service/src/main/java/com/ojosama/favoriteservice/presentation/controller/FavoriteController.java
@@ -7,9 +7,12 @@ import com.ojosama.favoriteservice.presentation.dto.CreateFavoriteRequestDto;
 import com.ojosama.favoriteservice.presentation.dto.CreateFavoriteResponseDto;
 import com.ojosama.favoriteservice.presentation.dto.GetFavoritesResponseDto;
 import jakarta.validation.Valid;
-import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -17,6 +20,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -29,10 +33,8 @@ public class FavoriteController {
 
     @PostMapping
     public ResponseEntity<ApiResponse<CreateFavoriteResponseDto>> createFavorite(
-            @Valid @RequestBody CreateFavoriteRequestDto favoriteDto) {
-
-        // TODO : 수정예정
-        UUID userId = UUID.fromString("bd4e3ba4-55dd-45d4-b1ca-55f38f0c4804");
+            @Valid @RequestBody CreateFavoriteRequestDto favoriteDto,
+            @RequestHeader("X-User-Id") UUID userId) {
 
         FavoriteResult result = favoriteService.createFavorite(favoriteDto.toCommand(), userId);
         return ResponseEntity
@@ -43,22 +45,21 @@ public class FavoriteController {
     }
 
     @DeleteMapping("/{favoriteId}")
-    public ResponseEntity<ApiResponse<Void>> deleteFavorite(@PathVariable("favoriteId") UUID favoriteId) {
+    public ResponseEntity<ApiResponse<Void>> deleteFavorite(@PathVariable("favoriteId") UUID favoriteId,
+                                                            @RequestHeader("X-User-Id") UUID userId) {
 
-        // TODO : 수정예정
-        UUID userId = UUID.fromString("bd4e3ba4-55dd-45d4-b1ca-55f38f0c4804");
         favoriteService.deleteFavorite(favoriteId, userId);
         return ResponseEntity.ok(ApiResponse.deleted());
     }
 
     @GetMapping
-    public ResponseEntity<ApiResponse<List<GetFavoritesResponseDto>>> getFavorites() {
+    public ResponseEntity<ApiResponse<Page<GetFavoritesResponseDto>>> getFavorites(
+            @RequestHeader("X-User-Id") UUID userId,
+            @PageableDefault(size = 10,
+                    sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
 
-        // TODO : 수정예정
-        UUID userId = UUID.fromString("bd4e3ba4-55dd-45d4-b1ca-55f38f0c4804");
-        List<GetFavoritesResponseDto> dto = favoriteService.getFavorites(userId).stream()
-                .map(GetFavoritesResponseDto::from)
-                .toList();
+        Page<GetFavoritesResponseDto> dto = favoriteService.getFavorites(userId, pageable)
+                .map(GetFavoritesResponseDto::from);
 
         return ResponseEntity.ok(ApiResponse.success(dto));
     }


### PR DESCRIPTION
## 🔗 Issue Number
- close #117

## 📝 작업 내역

- QueryDsl을 이용하여 찜 테이블에 있는 행사 정보를 한꺼번에 변경
- 페이징처리 추가

## 💡 PR 특이사항

- 특이사항
- 특이사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 즐겨찾기 조회에 페이지네이션 지원 추가로 대용량 데이터 처리 개선
  * 이벤트 업데이트 메시지 수신 시 변경 필드를 일괄 반영하는 비동기 처리 추가
  * 요청 헤더 기반 사용자 식별 도입(생성/삭제/조회 엔드포인트)

* **Chores**
  * 빌드 설정 업데이트로 쿼리 생성 도구 및 생성된 소스 처리 자동화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->