### PR TITLE
[FEATURE] Intenal에서 userId -> nickname 조회 API 추가

### DIFF
--- a/user-service/src/main/java/com/ojosama/userservice/application/service/UserService.java
+++ b/user-service/src/main/java/com/ojosama/userservice/application/service/UserService.java
@@ -193,4 +193,13 @@ public class UserService {
 
         return new GetCategoryManagerIdResult(manager.getId());
     }
+
+    //userId로 nickname 조회
+    @Transactional(readOnly = true)
+    public String getInternalUserNickname(UUID userId) {
+        User user = userRepository.findByIdAndDeletedAtIsNull(userId)
+                .orElseThrow(() -> new IllegalArgumentException("회원을 찾을 수 없습니다."));
+
+        return user.getNickname();
+    }
 }

--- a/user-service/src/main/java/com/ojosama/userservice/presentation/controller/InternalUserController.java
+++ b/user-service/src/main/java/com/ojosama/userservice/presentation/controller/InternalUserController.java
@@ -65,6 +65,14 @@ public class InternalUserController {
         );
         return InternalManagerIdResponseDto.from(result);
     }
+    
+    @GetMapping("/managers")
+    public UUID getInternalManagerIdValue(@RequestParam("categoryName") String categoryName) {
+        GetCategoryManagerIdResult result = userService.getInternalManagerId(
+                new GetCategoryManagerQuery(categoryName)
+        );
+        return result.managerId();
+    }
 
     @GetMapping("/{userId}/nickname")
     public InternalUserNicknameResponseDto getInternalUserNickname(@PathVariable UUID userId) {

--- a/user-service/src/main/java/com/ojosama/userservice/presentation/controller/InternalUserController.java
+++ b/user-service/src/main/java/com/ojosama/userservice/presentation/controller/InternalUserController.java
@@ -10,6 +10,7 @@ import com.ojosama.userservice.presentation.dto.response.InternalAdminIdResponse
 import com.ojosama.userservice.presentation.dto.response.InternalManagerIdResponseDto;
 import com.ojosama.userservice.presentation.dto.response.InternalUserEmailResponseDto;
 import com.ojosama.userservice.presentation.dto.response.InternalUserEmailsResponseDto;
+import com.ojosama.userservice.presentation.dto.response.InternalUserNicknameResponseDto;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -65,11 +66,10 @@ public class InternalUserController {
         return InternalManagerIdResponseDto.from(result);
     }
 
-    @GetMapping("/managers")
-    public UUID getInternalManagerIdValue(@RequestParam("categoryName") String categoryName) {
-        GetCategoryManagerIdResult result = userService.getInternalManagerId(
-                new GetCategoryManagerQuery(categoryName)
-        );
-        return result.managerId();
+    @GetMapping("/{userId}/nickname")
+    public InternalUserNicknameResponseDto getInternalUserNickname(@PathVariable UUID userId) {
+        String nickname = userService.getInternalUserNickname(userId);
+
+        return new InternalUserNicknameResponseDto(nickname);
     }
 }

--- a/user-service/src/main/java/com/ojosama/userservice/presentation/dto/response/InternalUserNicknameResponseDto.java
+++ b/user-service/src/main/java/com/ojosama/userservice/presentation/dto/response/InternalUserNicknameResponseDto.java
@@ -1,0 +1,6 @@
+package com.ojosama.userservice.presentation.dto.response;
+
+public record InternalUserNicknameResponseDto(
+        String nickname
+) {
+}


### PR DESCRIPTION
## 🔗 Issue Number
- close #158 

## 📝 작업 내역

userId -> nickname 조회 API 추가
## 💡 PR 특이사항


- 특이사항
- 특이사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 내부 API에 사용자 닉네임 조회 엔드포인트 추가 — 사용자 ID로 닉네임을 반환
* **변경**
  * 내부 API 응답 형식에 닉네임 전용 응답 추가
  * 기존 내부 관리자 관련 엔드포인트 동작은 유지됨
<!-- end of auto-generated comment: release notes by coderabbit.ai -->