### PR TITLE
[REFACTOR] post 목록조회 Controller 수정

### DIFF
--- a/common/src/main/java/com/ojosama/common/kafka/domain/EventType.java
+++ b/common/src/main/java/com/ojosama/common/kafka/domain/EventType.java
@@ -9,15 +9,6 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum EventType {
-
-
-    // Outbound
-    POST_CREATED("PostCreated"),
-    POST_UPDATED("PostUpdated"),
-    COMMENT_CREATED("CommentCreated"),
-    COMMENT_UPDATED("CommentUpdated"),
-    POST_REPORTED("PostReported"),
-    COMMENT_REPORTED("CommentReported"),
     
     // event
     EVENT_CREATED("EventCreated"),
@@ -42,6 +33,9 @@ public enum EventType {
     OPERATION_REQUEST_CREATED("OperationRequestCreated"),
     TARGET_BLINDED("TargetBlinded"),
     USER_BLACKLIST_STATUS_UPDATED("UserBlacklistStatusUpdated"),
+
+    //community
+    POST_DELETED("PostDeleted"),
 
     // ai
     AI_MODERATION_EVALUATED("AiModerationEvaluated"),

--- a/common/src/main/java/com/ojosama/common/kafka/domain/EventType.java
+++ b/common/src/main/java/com/ojosama/common/kafka/domain/EventType.java
@@ -36,6 +36,7 @@ public enum EventType {
 
     //community
     POST_DELETED("PostDeleted"),
+    TARGET_UNBLINDED("TargetUnblinded"),
 
     // ai
     AI_MODERATION_EVALUATED("AiModerationEvaluated"),

--- a/community-service-test.http
+++ b/community-service-test.http
@@ -1,0 +1,139 @@
+### Category Service Demo
+### IntelliJ HTTP Client용
+
+###카테고리 작성
+POST http://localhost:9001/v1/community-categories
+Content-Type: application/json
+
+{
+  "name":"테스트카테고리"
+}
+
+###카테고리 수정
+PATCH http://localhost:9001/v1/community-categories/{categoryId}
+Content-Type: application/json
+
+{
+
+  "name":"테스트카테고리이름변경"
+
+}
+
+###카테고리 삭제
+DELETE http://localhost:9001/v1/community-categories/{categoryId}
+Content-Type: application/json
+X-User-Id: 11111111-2222-1111-1111-111111111111
+
+###카테고리 목록조회
+GET http://localhost:9001/v1/community-categories?page=0&size=20
+
+###Post Service Demo
+### IntelliJ HTTP Client용
+
+###게시글 작성
+
+POST http://localhost:9001/v1/posts
+Content-Type: application/json
+X-User-Id: 11111111-1111-1111-1111-111111111111
+
+{
+  "categoryId":"b1ba71d8-323f-49a5-957d-2b65318dbc7e",
+  "title":"좋아요 테스트 게시글",
+  "content": "카프카 발행 본문입니다."
+}
+
+###게시글 수정
+PATCH http://localhost:9001/v1/posts/{postId}
+Content-Type: application/json
+X-User-Id: 11111111-1111-1111-1111-111111111111
+
+{
+  "categoryId":"b1ba71d8-323f-49a5-957d-2b65318dbc7e",
+  "title":"테스트 게시글 수정",
+  "content":"카프카 발행 수정용 본문입니다."
+}
+
+###게시글 삭제
+DELETE http://localhost:9001/v1/posts/d72ee555-858a-4735-8298-73810ed0f048
+X-User-Id: 11111111-1111-1111-1111-111111111111
+X-User-Role: ADMIN
+
+###전체 페이지 목록조회 (+ userId에 따른 페이지 목록 조회)
+GET http://localhost:9001/v1/posts?page=0&size=20
+
+###카테고리에 따른 페이지 목록 조회
+GET http://localhost:9001/v1/posts?categoryId=b1ba71d8-323f-49a5-957d-2b65318dbc7e&page=0&size=20
+
+###게시글 상세 조회
+GET http://localhost:9001/v1/posts/d72ee555-858a-4735-8298-73810ed0f048
+
+#operation-service → UserBlacklist 시연
+#operation-service → TargetBlinded 시연
+
+###Comment Service Demo
+### IntelliJ HTTP Client용
+
+###루트 댓글 작성
+POST http://localhost:9001/v1/posts/ee116b7c-bb6a-42ad-90ba-460b265095f5/comments
+Content-Type: application/json
+X-User-Id: 11111111-1111-1111-1111-111111111111
+
+{
+  "content":"루트 댓글입니다.",
+
+  "parentId":null
+}
+
+###대댓글 작성
+POST http://localhost:9001/v1/posts/af4b4c71-8bfb-4709-a9d3-3e4ac05eabe7/comments
+Content-Type: application/json
+X-User-Id: 11111111-1111-1111-1111-111111111111
+
+{
+  "content":"대댓글입니다.",
+  "parentId":"f48431e4-db13-4e34-a19f-1d143faaeabb"
+}
+
+###대댓글의 대댓글 검출 확인용
+POST http://localhost:9001/v1/posts/af4b4c71-8bfb-4709-a9d3-3e4ac05eabe7/comments
+Content-Type: application/json
+X-User-Id: 11111111-1111-1111-1111-111111111111
+
+{
+"content":"대댓글의 대댓글입니다",
+"parentId":"353da047-7411-4339-9cb8-aca77167fb0e"
+}
+
+
+###수정
+PATCH http://localhost:9001/v1/](http://localhost:9001/v1/posts/af4b4c71-8bfb-4709-a9d3-3e4ac05eabe7/comments)comments/{commentId}
+X-User-Id: 11111111-1111-1111-1111-111111111111
+
+{
+"content":"댓글 수정합니다."
+}
+
+###삭제
+DELETE http://localhost:9001/v1/](http://localhost:9001/v1/posts/af4b4c71-8bfb-4709-a9d3-3e4ac05eabe7/comments)comments/{commentId}
+X-User-Id: 11111111-1111-1111-1111-111111111111
+X-User-Role: ADMIN
+
+###posts에 해당하는 댓글 조회
+GET http://localhost:9001/v1/posts/af4b4c71-8bfb-4709-a9d3-3e4ac05eabe7/comments
+
+###댓글 상세조회(internal)
+internal/v1/comments/{commentId}
+
+###게시글 좋아요
+POST http://localhost:9001/v1/posts/d72ee555-858a-4735-8298-73810ed0f048/likes
+X-User-Id: 11111111-1111-1111-1111-111111111111
+
+#- 결과값
+#    {"status":200,"message":"성공하였습니다.","timestamp":"2026-05-02T10:45:41.798439008"}
+
+###댓글 좋아요
+POST http://localhost:9001/v1/comments/f48431e4-db13-4e34-a19f-1d143faaeabb/likes
+X-User-Id: 11111111-1111-1111-1111-111111111111
+
+#operation-service → UserBlacklist 시연
+#operation-service → TargetBlinded 시연

--- a/community-service-test.http
+++ b/community-service-test.http
@@ -106,15 +106,16 @@ X-User-Id: 11111111-1111-1111-1111-111111111111
 
 
 ###수정
-PATCH http://localhost:9001/v1/](http://localhost:9001/v1/posts/af4b4c71-8bfb-4709-a9d3-3e4ac05eabe7/comments)comments/{commentId}
+PATCH http://localhost:9001/v1/comments/{commentId}
 X-User-Id: 11111111-1111-1111-1111-111111111111
+Content-Type: application/json
 
 {
 "content":"댓글 수정합니다."
 }
 
 ###삭제
-DELETE http://localhost:9001/v1/](http://localhost:9001/v1/posts/af4b4c71-8bfb-4709-a9d3-3e4ac05eabe7/comments)comments/{commentId}
+DELETE http://localhost:9001/v1/comments/{commentId}
 X-User-Id: 11111111-1111-1111-1111-111111111111
 X-User-Role: ADMIN
 
@@ -122,7 +123,7 @@ X-User-Role: ADMIN
 GET http://localhost:9001/v1/posts/af4b4c71-8bfb-4709-a9d3-3e4ac05eabe7/comments
 
 ###댓글 상세조회(internal)
-internal/v1/comments/{commentId}
+GET http://localhost:9001/internal/v1/comments/{commentId}
 
 ###게시글 좋아요
 POST http://localhost:9001/v1/posts/d72ee555-858a-4735-8298-73810ed0f048/likes

--- a/community-service/src/main/java/com/ojosama/comment/application/service/CommentLikeService.java
+++ b/community-service/src/main/java/com/ojosama/comment/application/service/CommentLikeService.java
@@ -64,7 +64,7 @@ public class CommentLikeService {
         if (c.getDeletedAt() != null) {
             throw new CommentException(CommentErrorCode.COMMENT_NOT_FOUND);
         }
-        if (c.getStatus()== CommentStatus.BLOCKED) {
+        if (c.getStatus()== CommentStatus.BLINDED) {
             throw new CommentException(CommentErrorCode.COMMENT_BLOCKED);
         }
         return c;

--- a/community-service/src/main/java/com/ojosama/comment/application/service/CommentLikeService.java
+++ b/community-service/src/main/java/com/ojosama/comment/application/service/CommentLikeService.java
@@ -65,7 +65,7 @@ public class CommentLikeService {
             throw new CommentException(CommentErrorCode.COMMENT_NOT_FOUND);
         }
         if (c.getStatus()== CommentStatus.BLINDED) {
-            throw new CommentException(CommentErrorCode.COMMENT_BLOCKED);
+            throw new CommentException(CommentErrorCode.COMMENT_BLINDED);
         }
         return c;
     }

--- a/community-service/src/main/java/com/ojosama/comment/application/service/CommentService.java
+++ b/community-service/src/main/java/com/ojosama/comment/application/service/CommentService.java
@@ -47,7 +47,7 @@ public class CommentService {
     public CommentResult create(CreateCommentCommand cmd) {
         Post post = postRepository.findById(cmd.postId()).orElseThrow(
                 () -> new PostException(PostErrorCode.POST_NOT_FOUND));
-        if (post.getDeletedAt() != null || post.isBlocked()) {
+        if (post.getDeletedAt() != null || post.isBlinded()) {
             throw new PostException(PostErrorCode.POST_NOT_FOUND);
         }
 

--- a/community-service/src/main/java/com/ojosama/comment/application/service/CommentService.java
+++ b/community-service/src/main/java/com/ojosama/comment/application/service/CommentService.java
@@ -58,7 +58,7 @@ public class CommentService {
         } else {
             Comment parent = commentRepository.findById(cmd.parentId()).orElseThrow(() -> new CommentException(
                     CommentErrorCode.PARENT_COMMENT_NOT_FOUND));
-            if (parent.getDeletedAt() != null || parent.getStatus() == CommentStatus.BLOCKED) {
+            if (parent.getDeletedAt() != null || parent.getStatus() == CommentStatus.BLINDED) {
                 throw new CommentException(CommentErrorCode.PARENT_COMMENT_NOT_FOUND);
             }
             if (!parent.getPostId().equals(cmd.postId())) {
@@ -118,7 +118,7 @@ public class CommentService {
     public Page<CommentResult> listByPost(CommentListQuery query) {
         Page<Comment> roots = commentRepository
                 .findByPostIdAndParentIdIsNullAndDeletedAtIsNullAndStatusNot(
-                        query.postId(), CommentStatus.BLOCKED, query.pageable());
+                        query.postId(), CommentStatus.BLINDED, query.pageable());
 
         if (roots.isEmpty()) {
             return roots.map(CommentResult::flat);
@@ -129,7 +129,7 @@ public class CommentService {
 
         List<Comment> replies = commentRepository
                 .findByParentIdInAndDeletedAtIsNullAndStatusNotOrderByCreatedAtAsc(
-                        rootIds, CommentStatus.BLOCKED);
+                        rootIds, CommentStatus.BLINDED);
         //WHERE parent_id IN (댓글A_id, 댓글B_id) 쿼리 하나로 모든 대댓글을 가져온다.
 
         Map<UUID, List<CommentResult>> repliesByParent = replies.stream()

--- a/community-service/src/main/java/com/ojosama/comment/domain/event/payload/PostDeletedEvent.java
+++ b/community-service/src/main/java/com/ojosama/comment/domain/event/payload/PostDeletedEvent.java
@@ -1,0 +1,16 @@
+package com.ojosama.comment.domain.event.payload;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+//게시글 소프트 삭제 이벤트
+//community.post.deleted.v1
+//deletedBy는 게시글을 삭제한 사용자 UUID이며 로깅용, 댓글의 deletedBy는 deletedBy = null로 처리
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record PostDeletedEvent(
+        UUID postId,
+        UUID deletedBy,
+        LocalDateTime deletedAt
+) {
+}

--- a/community-service/src/main/java/com/ojosama/comment/domain/exception/CommentErrorCode.java
+++ b/community-service/src/main/java/com/ojosama/comment/domain/exception/CommentErrorCode.java
@@ -8,7 +8,7 @@ import org.springframework.http.HttpStatus;
 public enum CommentErrorCode implements ErrorCode {
     COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 댓글입니다."),
     PARENT_COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "부모 댓글을 찾을 수 없습니다."),
-    COMMENT_BLOCKED(HttpStatus.FORBIDDEN, "차단된 댓글입니다."),
+    COMMENT_BLINDED(HttpStatus.FORBIDDEN, "차단된 댓글입니다."),
     POST_MISMATCH(HttpStatus.BAD_REQUEST, "부모 댓글이 해당 게시글에 속하지 않습니다."),
     COMMENT_ACCESS_DENIED(HttpStatus.FORBIDDEN, "댓글에 대한 권한이 없습니다."),
     LIKE_COUNT_CANNOT_BE_NEGATIVE(HttpStatus.CONFLICT, "좋아요 수는 0 미만이 될 수 없습니다."),

--- a/community-service/src/main/java/com/ojosama/comment/domain/model/Comment.java
+++ b/community-service/src/main/java/com/ojosama/comment/domain/model/Comment.java
@@ -96,5 +96,5 @@ public class Comment extends BaseUserEntity {
     }
 
     public void markAsClean() { this.status = CommentStatus.CLEAN; }
-    public void block() { this.status = CommentStatus.BLOCKED; }
+    public void blind() { this.status = CommentStatus.BLINDED; }
 }

--- a/community-service/src/main/java/com/ojosama/comment/domain/model/CommentStatus.java
+++ b/community-service/src/main/java/com/ojosama/comment/domain/model/CommentStatus.java
@@ -3,5 +3,5 @@ package com.ojosama.comment.domain.model;
 public enum CommentStatus {
     UNVERIFIED, // 검증 전
     CLEAN,      // 정상
-    BLOCKED     // 차단됨
+    BLINDED     // 차단됨
 }

--- a/community-service/src/main/java/com/ojosama/comment/domain/repository/CommentRepository.java
+++ b/community-service/src/main/java/com/ojosama/comment/domain/repository/CommentRepository.java
@@ -35,7 +35,7 @@ public interface CommentRepository extends JpaRepository<Comment, UUID> {
     @Query("UPDATE Comment c SET c.status = com.ojosama.comment.domain.model.CommentStatus.BLINDED "
             + "WHERE c.userId = :userId AND c.deletedAt IS NULL "
             + "AND c.status <> com.ojosama.comment.domain.model.CommentStatus.BLINDED")
-    int blockAllByUserId(@Param("userId") UUID userId);
+    int blindAllByUserId(@Param("userId") UUID userId);
 
     @Query("SELECT c.userId FROM Comment c WHERE c.id = :id")
     Optional<UUID> findWriterIdById(@Param("id") UUID id);

--- a/community-service/src/main/java/com/ojosama/comment/domain/repository/CommentRepository.java
+++ b/community-service/src/main/java/com/ojosama/comment/domain/repository/CommentRepository.java
@@ -2,6 +2,7 @@ package com.ojosama.comment.domain.repository;
 
 import com.ojosama.comment.domain.model.Comment;
 import com.ojosama.comment.domain.model.CommentStatus;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -31,11 +32,18 @@ public interface CommentRepository extends JpaRepository<Comment, UUID> {
     void decrementLikeCount(@Param("id") UUID id);
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
-    @Query("UPDATE Comment c SET c.status = com.ojosama.comment.domain.model.CommentStatus.BLOCKED "
+    @Query("UPDATE Comment c SET c.status = com.ojosama.comment.domain.model.CommentStatus.BLINDED "
             + "WHERE c.userId = :userId AND c.deletedAt IS NULL "
-            + "AND c.status <> com.ojosama.comment.domain.model.CommentStatus.BLOCKED")
+            + "AND c.status <> com.ojosama.comment.domain.model.CommentStatus.BLINDED")
     int blockAllByUserId(@Param("userId") UUID userId);
 
     @Query("SELECT c.userId FROM Comment c WHERE c.id = :id")
     Optional<UUID> findWriterIdById(@Param("id") UUID id);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("UPDATE Comment c SET c.deletedAt = :deletedAt "
+            + "WHERE c.postId = :postId AND c.deletedAt IS NULL")
+    int softDeleteAllByPostId(@Param("postId") java.util.UUID postId,
+                              @Param("deletedAt") LocalDateTime deletedAt);
+
 }

--- a/community-service/src/main/java/com/ojosama/comment/infrastructure/messaging/kafka/consumer/PostDeletedConsumer.java
+++ b/community-service/src/main/java/com/ojosama/comment/infrastructure/messaging/kafka/consumer/PostDeletedConsumer.java
@@ -1,0 +1,79 @@
+package com.ojosama.comment.infrastructure.messaging.kafka.consumer;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ojosama.comment.domain.event.payload.PostDeletedEvent;
+import com.ojosama.comment.domain.repository.CommentRepository;
+import com.ojosama.common.kafka.domain.EventType;
+import com.ojosama.common.kafka.domain.IdempotentEventHandler;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+//PostDeleted 이벤트 컨슈밍.
+//토픽: community.post.deleted.v1
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PostDeletedConsumer {
+
+    private static final String CONSUMER_GROUP = "community-service-group";
+    private static final String EVENT_TYPE = EventType.POST_DELETED.getValue();
+
+    private final ObjectMapper objectMapper;
+    private final IdempotentEventHandler idempotentHandler;
+    private final CommentRepository commentRepository;
+
+    @KafkaListener(
+            topics = "${spring.kafka.topic.post-deleted}",
+            groupId = CONSUMER_GROUP,
+            containerFactory = "kafkaListenerContainerFactory"
+    )
+    public void onMessage(ConsumerRecord<String, String> record) {
+        UUID messageKey;
+        PostDeletedEvent event;
+
+        try {
+            messageKey = UUID.fromString(record.key());
+            event = parse(record.value());
+            idempotentHandler.handle(
+                    messageKey,
+                    CONSUMER_GROUP,
+                    record.topic(),
+                    EVENT_TYPE,
+                    () -> dispatch(event)
+            );
+            log.info("PostDeleted 이벤트 처리 완료. key={}, topic={}, postId={}",
+                    record.key(), record.topic(), event.postId());
+        } catch (RuntimeException e) {
+            log.error("PostDeleted 이벤트 처리에 실패했습니다. key={}, payload={}",
+                    record.key(), record.value(), e);
+            throw e;
+        }
+    }
+
+    private void dispatch(PostDeletedEvent event) {
+        if (event.postId() == null) {
+            log.warn("PostDeleted 이벤트에 postId가 없습니다. event={}. 스킵.", event);
+            return;
+        }
+        LocalDateTime deletedAt = event.deletedAt() != null
+                ? event.deletedAt()
+                : LocalDateTime.now();
+        int affected = commentRepository.softDeleteAllByPostId(event.postId(), deletedAt);
+        log.info("PostDeleted cascade — 댓글 소프트 삭제 완료. postId={}, affected={}",
+                event.postId(), affected);
+    }
+
+    private PostDeletedEvent parse(String payload) {
+        try {
+            return objectMapper.readValue(payload, PostDeletedEvent.class);
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException("PostDeleted 이벤트 페이로드 파싱에 실패했습니다.", e);
+        }
+    }
+}

--- a/community-service/src/main/java/com/ojosama/comment/infrastructure/messaging/kafka/consumer/PostDeletedConsumer.java
+++ b/community-service/src/main/java/com/ojosama/comment/infrastructure/messaging/kafka/consumer/PostDeletedConsumer.java
@@ -2,10 +2,10 @@ package com.ojosama.comment.infrastructure.messaging.kafka.consumer;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.ojosama.comment.domain.event.payload.PostDeletedEvent;
 import com.ojosama.comment.domain.repository.CommentRepository;
 import com.ojosama.common.kafka.domain.EventType;
 import com.ojosama.common.kafka.domain.IdempotentEventHandler;
+import com.ojosama.community.domain.event.payload.PostDeletedEvent;
 import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;

--- a/community-service/src/main/java/com/ojosama/comment/presentation/controller/CommentController.java
+++ b/community-service/src/main/java/com/ojosama/comment/presentation/controller/CommentController.java
@@ -78,6 +78,7 @@ public class CommentController {
         return ApiResponse.success(page.map(CommentResponse::from));
     }
 
+    //애그리거트
     @PostMapping("/v1/comments/{commentId}/likes")
     public ApiResponse<Integer> like(
             @PathVariable UUID commentId,

--- a/community-service/src/main/java/com/ojosama/comment/presentation/dto/response/CommentResponse.java
+++ b/community-service/src/main/java/com/ojosama/comment/presentation/dto/response/CommentResponse.java
@@ -20,7 +20,7 @@ public record CommentResponse(
         List<CommentResponse> replies
 ) {
     public static CommentResponse from(CommentResult r) {
-        boolean blocked = r.status() == CommentStatus.BLOCKED;
+        boolean blocked = r.status() == CommentStatus.BLINDED;
         List<CommentResponse> mappedReplies = r.replies() != null
                 ? r.replies().stream().map(CommentResponse::from).toList()
                 : List.of();

--- a/community-service/src/main/java/com/ojosama/community/domain/event/payload/PostDeletedEvent.java
+++ b/community-service/src/main/java/com/ojosama/community/domain/event/payload/PostDeletedEvent.java
@@ -1,4 +1,4 @@
-package com.ojosama.comment.domain.event.payload;
+package com.ojosama.community.domain.event.payload;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.time.LocalDateTime;

--- a/community-service/src/main/java/com/ojosama/community/domain/payload/TargetUnblindedEvent.java
+++ b/community-service/src/main/java/com/ojosama/community/domain/payload/TargetUnblindedEvent.java
@@ -1,0 +1,12 @@
+package com.ojosama.community.domain.payload;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.UUID;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record TargetUnblindedEvent(
+        UUID targetId,
+        TargetType targetType,
+        String reason
+) {
+}

--- a/community-service/src/main/java/com/ojosama/community/infrastructure/messaging/kafka/consumer/TargetBlindedConsumer.java
+++ b/community-service/src/main/java/com/ojosama/community/infrastructure/messaging/kafka/consumer/TargetBlindedConsumer.java
@@ -79,7 +79,7 @@ public class TargetBlindedConsumer {
             return;
         }
         if (comment.getStatus() == CommentStatus.BLINDED) {
-            log.debug("이미 BLOCKED 상태. 추가 처리 없이 종료. commentId={}", commentId);
+            log.debug("이미 BLINDED 상태. 추가 처리 없이 종료. commentId={}", commentId);
             return;
         }
         comment.blind();
@@ -93,7 +93,7 @@ public class TargetBlindedConsumer {
             return;
         }
         if (post.isBlinded()) {
-            log.debug("이미 BLOCKED 상태. 추가 처리 없이 종료. postId={}", postId);
+            log.debug("이미 BLINDED 상태. 추가 처리 없이 종료. postId={}", postId);
             return;
         }
         post.blind();

--- a/community-service/src/main/java/com/ojosama/community/infrastructure/messaging/kafka/consumer/TargetBlindedConsumer.java
+++ b/community-service/src/main/java/com/ojosama/community/infrastructure/messaging/kafka/consumer/TargetBlindedConsumer.java
@@ -78,11 +78,11 @@ public class TargetBlindedConsumer {
             log.warn("블라인드 대상 댓글을 찾을 수 없습니다. commentId={}", commentId);
             return;
         }
-        if (comment.getStatus() == CommentStatus.BLOCKED) {
+        if (comment.getStatus() == CommentStatus.BLINDED) {
             log.debug("이미 BLOCKED 상태. 추가 처리 없이 종료. commentId={}", commentId);
             return;
         }
-        comment.block();
+        comment.blind();
         commentRepository.save(comment);
     }
 
@@ -92,11 +92,11 @@ public class TargetBlindedConsumer {
             log.warn("블라인드 대상 게시글을 찾을 수 없습니다. postId={}", postId);
             return;
         }
-        if (post.isBlocked()) {
+        if (post.isBlinded()) {
             log.debug("이미 BLOCKED 상태. 추가 처리 없이 종료. postId={}", postId);
             return;
         }
-        post.block();
+        post.blind();
         postRepository.save(post);
     }
 

--- a/community-service/src/main/java/com/ojosama/community/infrastructure/messaging/kafka/consumer/TargetUnblindedConsumer.java
+++ b/community-service/src/main/java/com/ojosama/community/infrastructure/messaging/kafka/consumer/TargetUnblindedConsumer.java
@@ -1,0 +1,112 @@
+package com.ojosama.community.infrastructure.messaging.kafka.consumer;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ojosama.comment.domain.model.Comment;
+import com.ojosama.comment.domain.model.CommentStatus;
+import com.ojosama.comment.domain.repository.CommentRepository;
+import com.ojosama.common.kafka.domain.EventType;
+import com.ojosama.common.kafka.domain.IdempotentEventHandler;
+import com.ojosama.community.domain.payload.TargetUnblindedEvent;
+import com.ojosama.post.domain.model.Post;
+import com.ojosama.post.domain.repository.PostRepository;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+//operation.report.unblinded.v1
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class TargetUnblindedConsumer {
+
+    private static final String CONSUMER_GROUP = "community-service-group";
+    private static final String EVENT_TYPE = EventType.TARGET_UNBLINDED.getValue();
+
+    private final ObjectMapper objectMapper;
+    private final IdempotentEventHandler idempotentHandler;
+    private final CommentRepository commentRepository;
+    private final PostRepository postRepository;
+
+    @KafkaListener(
+            topics = "${spring.kafka.topic.report-unblinded}",
+            groupId = CONSUMER_GROUP,
+            containerFactory = "kafkaListenerContainerFactory"
+    )
+    public void onMessage(ConsumerRecord<String, String> record) {
+        UUID messageKey;
+        TargetUnblindedEvent event;
+
+        try {
+            messageKey = UUID.fromString(record.key());
+            event = parse(record.value());
+            idempotentHandler.handle(
+                    messageKey,
+                    CONSUMER_GROUP,
+                    record.topic(),
+                    EVENT_TYPE,
+                    () -> dispatch(event)
+            );
+            log.info("블라인드 해제 이벤트 처리 완료. key={}, topic={}, targetType={}, targetId={}, reason={}",
+                    record.key(), record.topic(),
+                    event.targetType(), event.targetId(), event.reason());
+        } catch (RuntimeException e) {
+            log.error("블라인드 해제 이벤트 처리에 실패했습니다. key={}, payload={}",
+                    record.key(), record.value(), e);
+            throw e;
+        }
+    }
+
+    private void dispatch(TargetUnblindedEvent event) {
+        if (event.targetType() == null || event.targetId() == null) {
+            log.warn("블라인드 해제 이벤트 필수 필드 누락. event={}. 스킵합니다.", event);
+            return;
+        }
+        switch (event.targetType()) {
+            case POST -> unblindPost(event.targetId());
+            case COMMENT -> unblindComment(event.targetId());
+            case CHAT -> log.debug("CHAT 타겟으로 스킵. targetId={}", event.targetId());
+        }
+    }
+
+    private void unblindPost(UUID postId) {
+        Post post = postRepository.findById(postId).orElse(null);
+        if (post == null) {
+            log.warn("블라인드 해제 대상 게시글을 찾을 수 없습니다. postId={}", postId);
+            return;
+        }
+        if (!post.isBlinded()) {
+            log.debug("BLINDED 상태가 아닙니다. 추가 처리 없이 종료. postId={}, status={}",
+                    postId, post.getStatus());
+            return;
+        }
+        post.markAsClean();
+        postRepository.save(post);
+    }
+
+    private void unblindComment(UUID commentId) {
+        Comment comment = commentRepository.findById(commentId).orElse(null);
+        if (comment == null) {
+            log.warn("블라인드 해제 대상 댓글을 찾을 수 없습니다. commentId={}", commentId);
+            return;
+        }
+        if (comment.getStatus() != CommentStatus.BLINDED) {
+            log.debug("BLINDED 상태가 아닙니다. 추가 처리 없이 종료. commentId={}, status={}",
+                    commentId, comment.getStatus());
+            return;
+        }
+        comment.markAsClean();
+        commentRepository.save(comment);
+    }
+
+    private TargetUnblindedEvent parse(String payload) {
+        try {
+            return objectMapper.readValue(payload, TargetUnblindedEvent.class);
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException("블라인드 해제 이벤트 페이로드 파싱에 실패했습니다.", e);
+        }
+    }
+}

--- a/community-service/src/main/java/com/ojosama/community/infrastructure/messaging/kafka/consumer/UserBlacklistStatusConsumer.java
+++ b/community-service/src/main/java/com/ojosama/community/infrastructure/messaging/kafka/consumer/UserBlacklistStatusConsumer.java
@@ -64,16 +64,16 @@ public class UserBlacklistStatusConsumer {
             return;
         }
         if (event.status() == BlacklistStatus.INACTIVE) {
-            // 사유 추적 컬럼이 없어 신고 누적 BLOCKED 와 구분 불가 → 운영 합의에 따라 무시
+            // 사유 추적 컬럼이 없어 신고 누적 BLINDED 와 구분 불가 → 운영 합의에 따라 무시
             log.info("INACTIVE 이벤트 수신 — 사유 추적 도입 전이므로 community 측 복구 없이 종료. userId={}",
                     event.userId());
             return;
         }
-        // ACTIVE: 해당 유저 콘텐츠 일괄 BLOCKED
-        int blockedComments = commentRepository.blockAllByUserId(event.userId());
-        int blockedPosts = postRepository.blockAllByUserId(event.userId());
-        log.info("블랙리스트 ACTIVE — 유저 콘텐츠 일괄 BLOCKED. userId={}, comments={}, posts={}",
-                event.userId(), blockedComments, blockedPosts);
+        // ACTIVE: 해당 유저 콘텐츠 일괄 BLINDED
+        int blindedComments = commentRepository.blindAllByUserId(event.userId());
+        int blindedPosts = postRepository.blindAllByUserId(event.userId());
+        log.info("블랙리스트 ACTIVE — 유저 콘텐츠 일괄 BLINDED. userId={}, comments={}, posts={}",
+                event.userId(), blindedComments, blindedPosts);
     }
 
     private UserBlacklistStatusEvent parse(String payload) {

--- a/community-service/src/main/java/com/ojosama/post/application/service/PostLikeService.java
+++ b/community-service/src/main/java/com/ojosama/post/application/service/PostLikeService.java
@@ -61,7 +61,7 @@ public class PostLikeService {
         if (post.getDeletedAt() != null) {
             throw new PostException(PostErrorCode.POST_NOT_FOUND);
         }
-        if (post.isBlocked()) {
+        if (post.isBlinded()) {
             throw new PostException(PostErrorCode.POST_BLOCKED);
         }
     }

--- a/community-service/src/main/java/com/ojosama/post/application/service/PostLikeService.java
+++ b/community-service/src/main/java/com/ojosama/post/application/service/PostLikeService.java
@@ -62,7 +62,7 @@ public class PostLikeService {
             throw new PostException(PostErrorCode.POST_NOT_FOUND);
         }
         if (post.isBlinded()) {
-            throw new PostException(PostErrorCode.POST_BLOCKED);
+            throw new PostException(PostErrorCode.POST_BLINDED);
         }
     }
 

--- a/community-service/src/main/java/com/ojosama/post/application/service/PostService.java
+++ b/community-service/src/main/java/com/ojosama/post/application/service/PostService.java
@@ -104,7 +104,7 @@ public class PostService {
     @Transactional
     public PostResult getDetail(UUID postId) {
         Post post = loadAlive(postId);
-        // BLOCKED 게시글도 200으로 응답한다 (PostResponse에서 마스킹 처리).
+        // BLINDED 게시글도 200으로 응답한다 (PostResponse에서 마스킹 처리).
         // 단, 조회수는 증가시키지 않음 — 차단된 게시글에 어뷰징성 조회수 발생 방지.
         if (post.isBlinded()) {
             return PostResult.from(post);

--- a/community-service/src/main/java/com/ojosama/post/application/service/PostService.java
+++ b/community-service/src/main/java/com/ojosama/post/application/service/PostService.java
@@ -1,5 +1,6 @@
 package com.ojosama.post.application.service;
 
+import com.ojosama.community.domain.event.payload.PostDeletedEvent;
 import com.ojosama.community.domain.model.Content;
 import com.ojosama.common.kafka.domain.EventType;
 import com.ojosama.common.kafka.domain.OutboxEventPublisher;
@@ -34,6 +35,9 @@ public class PostService {
 
     @Value("${spring.kafka.topic.community-moderation-requested}")
     private String moderationRequestedTopic;
+
+    @Value("${spring.kafka.topic.post-deleted}")
+    private String postDeletedTopic;
 
     @Transactional
     public PostResult create(CreatePostCommand cmd){
@@ -88,6 +92,13 @@ public class PostService {
             throw new PostException(PostErrorCode.POST_ACCESS_DENIED);
         }
         post.deleted(cmd.requesterId());
+
+        // PostDeleted 이벤트 발행
+        outbox.publish(
+                AGGREGATE_TYPE, post.getId(),
+                EventType.POST_DELETED, postDeletedTopic,
+                new PostDeletedEvent(post.getId(), cmd.requesterId(), post.getDeletedAt())
+        );
     }
 
     @Transactional

--- a/community-service/src/main/java/com/ojosama/post/application/service/PostService.java
+++ b/community-service/src/main/java/com/ojosama/post/application/service/PostService.java
@@ -109,13 +109,13 @@ public class PostService {
         Page<Post> posts;
         if (query.categoryId() != null) {
             posts = postRepository.findByCategoryIdAndDeletedAtIsNullAndStatusNot(
-                    query.categoryId(), PostStatus.BLOCKED, query.pageable());
+                    query.categoryId(), PostStatus.BLINDED, query.pageable());
         } else if (query.userId() != null) {
             posts = postRepository.findByUserIdAndDeletedAtIsNullAndStatusNot(
-                    query.userId(), PostStatus.BLOCKED, query.pageable());
+                    query.userId(), PostStatus.BLINDED, query.pageable());
         } else {
             posts = postRepository.findByDeletedAtIsNullAndStatusNot(
-                    PostStatus.BLOCKED, query.pageable());
+                    PostStatus.BLINDED, query.pageable());
         }
         return posts.map(PostResult::from);
     }

--- a/community-service/src/main/java/com/ojosama/post/application/service/PostService.java
+++ b/community-service/src/main/java/com/ojosama/post/application/service/PostService.java
@@ -95,7 +95,7 @@ public class PostService {
         Post post = loadAlive(postId);
         // BLOCKED 게시글도 200으로 응답한다 (PostResponse에서 마스킹 처리).
         // 단, 조회수는 증가시키지 않음 — 차단된 게시글에 어뷰징성 조회수 발생 방지.
-        if (post.isBlocked()) {
+        if (post.isBlinded()) {
             return PostResult.from(post);
         }
         int affected = postRepository.incrementViewCount(postId);

--- a/community-service/src/main/java/com/ojosama/post/domain/exception/PostErrorCode.java
+++ b/community-service/src/main/java/com/ojosama/post/domain/exception/PostErrorCode.java
@@ -8,7 +8,7 @@ import org.springframework.http.HttpStatus;
 public enum PostErrorCode implements ErrorCode {
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 게시글입니다."),
     POST_ACCESS_DENIED(HttpStatus.FORBIDDEN, "게시글에 대한 권한이 없습니다."),
-    POST_BLOCKED(HttpStatus.FORBIDDEN, "차단된 게시글입니다."),
+    POST_BLINDED(HttpStatus.FORBIDDEN, "차단된 게시글입니다."),
 
     INVALID_POST_TITLE(HttpStatus.BAD_REQUEST, "게시글 제목이 올바르지 않습니다."),
     INVALID_CATEGORY(HttpStatus.BAD_REQUEST, "카테고리 이름이 올바르지 않습니다."),

--- a/community-service/src/main/java/com/ojosama/post/domain/model/Post.java
+++ b/community-service/src/main/java/com/ojosama/post/domain/model/Post.java
@@ -111,12 +111,12 @@ public class Post extends BaseUserEntity {
     /**
      * 게시글 차단. AI 부적절 판정 또는 관리자 차단 또는 작성자 블랙리스트 처리 시 호출.
      */
-    public void block() {
-        this.status = PostStatus.BLOCKED;
+    public void blind() {
+        this.status = PostStatus.BLINDED;
     }
 
-    public boolean isBlocked() {
-        return this.status == PostStatus.BLOCKED;
+    public boolean isBlinded() {
+        return this.status == PostStatus.BLINDED;
     }
 
     // ── 인가 헬퍼 ─────────────────────────────────────────────

--- a/community-service/src/main/java/com/ojosama/post/domain/model/PostStatus.java
+++ b/community-service/src/main/java/com/ojosama/post/domain/model/PostStatus.java
@@ -4,5 +4,5 @@ public enum PostStatus {
     UNVERIFIED, // 검증 전
     CLEAN,      // 정상
     REPORTED,   // 신고됨
-    BLOCKED     // 차단됨
+    BLINDED     // 차단됨 => BLIND
 }

--- a/community-service/src/main/java/com/ojosama/post/domain/repository/PostRepository.java
+++ b/community-service/src/main/java/com/ojosama/post/domain/repository/PostRepository.java
@@ -63,9 +63,9 @@ public interface PostRepository extends JpaRepository<Post, UUID> {
 
     //블랙리스트 post 삭제 처리
     @Modifying(clearAutomatically = true, flushAutomatically = true)
-    @Query("UPDATE Post p SET p.status = com.ojosama.post.domain.model.PostStatus.BLOCKED "
+    @Query("UPDATE Post p SET p.status = com.ojosama.post.domain.model.PostStatus.BLINDED "
             + "WHERE p.userId = :userId AND p.deletedAt IS NULL "
-            + "AND p.status <> com.ojosama.post.domain.model.PostStatus.BLOCKED")
+            + "AND p.status <> com.ojosama.post.domain.model.PostStatus.BLINDED")
     int blockAllByUserId(@Param("userId") UUID userId);
 
     @Query("SELECT p.userId FROM Post p WHERE p.id = :id")

--- a/community-service/src/main/java/com/ojosama/post/domain/repository/PostRepository.java
+++ b/community-service/src/main/java/com/ojosama/post/domain/repository/PostRepository.java
@@ -66,7 +66,7 @@ public interface PostRepository extends JpaRepository<Post, UUID> {
     @Query("UPDATE Post p SET p.status = com.ojosama.post.domain.model.PostStatus.BLINDED "
             + "WHERE p.userId = :userId AND p.deletedAt IS NULL "
             + "AND p.status <> com.ojosama.post.domain.model.PostStatus.BLINDED")
-    int blockAllByUserId(@Param("userId") UUID userId);
+    int blindAllByUserId(@Param("userId") UUID userId);
 
     @Query("SELECT p.userId FROM Post p WHERE p.id = :id")
     Optional<UUID> findWriterIdById(@Param("id") UUID id);

--- a/community-service/src/main/java/com/ojosama/post/presesntation/controller/PostController.java
+++ b/community-service/src/main/java/com/ojosama/post/presesntation/controller/PostController.java
@@ -77,7 +77,7 @@ public class PostController {
     @GetMapping
     public ApiResponse<Page<PostResponse>> list(
             @RequestParam(required = false) UUID categoryId,
-            @RequestHeader(USER_ID_HEADER) UUID userId,
+            @RequestHeader(value = USER_ID_HEADER, required = false) UUID userId,
             @PageableDefault(size = 20, sort = "createdAt") Pageable pageable) {
         PostListQuery query;
         if (categoryId != null) {

--- a/community-service/src/main/java/com/ojosama/post/presesntation/dto/response/PostResponse.java
+++ b/community-service/src/main/java/com/ojosama/post/presesntation/dto/response/PostResponse.java
@@ -20,7 +20,7 @@ public record PostResponse(
         LocalDateTime updatedAt
 ) {
     public static PostResponse from(PostResult r) {
-        boolean blocked = r.status() == PostStatus.BLOCKED;
+        boolean blocked = r.status() == PostStatus.BLINDED;
         return new PostResponse(
                 r.id(),
                 r.userId(),

--- a/docs/community-service-test.http
+++ b/docs/community-service-test.http
@@ -3,31 +3,26 @@
 
 ###카테고리 작성
 POST {{communityUrl}}/v1/community-categories
-
 Content-Type: application/json
+
 {
-"name":"테스트카테고리"
+  "name":"테스트카테고리"
 }
 
 ###카테고리 수정
 PATCH {{communityUrl}}/v1/community-categories/{categoryId}
-
 Content-Type: application/json
+
 {
 
-"name":"테스트카테고리이름변경"
+  "name":"테스트카테고리이름변경"
 
 }
 
 ###카테고리 삭제
 DELETE {{communityUrl}}/v1/community-categories/{categoryId}
-
 Content-Type: application/json
-{
-
-"name":"테스트카테고리이름변경"
-
-}
+X-User-Id: 11111111-2222-1111-1111-111111111111
 
 ###카테고리 목록조회
 GET {{communityUrl}}/v1/community-categories?page=0&size=20
@@ -39,6 +34,18 @@ GET {{communityUrl}}/v1/community-categories?page=0&size=20
 
 POST {{communityUrl}}/v1/posts
 Content-Type: application/json
+X-User-Id: 11111111-1111-1111-1111-111111111111
+
+{
+  "categoryId":"b1ba71d8-323f-49a5-957d-2b65318dbc7e",
+  "title":"좋아요 테스트 게시글",
+  "content": "카프카 발행 본문입니다."
+}
+
+###게시글 수정
+PATCH {{communityUrl}}/v1/posts/{postId}
+Content-Type: application/json
+X-User-Id: 11111111-1111-1111-1111-111111111111
 
 {
   "categoryId":"b1ba71d8-323f-49a5-957d-2b65318dbc7e",
@@ -46,25 +53,19 @@ Content-Type: application/json
   "content":"카프카 발행 수정용 본문입니다."
 }
 
-###게시글 수정
-PATCH {{communityUrl}}/v1/posts/{postId}
-
-{
-"categoryId":"b1ba71d8-323f-49a5-957d-2b65318dbc7e",
-"title":"테스트 게시글 수정",
-"content":"카프카 발행 수정용 본문입니다."
-}
-
 ###게시글 삭제
-DELETE {{communityUrl}}/v1/posts/{postId}
+DELETE {{communityUrl}}/v1/posts/d72ee555-858a-4735-8298-73810ed0f048
+X-User-Id: 11111111-1111-1111-1111-111111111111
+X-User-Role: ADMIN
 
-###전체 페이지 목록조회 + 카테고리에 따른 페이지 목록 조회 + userId에 따른 페이지 목록 조회
+###전체 페이지 목록조회 (+ userId에 따른 페이지 목록 조회)
 GET {{communityUrl}}/v1/posts?page=0&size=20
 
+###카테고리에 따른 페이지 목록 조회
 GET {{communityUrl}}/v1/posts?categoryId=b1ba71d8-323f-49a5-957d-2b65318dbc7e&page=0&size=20
 
 ###게시글 상세 조회
-GET {{communityUrl}}/v1/posts/af4b4c71-8bfb-4709-a9d3-3e4ac05eabe7
+GET {{communityUrl}}/v1/posts/d72ee555-858a-4735-8298-73810ed0f048
 
 #operation-service → UserBlacklist 시연
 #operation-service → TargetBlinded 시연
@@ -73,8 +74,9 @@ GET {{communityUrl}}/v1/posts/af4b4c71-8bfb-4709-a9d3-3e4ac05eabe7
 ### IntelliJ HTTP Client용
 
 ###루트 댓글 작성
-POST {{communityUrl}}/v1/posts/af4b4c71-8bfb-4709-a9d3-3e4ac05eabe7/comments
+POST {{communityUrl}}/v1/posts/ee116b7c-bb6a-42ad-90ba-460b265095f5/comments
 Content-Type: application/json
+X-User-Id: 11111111-1111-1111-1111-111111111111
 
 {
   "content":"루트 댓글입니다.",
@@ -85,6 +87,7 @@ Content-Type: application/json
 ###대댓글 작성
 POST {{communityUrl}}/v1/posts/af4b4c71-8bfb-4709-a9d3-3e4ac05eabe7/comments
 Content-Type: application/json
+X-User-Id: 11111111-1111-1111-1111-111111111111
 
 {
   "content":"대댓글입니다.",
@@ -93,16 +96,18 @@ Content-Type: application/json
 
 ###대댓글의 대댓글 검출 확인용
 POST {{communityUrl}}/v1/posts/af4b4c71-8bfb-4709-a9d3-3e4ac05eabe7/comments
-Content-Type: application/json"
+Content-Type: application/json
+X-User-Id: 11111111-1111-1111-1111-111111111111
 
 {
-"content":"대댓글의 대댓글입니다",
-"parentId":"353da047-7411-4339-9cb8-aca77167fb0e;"
+  "content":"대댓글의 대댓글입니다",
+  "parentId":"353da047-7411-4339-9cb8-aca77167fb0e"
 }
 
 
 ###수정
 PATCH {{communityUrl}}/v1/]({{communityUrl}}/v1/posts/af4b4c71-8bfb-4709-a9d3-3e4ac05eabe7/comments)comments/{commentId}
+X-User-Id: 11111111-1111-1111-1111-111111111111
 
 {
 "content":"댓글 수정합니다."
@@ -110,21 +115,25 @@ PATCH {{communityUrl}}/v1/]({{communityUrl}}/v1/posts/af4b4c71-8bfb-4709-a9d3-3e
 
 ###삭제
 DELETE {{communityUrl}}/v1/]({{communityUrl}}/v1/posts/af4b4c71-8bfb-4709-a9d3-3e4ac05eabe7/comments)comments/{commentId}
+X-User-Id: 11111111-1111-1111-1111-111111111111
+X-User-Role: ADMIN
 
 ###posts에 해당하는 댓글 조회
-{{communityUrl}}/v1/posts/af4b4c71-8bfb-4709-a9d3-3e4ac05eabe7/comments
+GET {{communityUrl}}/v1/posts/af4b4c71-8bfb-4709-a9d3-3e4ac05eabe7/comments
 
 ###댓글 상세조회(internal)
 internal/v1/comments/{commentId}
 
 ###게시글 좋아요
-POST {{communityUrl}}/v1/posts/af4b4c71-8bfb-4709-a9d3-3e4ac05eabe7/likes
+POST {{communityUrl}}/v1/posts/d72ee555-858a-4735-8298-73810ed0f048/likes
+X-User-Id: 11111111-1111-1111-1111-111111111111
 
 #- 결과값
 #    {"status":200,"message":"성공하였습니다.","timestamp":"2026-05-02T10:45:41.798439008"}
 
 ###댓글 좋아요
 POST {{communityUrl}}/v1/comments/f48431e4-db13-4e34-a19f-1d143faaeabb/likes
+X-User-Id: 11111111-1111-1111-1111-111111111111
 
 #operation-service → UserBlacklist 시연
 #operation-service → TargetBlinded 시연

--- a/docs/community-service-test.http
+++ b/docs/community-service-test.http
@@ -106,7 +106,7 @@ X-User-Id: 11111111-1111-1111-1111-111111111111
 
 
 ###수정
-PATCH {{communityUrl}}/v1/]({{communityUrl}}/v1/posts/af4b4c71-8bfb-4709-a9d3-3e4ac05eabe7/comments)comments/{commentId}
+PATCH {{communityUrl}}/v1/posts/af4b4c71-8bfb-4709-a9d3-3e4ac05eabe7/comments)comments/{commentId}
 X-User-Id: 11111111-1111-1111-1111-111111111111
 
 {
@@ -114,7 +114,7 @@ X-User-Id: 11111111-1111-1111-1111-111111111111
 }
 
 ###삭제
-DELETE {{communityUrl}}/v1/]({{communityUrl}}/v1/posts/af4b4c71-8bfb-4709-a9d3-3e4ac05eabe7/comments)comments/{commentId}
+DELETE {{communityUrl}}/v1/posts/af4b4c71-8bfb-4709-a9d3-3e4ac05eabe7/comments)comments/{commentId}
 X-User-Id: 11111111-1111-1111-1111-111111111111
 X-User-Role: ADMIN
 


### PR DESCRIPTION
## 🔗 Issue Number
- 

## 📝 작업 내역

- post 목록조회 유저ID 헤더에 안넣어도 되게 수정
- community-service-test.http 업로드
- refactor: Post,Comment 상태값 BLOCKED -> BLINDED 변경
- 댓글 PostDeleted 컨슈밍
- 게시글 PostDeleted 포로듀싱
- TargetUnblinded 이벤트 구현

## 💡 PR 특이사항

- 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 변경 사항

* **개선 사항**
  * 포스트 목록 조회 API에서 X-User-Id 헤더가 선택 항목이 되었습니다. 미전송 시 카테고리 필터 또는 전체 목록으로 정상 동작합니다.
  * 숨김(블라인드) 상태로의 전환과 관련된 동작(게시글/댓글 조회, 좋아요 등)이 일관되게 적용됩니다. 숨김 대상은 상호작용이 제한됩니다.

* **신규 기능**
  * 게시글 삭제 시 연관 댓글에 대한 일괄 소프트 삭제 처리와 관련 이벤트 처리가 추가되었습니다.

* **문서화**
  * API 테스트 예시(요청 헤더·페이로드·엔드포인트)가 표준화 및 보강되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->