### PR TITLE
[HOTFIX] 행사 요청 물리적 삭제 제거, 불필요한 save() 호출 제거

### DIFF
--- a/event-service/src/main/java/com/ojosama/eventservice/event/application/service/EventCommandService.java
+++ b/event-service/src/main/java/com/ojosama/eventservice/event/application/service/EventCommandService.java
@@ -110,7 +110,6 @@ public class EventCommandService {
                 .orElseThrow(() -> new EventException(EventErrorCode.EVENT_NOT_FOUND));
 
         event.deleted(userId);
-        eventRepository.delete(event);
 
         applicationEventPublisher.publishEvent(new EventDeletedMessage(event.getId(), event.getName()));
     }

--- a/event-service/src/main/java/com/ojosama/eventservice/eventrequest/application/service/EventRequestCommandService.java
+++ b/event-service/src/main/java/com/ojosama/eventservice/eventrequest/application/service/EventRequestCommandService.java
@@ -49,21 +49,19 @@ public class EventRequestCommandService {
         EventRequest request = eventRequestRepository.findById(requestId)
                 .orElseThrow(() -> new EventRequestException(EventRequestErrorCode.EVENT_REQUEST_NOT_FOUND));
         request.cancel(userId);
-        eventRequestRepository.save(request);
     }
 
     public void adminCancelEventRequest(UUID adminId, UUID requestId) {
         EventRequest request = eventRequestRepository.findById(requestId)
                 .orElseThrow(() -> new EventRequestException(EventRequestErrorCode.EVENT_REQUEST_NOT_FOUND));
         request.adminCancel(adminId);
-        eventRequestRepository.save(request);
     }
 
     public EventRequestResult approveEventRequest(UUID requestId) {
         EventRequest request = eventRequestRepository.findById(requestId)
                 .orElseThrow(() -> new EventRequestException(EventRequestErrorCode.EVENT_REQUEST_NOT_FOUND));
         request.approve();
-        EventRequestResult result = EventRequestResult.from(eventRequestRepository.save(request));
+        EventRequestResult result = EventRequestResult.from(request);
         applicationEventPublisher.publishEvent(
                 new EventRequestProcessedMessage(request.getId(), request.getRequesterId(), "approved", request.getEventName()));
         return result;
@@ -73,7 +71,7 @@ public class EventRequestCommandService {
         EventRequest request = eventRequestRepository.findById(requestId)
                 .orElseThrow(() -> new EventRequestException(EventRequestErrorCode.EVENT_REQUEST_NOT_FOUND));
         request.reject(rejectReason);
-        EventRequestResult result = EventRequestResult.from(eventRequestRepository.save(request));
+        EventRequestResult result = EventRequestResult.from(request);
         applicationEventPublisher.publishEvent(
                 new EventRequestProcessedMessage(request.getId(), request.getRequesterId(), "rejected", request.getEventName()));
         return result;


### PR DESCRIPTION
## 🔗 Issue Number
- close #123 

## 📝 작업 내역

- 행사 요청 물리적 삭제 제거(delete() 호출)
- EventRequestCommandService에서 불필요한 save() 호출 제거

## 💡 PR 특이사항



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정
* 이벤트 삭제 처리 메커니즘이 개선되었습니다.
* 이벤트 요청 승인 및 거부 프로세스의 신뢰성이 향상되었습니다.

## 리팩터
* 이벤트 요청 처리 로직이 최적화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->