### PR TITLE
[Fix] chat-service Consumer 필드명 통일, 실행시 버그 수정

### DIFF
--- a/chat-service/src/main/java/com/ojosama/chatservice/infrastructure/messaging/kafka/consumer/EventCreatedConsumer.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/infrastructure/messaging/kafka/consumer/EventCreatedConsumer.java
@@ -65,7 +65,7 @@ public class EventCreatedConsumer {
                     event.eventStartAt(),
                     event.eventEndAt()
             );
-            EventCategory category = parseCategory(event.categoryCode());
+            EventCategory category = parseCategory(event.categoryName());
 
             chatRoomService.createChatRoom(
                     new CreateChatRoomCommand(
@@ -76,8 +76,8 @@ public class EventCreatedConsumer {
                             schedule.getScheduledCloseAt()
                     )
             );
-            log.info("행사 이벤트로 채팅방을 자동 생성했습니다. eventId={}, eventName={}, categoryCode={}",
-                    event.eventId(), event.eventName(), event.categoryCode());
+            log.info("행사 이벤트로 채팅방을 자동 생성했습니다. eventId={}, eventName={}, categoryName={}",
+                    event.eventId(), event.eventName(), event.categoryName());
         } catch (ChatException e) {
             if (HttpStatus.CONFLICT.equals(e.getStatus())) {
                 log.info("채팅방이 이미 존재해서 이벤트를 건너뜁니다. eventId={}", event.eventId());
@@ -95,14 +95,14 @@ public class EventCreatedConsumer {
         }
     }
 
-    private EventCategory parseCategory(String categoryCode) {
-        if (categoryCode == null || categoryCode.isBlank()) {
-            throw new IllegalArgumentException("카테고리 코드는 비어 있을 수 없습니다.");
+    private EventCategory parseCategory(String categoryName) {
+        if (categoryName == null || categoryName.isBlank()) {
+            throw new IllegalArgumentException("카테고리 이름은 비어 있을 수 없습니다.");
         }
         try {
-            return EventCategory.valueOf(categoryCode.trim().toUpperCase());
+            return EventCategory.valueOf(categoryName.trim().toUpperCase());
         } catch (IllegalArgumentException e) {
-            throw new IllegalArgumentException("지원하지 않는 카테고리 코드입니다: " + categoryCode, e);
+            throw new IllegalArgumentException("지원하지 않는 카테고리 이름입니다: " + categoryName, e);
         }
     }
 }

--- a/chat-service/src/main/java/com/ojosama/chatservice/infrastructure/messaging/kafka/dto/EventCreatedEvent.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/infrastructure/messaging/kafka/dto/EventCreatedEvent.java
@@ -9,7 +9,7 @@ public record EventCreatedEvent(
         UUID eventId,
         String eventName,
         UUID categoryId,
-        String categoryCode,
+        String categoryName,
         LocalDateTime eventStartAt,
         LocalDateTime eventEndAt
 ) {

--- a/chat-service/src/main/resources/db/migration/V1__add_audit_columns.sql
+++ b/chat-service/src/main/resources/db/migration/V1__add_audit_columns.sql
@@ -1,9 +1,0 @@
-ALTER TABLE chat_schema.p_chat_room
-    ADD COLUMN created_by uuid,
-ADD COLUMN updated_by uuid,
-ADD COLUMN deleted_by uuid;
-
-ALTER TABLE chat_schema.p_message
-    ADD COLUMN created_by uuid,
-ADD COLUMN updated_by uuid,
-ADD COLUMN deleted_by uuid;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -164,6 +164,8 @@ services:
       CONFIG_SERVER_URL: http://config-server:8888
       CONFIG_USERNAME: ${CONFIG_USERNAME:-test}
       CONFIG_PASSWORD: ${CONFIG_PASSWORD:-test}
+      TZ: Asia/Seoul
+      JAVA_TOOL_OPTIONS: -Duser.timezone=Asia/Seoul
       SPRING_DATASOURCE_URL: jdbc:postgresql://festie-postgres:5432/${POSTGRES_DB:-festie}
       SPRING_DATASOURCE_USERNAME: ${POSTGRES_USER:-festie}
       SPRING_DATASOURCE_PASSWORD: ${POSTGRES_PASSWORD:-1234}
@@ -302,6 +304,8 @@ services:
     environment:
       SPRING_PROFILES_ACTIVE: docker
       SERVER_PORT: 8082
+      TZ: Asia/Seoul
+      JAVA_TOOL_OPTIONS: -Duser.timezone=Asia/Seoul
       SPRING_DATASOURCE_URL: jdbc:postgresql://festie-postgres:5432/${POSTGRES_DB:-festie}
       SPRING_DATASOURCE_USERNAME: ${POSTGRES_USER:-festie}
       SPRING_DATASOURCE_PASSWORD: ${POSTGRES_PASSWORD:-1234}


### PR DESCRIPTION
## 🔗 Issue Number
- close #141 

## 📝 작업 내역

- 행사 생성시 발행되는 필드명의 불일치( `categoryCode` -> `categoryName` )으로 통일하였습니다
- 실행시 버그났던게 flyway문제임을 확인하고, 마이그레이션 파일을 삭제후 docker 불륨 삭제하고 다시띄우면 에러없이 잘 실행됨을 확인하였습니다
- 채팅방 오픈시 시간이 기본시간이어서 TZ을 서울로 변경하였습니다 (docker-compose.yml)

## 💡 PR 특이사항

- 전체 도커 올린후 행사생성 -> 채팅방 자동 생성 확인
- 행사 일정 수정 -> 채팅방 일정 수정 확인
- 기본 채팅방 / 메시지 테스트도 확인 완료 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * 이벤트 카테고리 처리 방식이 카테고리 코드에서 카테고리 이름으로 변경되었습니다.
  * 데이터베이스 감사 추적 열이 제거되었습니다.

* **Chores**
  * 서비스의 타임존이 Asia/Seoul로 표준화되어 시간 정보의 일관성이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->