### PR TITLE
fix: 행사 도메인 인가 제거

### DIFF
--- a/event-service/src/main/java/com/ojosama/eventservice/EventServiceApplication.java
+++ b/event-service/src/main/java/com/ojosama/eventservice/EventServiceApplication.java
@@ -2,14 +2,16 @@ package com.ojosama.eventservice;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-@SpringBootApplication
+//@SpringBootApplication
 @EnableFeignClients
 @ConfigurationPropertiesScan
 @EnableJpaAuditing
+@SpringBootApplication(exclude = {SecurityAutoConfiguration.class})
 public class EventServiceApplication {
 
     public static void main(String[] args) {

--- a/event-service/src/main/java/com/ojosama/eventservice/event/presentation/controller/EventCategoryController.java
+++ b/event-service/src/main/java/com/ojosama/eventservice/event/presentation/controller/EventCategoryController.java
@@ -94,8 +94,6 @@ public class EventCategoryController {
     }
 
     private void validateGatewayHeaders(UUID userId, String userRole) {
-        if (userId == null || userRole == null || userRole.isBlank()) {
-            throw new CustomException(CommonErrorCode.INVALID_TOKEN);
-        }
+//        if (userId == null || userRole == null || userRole.isBlank()) { throw new CustomException(CommonErrorCode.INVALID_TOKEN); }
     }
 }

--- a/event-service/src/main/java/com/ojosama/eventservice/event/presentation/controller/EventCategoryController.java
+++ b/event-service/src/main/java/com/ojosama/eventservice/event/presentation/controller/EventCategoryController.java
@@ -37,7 +37,7 @@ public class EventCategoryController {
     private final EventCategoryQueryService eventCategoryQueryService;
 
     @GetMapping
-    @PreAuthorize("hasRole('ADMIN')")
+//    @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<ApiResponse<List<EventCategoryResponse>>> getCategories(
             @RequestHeader(value = "X-User-Id", required = false) UUID userId,
             @RequestHeader(value = "X-User-Role", required = false) String userRole) {
@@ -51,7 +51,7 @@ public class EventCategoryController {
     }
 
     @PostMapping
-    @PreAuthorize("hasRole('ADMIN')")
+//    @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<ApiResponse<EventCategoryResponse>> createCategory(
             @RequestHeader(value = "X-User-Id", required = false) UUID userId,
             @RequestHeader(value = "X-User-Role", required = false) String userRole,
@@ -66,7 +66,7 @@ public class EventCategoryController {
     }
 
     @PatchMapping("/{categoryId}")
-    @PreAuthorize("hasRole('ADMIN')")
+//    @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<ApiResponse<EventCategoryResponse>> updateCategory(
             @RequestHeader(value = "X-User-Id", required = false) UUID userId,
             @RequestHeader(value = "X-User-Role", required = false) String userRole,
@@ -81,7 +81,7 @@ public class EventCategoryController {
     }
 
     @DeleteMapping("/{categoryId}")
-    @PreAuthorize("hasRole('ADMIN')")
+//    @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<Void> deleteCategory(
             @RequestHeader(value = "X-User-Id", required = false) UUID userId,
             @RequestHeader(value = "X-User-Role", required = false) String userRole,

--- a/event-service/src/main/java/com/ojosama/eventservice/event/presentation/controller/EventCommandController.java
+++ b/event-service/src/main/java/com/ojosama/eventservice/event/presentation/controller/EventCommandController.java
@@ -33,48 +33,39 @@ public class EventCommandController {
     private final EventCommandService eventCommandService;
 
     @PostMapping
-    @PreAuthorize("hasAnyRole('ADMIN', 'CONCERT_MANAGER', 'FESTIVAL_MANAGER', 'FANMEETING_MANAGER', 'POPUP_MANAGER')")
+//    @PreAuthorize("hasAnyRole('ADMIN', 'CONCERT_MANAGER', 'FESTIVAL_MANAGER', 'FANMEETING_MANAGER', 'POPUP_MANAGER')")
     public ResponseEntity<ApiResponse<EventResponse>> createEvent(
             @RequestHeader(value = "X-User-Id", required = false) UUID userId,
             @RequestHeader(value = "X-User-Role", required = false) String userRole,
             @Valid @RequestBody CreateEventRequest request) {
 
-        if (userId == null || userRole == null) {
-            throw new CustomException(CommonErrorCode.INVALID_TOKEN);
-        }
-
+//        if (userId == null || userRole == null) { throw new CustomException(CommonErrorCode.INVALID_TOKEN); }
         EventResult result = eventCommandService.createEvent(CreateEventCommand.from(userId, request));
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(ApiResponse.created(EventResponse.from(result)));
     }
 
     @PatchMapping("/{eventId}")
-    @PreAuthorize("hasAnyRole('ADMIN', 'CONCERT_MANAGER', 'FESTIVAL_MANAGER', 'FANMEETING_MANAGER', 'POPUP_MANAGER')")
+//    @PreAuthorize("hasAnyRole('ADMIN', 'CONCERT_MANAGER', 'FESTIVAL_MANAGER', 'FANMEETING_MANAGER', 'POPUP_MANAGER')")
     public ResponseEntity<ApiResponse<EventResponse>> updateEvent(
             @RequestHeader(value = "X-User-Id", required = false) UUID userId,
             @RequestHeader(value = "X-User-Role", required = false) String userRole,
             @PathVariable UUID eventId,
             @Valid @RequestBody UpdateEventRequest request) {
 
-        if (userId == null || userRole == null) {
-            throw new CustomException(CommonErrorCode.INVALID_TOKEN);
-        }
-
+//        if (userId == null || userRole == null) { throw new CustomException(CommonErrorCode.INVALID_TOKEN); }
         EventResult result = eventCommandService.updateEvent(UpdateEventCommand.from(eventId, userId, request));
         return ResponseEntity.ok(ApiResponse.success(EventResponse.from(result)));
     }
 
     @DeleteMapping("/{eventId}")
-    @PreAuthorize("hasAnyRole('ADMIN', 'CONCERT_MANAGER', 'FESTIVAL_MANAGER', 'FANMEETING_MANAGER', 'POPUP_MANAGER')")
+//    @PreAuthorize("hasAnyRole('ADMIN', 'CONCERT_MANAGER', 'FESTIVAL_MANAGER', 'FANMEETING_MANAGER', 'POPUP_MANAGER')")
     public ResponseEntity<Void> deleteEvent(
             @RequestHeader(value = "X-User-Id", required = false) UUID userId,
             @RequestHeader(value = "X-User-Role", required = false) String userRole,
             @PathVariable UUID eventId) {
 
-        if (userId == null || userRole == null) {
-            throw new CustomException(CommonErrorCode.INVALID_TOKEN);
-        }
-
+//        if (userId == null || userRole == null) { throw new CustomException(CommonErrorCode.INVALID_TOKEN); }
         eventCommandService.deleteEvent(userId, eventId);
         return ResponseEntity.noContent().build();
     }

--- a/event-service/src/main/java/com/ojosama/eventservice/event/presentation/controller/EventQueryController.java
+++ b/event-service/src/main/java/com/ojosama/eventservice/event/presentation/controller/EventQueryController.java
@@ -66,8 +66,6 @@ public class EventQueryController {
     }
 
     private void validateAuthHeaders(UUID userId, String userRole) {
-        if (userId == null || !StringUtils.hasText(userRole)) {
-            throw new CustomException(CommonErrorCode.INVALID_TOKEN);
-        }
+//        if (userId == null || !StringUtils.hasText(userRole)) { throw new CustomException(CommonErrorCode.INVALID_TOKEN); }
     }
 }

--- a/event-service/src/main/java/com/ojosama/eventservice/eventrequest/presentation/controller/EventRequestController.java
+++ b/event-service/src/main/java/com/ojosama/eventservice/eventrequest/presentation/controller/EventRequestController.java
@@ -41,7 +41,7 @@ public class EventRequestController {
     private final EventRequestQueryService eventRequestQueryService;
 
     @PostMapping
-    @PreAuthorize("hasAnyRole('USER')")
+//    @PreAuthorize("hasAnyRole('USER')")
     public ResponseEntity<ApiResponse<EventRequestResponse>> createEventRequest(
             @RequestHeader(value = "X-User-Id", required = false) UUID userId,
             @RequestHeader(value = "X-User-Role", required = false) String userRole,
@@ -58,7 +58,7 @@ public class EventRequestController {
     }
 
     @DeleteMapping("/{requestId}")
-    @PreAuthorize("hasAnyRole('ADMIN', 'USER')")
+//    @PreAuthorize("hasAnyRole('ADMIN', 'USER')")
     public ResponseEntity<Void> cancelEventRequest(
             @RequestHeader(value = "X-User-Id", required = false) UUID userId,
             @RequestHeader(value = "X-User-Role", required = false) String userRole,
@@ -75,7 +75,7 @@ public class EventRequestController {
     }
 
     @PostMapping("/{requestId}/approval")
-    @PreAuthorize("hasAnyRole('ADMIN', 'CONCERT_MANAGER', 'FESTIVAL_MANAGER', 'FANMEETING_MANAGER', 'POPUP_MANAGER')")
+//    @PreAuthorize("hasAnyRole('ADMIN', 'CONCERT_MANAGER', 'FESTIVAL_MANAGER', 'FANMEETING_MANAGER', 'POPUP_MANAGER')")
     public ResponseEntity<ApiResponse<EventRequestResponse>> approveEventRequest(
             @RequestHeader(value = "X-User-Id", required = false) UUID userId,
             @RequestHeader(value = "X-User-Role", required = false) String userRole,
@@ -90,7 +90,7 @@ public class EventRequestController {
     }
 
     @PostMapping("/{requestId}/rejections")
-    @PreAuthorize("hasAnyRole('ADMIN', 'CONCERT_MANAGER', 'FESTIVAL_MANAGER', 'FANMEETING_MANAGER', 'POPUP_MANAGER')")
+//    @PreAuthorize("hasAnyRole('ADMIN', 'CONCERT_MANAGER', 'FESTIVAL_MANAGER', 'FANMEETING_MANAGER', 'POPUP_MANAGER')")
     public ResponseEntity<ApiResponse<EventRequestResponse>> rejectEventRequest(
             @RequestHeader(value = "X-User-Id", required = false) UUID userId,
             @RequestHeader(value = "X-User-Role", required = false) String userRole,
@@ -106,7 +106,7 @@ public class EventRequestController {
     }
 
     @GetMapping
-    @PreAuthorize("hasAnyRole('ADMIN', 'CONCERT_MANAGER', 'FESTIVAL_MANAGER', 'FANMEETING_MANAGER', 'POPUP_MANAGER')")
+//    @PreAuthorize("hasAnyRole('ADMIN', 'CONCERT_MANAGER', 'FESTIVAL_MANAGER', 'FANMEETING_MANAGER', 'POPUP_MANAGER')")
     public ResponseEntity<ApiResponse<Page<EventRequestResponse>>> getEventRequests(
             @RequestHeader(value = "X-User-Id", required = false) UUID userId,
             @RequestHeader(value = "X-User-Role", required = false) String userRole,
@@ -120,7 +120,7 @@ public class EventRequestController {
     }
 
     @GetMapping("/me")
-    @PreAuthorize("hasAnyRole('USER')")
+//    @PreAuthorize("hasAnyRole('USER')")
     public ResponseEntity<ApiResponse<Page<EventRequestResponse>>> getMyEventRequests(
             @RequestHeader(value = "X-User-Id", required = false) UUID userId,
             @RequestHeader(value = "X-User-Role", required = false) String userRole,
@@ -134,7 +134,7 @@ public class EventRequestController {
     }
 
     @GetMapping("/{requestId}")
-    @PreAuthorize("hasAnyRole('ADMIN', 'CONCERT_MANAGER', 'FESTIVAL_MANAGER', 'FANMEETING_MANAGER', 'POPUP_MANAGER', 'USER')")
+//    @PreAuthorize("hasAnyRole('ADMIN', 'CONCERT_MANAGER', 'FESTIVAL_MANAGER', 'FANMEETING_MANAGER', 'POPUP_MANAGER', 'USER')")
     public ResponseEntity<ApiResponse<EventRequestResponse>> getEventRequest(
             @RequestHeader(value = "X-User-Id", required = false) UUID userId,
             @RequestHeader(value = "X-User-Role", required = false) String userRole,

--- a/event-service/src/main/java/com/ojosama/eventservice/eventrequest/presentation/controller/EventRequestController.java
+++ b/event-service/src/main/java/com/ojosama/eventservice/eventrequest/presentation/controller/EventRequestController.java
@@ -47,10 +47,7 @@ public class EventRequestController {
             @RequestHeader(value = "X-User-Role", required = false) String userRole,
             @Valid @RequestBody CreateEventRequestRequest request) {
 
-        if (userId == null || userRole == null) {
-            throw new CustomException(CommonErrorCode.INVALID_TOKEN);
-        }
-
+//        if (userId == null || userRole == null) { throw new CustomException(CommonErrorCode.INVALID_TOKEN); }
         EventRequestResult result = eventRequestCommandService.createEventRequest(
                 CreateEventRequestCommand.from(userId, request));
         return ResponseEntity.status(HttpStatus.CREATED)
@@ -81,10 +78,7 @@ public class EventRequestController {
             @RequestHeader(value = "X-User-Role", required = false) String userRole,
             @PathVariable UUID requestId) {
 
-        if (userId == null || userRole == null) {
-            throw new CustomException(CommonErrorCode.INVALID_TOKEN);
-        }
-
+//        if (userId == null || userRole == null) { throw new CustomException(CommonErrorCode.INVALID_TOKEN); }
         EventRequestResult result = eventRequestCommandService.approveEventRequest(requestId);
         return ResponseEntity.ok(ApiResponse.success(EventRequestResponse.from(result)));
     }
@@ -97,10 +91,7 @@ public class EventRequestController {
             @PathVariable UUID requestId,
             @Valid @RequestBody RejectEventRequestRequest request) {
 
-        if (userId == null || userRole == null) {
-            throw new CustomException(CommonErrorCode.INVALID_TOKEN);
-        }
-
+//        if (userId == null || userRole == null) { throw new CustomException(CommonErrorCode.INVALID_TOKEN); }
         EventRequestResult result = eventRequestCommandService.rejectEventRequest(requestId, request.rejectReason());
         return ResponseEntity.ok(ApiResponse.success(EventRequestResponse.from(result)));
     }
@@ -147,8 +138,6 @@ public class EventRequestController {
     }
 
     private void validateAuthHeaders(UUID userId, String userRole) {
-        if (userId == null || !StringUtils.hasText(userRole)) {
-            throw new CustomException(CommonErrorCode.INVALID_TOKEN);
-        }
+//        if (userId == null || !StringUtils.hasText(userRole)) { throw new CustomException(CommonErrorCode.INVALID_TOKEN); }
     }
 }


### PR DESCRIPTION
## 🔗 Issue Number
- close #129

## 📝 작업 내역

- 테스트하기 위해 임시로 @PreAuthorize 주석 처리

## 💡 PR 특이사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * 이벤트 관련 API들(카테고리·요청·명령·조회)의 엔드포인트 수준 역할 기반 접근 제어가 제거되었습니다.
  * 게이트웨이/인증 헤더 유효성 검사 일부가 완화되어, 일부 요청에서 이전과 달리 누락된 인증 헤더로 인한 즉시 거부가 발생하지 않습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->