### PR TITLE
[REFACTOR] 신고 도메인 리팩토링 및 AI 검증 도메인 프롬프트 수정

### DIFF
--- a/ai-service/src/main/java/com/ojosama/moderation/infrastructure/prompt/AiModerationPromptTemplate.java
+++ b/ai-service/src/main/java/com/ojosama/moderation/infrastructure/prompt/AiModerationPromptTemplate.java
@@ -9,7 +9,7 @@ public class AiModerationPromptTemplate {
         제공된 텍스트 리스트를 분석하여 각 항목의 유해성을 판별하세요.
         
         판별 카테고리:
-        - PROFANITY: 욕설 및 비방 (단, "바보", "멍청이" 등 가벼운 단어는 SAFE로 처리)
+        - PROFANITY: 욕설 및 비방 (예: 심각한 욕설, 인신공격)
         - HATE_SPEECH: 혐오 표현
         - SEXUAL_CONTENT: 음란성 내용
         - SPAM: 광고 및 도배
@@ -18,6 +18,23 @@ public class AiModerationPromptTemplate {
         - UNAUTHORIZED_TRADE: 불법 거래 유도
         - OTHER: 기타 부적절한 내용
         - SAFE: 유해하지 않음
+        
+        중요한 판별 기준:
+        1) 일상적인 감탄사나 표현은 SAFE로 처리하세요:
+           - "미친", "죽인다", "지린다", "개쩐다" 등의 긍정적 감탄사
+           - "바보", "멍청이" 등의 가벼운 농담성 표현
+           - 문맥상 감탄이나 놀라움을 표현하는 경우
+
+        2) PROFANITY로 판별해야 하는 경우:
+           - 특정인을 향한 명백한 욕설이나 인신공격
+           - 심각하고 공격적인 비속어
+           - 타인을 모욕하거나 비하할 의도가 명확한 표현
+
+        3) 문맥을 고려하세요:
+           - "미친 실력이다" → SAFE (긍정적 감탄)
+           - "너 미쳤냐?" (비난 의도) → PROFANITY
+           - "죽여준다" (칭찬) → SAFE
+           - "죽여버린다" (협박) → OTHER
         
         응답 규칙:
         1) 입력으로 받은 각 targetId마다 정확히 1개의 결과를 반환하세요.

--- a/common/src/main/java/com/ojosama/common/kafka/domain/EventType.java
+++ b/common/src/main/java/com/ojosama/common/kafka/domain/EventType.java
@@ -35,6 +35,7 @@ public enum EventType {
 
     // operation
     REPORT_BLINDED("ReportBlinded"),
+    REPORT_UNBLINDED("ReportUnblinded"),
     BLACKLIST_REGISTERED("BlacklistRegistered"),
     BLACKLIST_UPDATED("BlacklistUpdated"),
     BLACKLIST_REVIEW_REQUESTED("BlacklistReviewRequested"),

--- a/common/src/main/java/com/ojosama/common/kafka/domain/EventType.java
+++ b/common/src/main/java/com/ojosama/common/kafka/domain/EventType.java
@@ -10,7 +10,6 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum EventType {
 
-
     // Outbound
     POST_CREATED("PostCreated"),
     POST_UPDATED("PostUpdated"),

--- a/operation-service/src/main/java/com/ojosama/report/application/dto/command/UpdateReportCommand.java
+++ b/operation-service/src/main/java/com/ojosama/report/application/dto/command/UpdateReportCommand.java
@@ -1,3 +1,5 @@
 package com.ojosama.report.application.dto.command;
 
-public record UpdateReportCommand(Boolean isResolved, String operatorMemo) { }
+import com.ojosama.report.domain.model.enums.ReportStatus;
+
+public record UpdateReportCommand(ReportStatus status, String operatorMemo) { }

--- a/operation-service/src/main/java/com/ojosama/report/application/service/ReportService.java
+++ b/operation-service/src/main/java/com/ojosama/report/application/service/ReportService.java
@@ -98,7 +98,7 @@ public class ReportService {
     }
 
     private void validateReportIsPending(Report report) {
-        if (report.getStatus() != ReportStatus.PENDING) {
+        if (report.getStatus() != ReportStatus.AUTO_BLINDED) {
             throw new ReportException(ReportErrorCode.REPORT_ALREADY_PROCESSED);
         }
     }

--- a/operation-service/src/main/java/com/ojosama/report/application/service/ReportService.java
+++ b/operation-service/src/main/java/com/ojosama/report/application/service/ReportService.java
@@ -114,7 +114,7 @@ public class ReportService {
         long reportCount = reportRepository.countByTargetId(command.targetId());
 
         // 신고가 3회 이상이면 신고 대상 블라인드 처리 및 유저 블랙리스트 조건 검사
-        if (reportCount + 1 == 3) {
+        if (reportCount >= 3) {
             publishBlindEvent(command);
             publishBlacklistReviewRequestEvent(command.targetUserId());
         }
@@ -144,13 +144,12 @@ public class ReportService {
 
     private void publishBlacklistReviewRequestEvent(UUID targetUserId) {
         long userBlindCount = reportRepository.countBlindedTargetByUserId(targetUserId);
-        long blindCountAfter = userBlindCount + 1;
 
-        if (blindCountAfter >= 5) {
+        if (userBlindCount >= 5) {
             BlacklistReviewRequestEvent event = new BlacklistReviewRequestEvent(
                     targetUserId,
                     "블라인드 처리가 5회 누적되어 블랙리스트 등록 검토가 필요합니다.",
-                    blindCountAfter
+                    userBlindCount
             );
 
             outbox.publish(

--- a/operation-service/src/main/java/com/ojosama/report/application/service/ReportService.java
+++ b/operation-service/src/main/java/com/ojosama/report/application/service/ReportService.java
@@ -7,8 +7,8 @@ import com.ojosama.report.application.dto.command.UpdateReportCommand;
 import com.ojosama.report.application.dto.query.ListReportQuery;
 import com.ojosama.report.application.dto.result.ReportInfoResult;
 import com.ojosama.report.application.dto.result.ReportResult;
-import com.ojosama.report.domain.event.payload.BlacklistReviewRequestEvent;
-import com.ojosama.report.domain.event.payload.TargetBlindEvent;
+import com.ojosama.report.domain.event.payload.BlacklistReviewRequestedEvent;
+import com.ojosama.report.domain.event.payload.TargetBlindedEvent;
 import com.ojosama.report.domain.exception.ReportErrorCode;
 import com.ojosama.report.domain.exception.ReportException;
 import com.ojosama.report.domain.model.entity.Report;
@@ -132,7 +132,7 @@ public class ReportService {
                 command.targetId(),
                 EventType.REPORT_BLINDED,
                 targetBlindedTopic,
-                new TargetBlindEvent(
+                new TargetBlindedEvent(
                         command.targetId(),
                         command.targetType(),
                         command.targetUserId(),
@@ -146,7 +146,7 @@ public class ReportService {
         long userBlindCount = reportRepository.countBlindedTargetByUserId(targetUserId);
 
         if (userBlindCount >= 5) {
-            BlacklistReviewRequestEvent event = new BlacklistReviewRequestEvent(
+            BlacklistReviewRequestedEvent event = new BlacklistReviewRequestedEvent(
                     targetUserId,
                     "블라인드 처리가 5회 누적되어 블랙리스트 등록 검토가 필요합니다.",
                     userBlindCount

--- a/operation-service/src/main/java/com/ojosama/report/application/service/ReportService.java
+++ b/operation-service/src/main/java/com/ojosama/report/application/service/ReportService.java
@@ -9,6 +9,7 @@ import com.ojosama.report.application.dto.result.ReportInfoResult;
 import com.ojosama.report.application.dto.result.ReportResult;
 import com.ojosama.report.domain.event.payload.BlacklistReviewRequestedEvent;
 import com.ojosama.report.domain.event.payload.TargetBlindedEvent;
+import com.ojosama.report.domain.event.payload.TargetUnblindedEvent;
 import com.ojosama.report.domain.exception.ReportErrorCode;
 import com.ojosama.report.domain.exception.ReportException;
 import com.ojosama.report.domain.model.entity.Report;
@@ -34,6 +35,9 @@ public class ReportService {
 
     @Value("${spring.kafka.topic.report-blinded}")
     private String targetBlindedTopic;
+
+    @Value("${spring.kafka.topic.report-unblinded}")
+    private String targetUnblindedTopic;
 
     @Value("${spring.kafka.topic.blacklist-requested}")
     private String blacklistReviewRequestedTopic;
@@ -66,12 +70,17 @@ public class ReportService {
     @Transactional
     public ReportInfoResult updateReport(UUID reportId, UpdateReportCommand command) {
         Report report = findReportById(reportId);
-        validateReportIsPending(report);
+        validateReportIsAutoBlinded(report);
+        validateStatusIsValid(command.status());
 
-        if (command.isResolved()) {
+        if (command.status() == ReportStatus.RESOLVED) {
             report.resolve(command.operatorMemo());
-        } else {
+            // RESOLVED된 경우 블랙리스트 검토
+            checkAndPublishBlacklistReviewForResolved(report.getTargetUserId());
+        } else if (command.status() == ReportStatus.REJECTED) {
             report.reject(command.operatorMemo());
+            // 블라인드 해제 이벤트 발행
+            publishUnblindEvent(report);
         }
 
         return ReportInfoResult.from(report);
@@ -97,9 +106,15 @@ public class ReportService {
                 .orElseThrow(() -> new ReportException(ReportErrorCode.REPORT_NOT_FOUND));
     }
 
-    private void validateReportIsPending(Report report) {
+    private void validateReportIsAutoBlinded(Report report) {
         if (report.getStatus() != ReportStatus.AUTO_BLINDED) {
             throw new ReportException(ReportErrorCode.REPORT_ALREADY_PROCESSED);
+        }
+    }
+
+    private void validateStatusIsValid(ReportStatus status) {
+        if (status != ReportStatus.RESOLVED && status != ReportStatus.REJECTED) {
+            throw new ReportException(ReportErrorCode.INVALID_STATUS);
         }
     }
 
@@ -113,10 +128,9 @@ public class ReportService {
     private void checkAndProcessAutomaticBlind(CreateReportCommand command) {
         long reportCount = reportRepository.countByTargetId(command.targetId());
 
-        // 신고가 3회 이상이면 신고 대상 블라인드 처리 및 유저 블랙리스트 조건 검사
+        // 신고가 3회 이상이면 신고 대상 블라인드 처리
         if (reportCount >= 3) {
             publishBlindEvent(command);
-            publishBlacklistReviewRequestEvent(command.targetUserId());
         }
     }
 
@@ -142,14 +156,31 @@ public class ReportService {
         );
     }
 
-    private void publishBlacklistReviewRequestEvent(UUID targetUserId) {
-        long userBlindCount = reportRepository.countBlindedTargetByUserId(targetUserId);
+    // 블라인드 해제 이벤트 발행 (REJECTED 시)
+    private void publishUnblindEvent(Report report) {
+        outbox.publish(
+                "REPORT",
+                report.getTargetId(),
+                EventType.REPORT_UNBLINDED,
+                targetUnblindedTopic,
+                new TargetUnblindedEvent(
+                        report.getTargetId(),
+                        report.getTargetType(),
+                        report.getTargetUserId(),
+                        "매니저 검토 결과 오인 신고로 판단되어 블라인드가 해제되었습니다."
+                )
+        );
+    }
 
-        if (userBlindCount >= 5) {
+    // 블랙리스트 검토 로직 (RESOLVED된 게시글만 카운트)
+    private void checkAndPublishBlacklistReviewForResolved(UUID targetUserId) {
+        long userResolvedCount = reportRepository.countResolvedTargetByUserId(targetUserId);
+
+        if (userResolvedCount >= 5) {
             BlacklistReviewRequestedEvent event = new BlacklistReviewRequestedEvent(
                     targetUserId,
-                    "블라인드 처리가 5회 누적되어 블랙리스트 등록 검토가 필요합니다.",
-                    userBlindCount
+                    "매니저에 의해 확정된 블라인드 처리가 5회 누적되어 블랙리스트 등록 검토가 필요합니다.",
+                    userResolvedCount
             );
 
             outbox.publish(

--- a/operation-service/src/main/java/com/ojosama/report/domain/event/ReportEventProducer.java
+++ b/operation-service/src/main/java/com/ojosama/report/domain/event/ReportEventProducer.java
@@ -1,12 +1,12 @@
 package com.ojosama.report.domain.event;
 
-import com.ojosama.report.domain.event.payload.BlacklistReviewRequestEvent;
-import com.ojosama.report.domain.event.payload.TargetBlindEvent;
+import com.ojosama.report.domain.event.payload.BlacklistReviewRequestedEvent;
+import com.ojosama.report.domain.event.payload.TargetBlindedEvent;
 
 public interface ReportEventProducer {
     // 타겟(게시글/채팅)이 3회 누적되어 자동 블라인드 되었음을 알리는 이벤트
-    void publishTargetBlindEvent(TargetBlindEvent event);
+    void publishTargetBlindEvent(TargetBlindedEvent event);
 
     // 유저의 블라인드 횟수가 5회 누적되어 블랙리스트 등록 대상임을 알리는 이벤트
-    void publishBlacklistReviewRequestEvent(BlacklistReviewRequestEvent event);
+    void publishBlacklistReviewRequestEvent(BlacklistReviewRequestedEvent event);
 }

--- a/operation-service/src/main/java/com/ojosama/report/domain/event/payload/AiReportedEvent.java
+++ b/operation-service/src/main/java/com/ojosama/report/domain/event/payload/AiReportedEvent.java
@@ -1,12 +1,11 @@
 package com.ojosama.report.domain.event.payload;
 
-import com.ojosama.report.domain.model.enums.TargetType;
 import java.util.UUID;
 
-public record TargetBlindEvent (
+public record AiReportedEvent(
         UUID targetId,
-        TargetType targetType,
         UUID targetUserId,
+        String targetType,
         String category,
-        String reason
-){ }
+        String content
+) { }

--- a/operation-service/src/main/java/com/ojosama/report/domain/event/payload/BlacklistReviewRequestedEvent.java
+++ b/operation-service/src/main/java/com/ojosama/report/domain/event/payload/BlacklistReviewRequestedEvent.java
@@ -2,7 +2,7 @@ package com.ojosama.report.domain.event.payload;
 
 import java.util.UUID;
 
-public record BlacklistReviewRequestEvent(
+public record BlacklistReviewRequestedEvent(
         UUID targetUserId,
         String reason,
         long blindCount

--- a/operation-service/src/main/java/com/ojosama/report/domain/event/payload/TargetBlindedEvent.java
+++ b/operation-service/src/main/java/com/ojosama/report/domain/event/payload/TargetBlindedEvent.java
@@ -1,11 +1,12 @@
 package com.ojosama.report.domain.event.payload;
 
+import com.ojosama.report.domain.model.enums.TargetType;
 import java.util.UUID;
 
-public record AiReportEvent(
+public record TargetBlindedEvent(
         UUID targetId,
+        TargetType targetType,
         UUID targetUserId,
-        String targetType,
         String category,
-        String content
-) { }
+        String reason
+){ }

--- a/operation-service/src/main/java/com/ojosama/report/domain/event/payload/TargetUnblindedEvent.java
+++ b/operation-service/src/main/java/com/ojosama/report/domain/event/payload/TargetUnblindedEvent.java
@@ -1,0 +1,11 @@
+package com.ojosama.report.domain.event.payload;
+
+import com.ojosama.report.domain.model.enums.TargetType;
+import java.util.UUID;
+
+public record TargetUnblindedEvent (
+        UUID targetId,
+        TargetType targetType,
+        UUID targetUserId,
+        String reason
+){ }

--- a/operation-service/src/main/java/com/ojosama/report/domain/exception/ReportErrorCode.java
+++ b/operation-service/src/main/java/com/ojosama/report/domain/exception/ReportErrorCode.java
@@ -9,7 +9,8 @@ public enum ReportErrorCode implements ErrorCode {
     REPORT_NOT_FOUND(HttpStatus.NOT_FOUND, "신고 요청을 찾을 수 없습니다."),
     REPORT_EXISTS(HttpStatus.BAD_REQUEST, "이미 존재하는 신고 요청입니다."),
     REPORT_ALREADY_PROCESSED(HttpStatus.BAD_REQUEST, "이미 처리된 신고 요청입니다."),
-    DUPLICATE_REPORT(HttpStatus.BAD_REQUEST, "중복된 신고 요청입니다.");
+    DUPLICATE_REPORT(HttpStatus.BAD_REQUEST, "중복된 신고 요청입니다."),
+    INVALID_STATUS(HttpStatus.BAD_REQUEST, "유효하지 않은 상태입니다. RESOLVED 또는 REJECTED만 입력 가능합니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/operation-service/src/main/java/com/ojosama/report/domain/model/entity/Report.java
+++ b/operation-service/src/main/java/com/ojosama/report/domain/model/entity/Report.java
@@ -79,7 +79,7 @@ public class Report extends BaseEntity {
         this.category = category;
         this.description = description;
         this.content = content;
-        this.status = ReportStatus.PENDING;
+        this.status = ReportStatus.AUTO_BLINDED;
     }
 
     public static Report of(UUID reporterId, ReporterType reporterType, UUID targetId, UUID targetUserId,

--- a/operation-service/src/main/java/com/ojosama/report/domain/model/enums/ReportStatus.java
+++ b/operation-service/src/main/java/com/ojosama/report/domain/model/enums/ReportStatus.java
@@ -6,7 +6,7 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum ReportStatus {
-    PENDING("대기 중/자동 블라인드"), // 신고 접수됨 또는 AI에 의해 임시 숨김
+    AUTO_BLINDED("자동 블라인드 처리됨"), // 신고 접수됨 또는 AI에 의해 임시 숨김
     RESOLVED("제재 확정"),          // 관리자 확인 후 악성 글로 판별됨 (제재 유지)
     REJECTED("오인 신고/반려");       // 관리자 확인 후 정상 글로 판별됨 (제재 해제)
 

--- a/operation-service/src/main/java/com/ojosama/report/domain/repository/ReportRepository.java
+++ b/operation-service/src/main/java/com/ojosama/report/domain/repository/ReportRepository.java
@@ -20,5 +20,5 @@ public interface ReportRepository {
 
     long countByTargetId(UUID targetId);
 
-    long countBlindedTargetByUserId(UUID targetUserId);
+    long countResolvedTargetByUserId(UUID targetUserId);
 }

--- a/operation-service/src/main/java/com/ojosama/report/infrastructure/messaging/kafka/consumer/AiReportEventConsumer.java
+++ b/operation-service/src/main/java/com/ojosama/report/infrastructure/messaging/kafka/consumer/AiReportEventConsumer.java
@@ -5,7 +5,7 @@ import com.ojosama.common.kafka.domain.EventType;
 import com.ojosama.common.kafka.domain.IdempotentEventHandler;
 import com.ojosama.report.application.dto.command.CreateReportCommand;
 import com.ojosama.report.application.service.ReportService;
-import com.ojosama.report.domain.event.payload.AiReportEvent;
+import com.ojosama.report.domain.event.payload.AiReportedEvent;
 import com.ojosama.report.domain.model.enums.ReportCategory;
 import com.ojosama.report.domain.model.enums.TargetType;
 import com.ojosama.report.domain.model.enums.ReporterType;
@@ -34,11 +34,11 @@ public class AiReportEventConsumer {
     @KafkaListener(topics = "${spring.kafka.topic.ai-moderation-reported}", groupId = "operation-service-group")
     public void consumeAiReport(ConsumerRecord<String, String> record) {
         UUID messageKey;
-        AiReportEvent event;
+        AiReportedEvent event;
 
         try {
             messageKey = UUID.fromString(record.key());
-            event = objectMapper.readValue(record.value(), AiReportEvent.class);
+            event = objectMapper.readValue(record.value(), AiReportedEvent.class);
         } catch (Exception e) {
             log.error("AI Report 메시지 파싱 실패. key={}, value={}", record.key(), record.value(), e);
             return;
@@ -54,7 +54,7 @@ public class AiReportEventConsumer {
         );
     }
 
-    private void dispatch(AiReportEvent event){
+    private void dispatch(AiReportedEvent event){
         try {
             if (event == null || event.targetType() == null || event.category() == null) {
                 log.error("AI 신고 이벤트 필수 필드 누락. 처리를 스킵합니다. event: {}", event);

--- a/operation-service/src/main/java/com/ojosama/report/infrastructure/messaging/kafka/producer/ReportEventProducerImpl.java
+++ b/operation-service/src/main/java/com/ojosama/report/infrastructure/messaging/kafka/producer/ReportEventProducerImpl.java
@@ -2,9 +2,8 @@ package com.ojosama.report.infrastructure.messaging.kafka.producer;
 
 import com.ojosama.common.exception.CommonErrorCode;
 import com.ojosama.report.domain.event.ReportEventProducer;
-import com.ojosama.blacklist.domain.event.payload.BlacklistRegisterEvent;
-import com.ojosama.report.domain.event.payload.BlacklistReviewRequestEvent;
-import com.ojosama.report.domain.event.payload.TargetBlindEvent;
+import com.ojosama.report.domain.event.payload.BlacklistReviewRequestedEvent;
+import com.ojosama.report.domain.event.payload.TargetBlindedEvent;
 import com.ojosama.report.domain.exception.ReportException;
 import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
@@ -26,7 +25,7 @@ public class ReportEventProducerImpl implements ReportEventProducer {
     private String blacklistReviewRequestedTopic;
 
     @Override
-    public void publishTargetBlindEvent(TargetBlindEvent event) {
+    public void publishTargetBlindEvent(TargetBlindedEvent event) {
         try {
             kafkaTemplate.send(targetBlindedTopic, event.targetId().toString(), event).get(3, TimeUnit.SECONDS);
             log.info("블라인드 처리 이벤트 발행 성공: targetId={}", event.targetId());
@@ -38,7 +37,7 @@ public class ReportEventProducerImpl implements ReportEventProducer {
 
     // 특정 유저의 게시글이 5번 블라인드 처리되는 순간, 시스템이 자동으로 블랙리스트 등록 검토 알림
     @Override
-    public void publishBlacklistReviewRequestEvent(BlacklistReviewRequestEvent event) {
+    public void publishBlacklistReviewRequestEvent(BlacklistReviewRequestedEvent event) {
         try {
             kafkaTemplate.send(blacklistReviewRequestedTopic, event.targetUserId().toString(), event).get(3, TimeUnit.SECONDS);
             log.info("블랙리스트 검토 요청 이벤트 발행 성공: userId={}", event.targetUserId());

--- a/operation-service/src/main/java/com/ojosama/report/infrastructure/persistence/ReportJpaRepository.java
+++ b/operation-service/src/main/java/com/ojosama/report/infrastructure/persistence/ReportJpaRepository.java
@@ -23,6 +23,6 @@ public interface ReportJpaRepository extends JpaRepository<Report, UUID> {
 
     @Query("SELECT COUNT(DISTINCT r.targetId) FROM Report r " +
             "WHERE r.targetUserId = :targetUserId " +
-            "AND (SELECT COUNT(r2) FROM Report r2 WHERE r2.targetId = r.targetId) >= 3")
-    Long countBlindedTargetByUserId(@Param("targetUserId") UUID targetUserId);
+            "AND r.status = 'RESOLVED'")
+    Long countResolvedTargetByUserId(@Param("targetUserId") UUID targetUserId);
 }

--- a/operation-service/src/main/java/com/ojosama/report/infrastructure/persistence/ReportRepositoryImpl.java
+++ b/operation-service/src/main/java/com/ojosama/report/infrastructure/persistence/ReportRepositoryImpl.java
@@ -46,7 +46,7 @@ public class ReportRepositoryImpl implements ReportRepository {
     };
 
     @Override
-    public long countBlindedTargetByUserId(UUID targetUserId){
-        return reportJpaRepository.countBlindedTargetByUserId(targetUserId);
+    public long countResolvedTargetByUserId(UUID targetUserId){
+        return reportJpaRepository.countResolvedTargetByUserId(targetUserId);
     };
 }

--- a/operation-service/src/main/java/com/ojosama/report/presentation/dto/UpdateReportRequest.java
+++ b/operation-service/src/main/java/com/ojosama/report/presentation/dto/UpdateReportRequest.java
@@ -1,17 +1,18 @@
 package com.ojosama.report.presentation.dto;
 
 import com.ojosama.report.application.dto.command.UpdateReportCommand;
+import com.ojosama.report.domain.model.enums.ReportStatus;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 public record UpdateReportRequest(
         @NotNull(message = "제재 확정 여부를 선택해주세요.")
-        Boolean isResolved,
+        ReportStatus status,
 
         @NotBlank(message = "관리자 처리 사유를 입력해주세요.")
         String operatorMemo
 ) {
     public UpdateReportCommand toCommand() {
-        return new UpdateReportCommand(isResolved, operatorMemo);
+        return new UpdateReportCommand(status, operatorMemo);
     }
 }

--- a/operation-service/src/main/java/com/ojosama/report/presentation/dto/UpdateReportRequest.java
+++ b/operation-service/src/main/java/com/ojosama/report/presentation/dto/UpdateReportRequest.java
@@ -6,7 +6,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 public record UpdateReportRequest(
-        @NotNull(message = "제재 확정 여부를 선택해주세요.")
+        @NotNull(message = "신고 처리 상태를 선택해주세요.")
         ReportStatus status,
 
         @NotBlank(message = "관리자 처리 사유를 입력해주세요.")


### PR DESCRIPTION
## 🔗 Issue Number
- close #168 

## 📝 작업 내역

- 신고 시스템 매니저 검토 프로세스 개선
- 자동 블라인드 후 매니저 검토 단계 추가
- 매니저 확정(RESOLVED)된 블라인드만 블랙리스트 카운트에 포함
- 블라인드 해제 이벤트 추가
- AI 검증 프롬프트 개선
- 일상적 감탄사 오탐 방지
- 문맥 기반 욕설 판별 강화

## 💡 PR 특이사항

- 잘 작동되는지 추후 확인해봐야 합니다!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 신고 거부 시 대상의 블라인드 해제(언블라인드) 발동 추가

* **개선 사항**
  * AI 중재 기준 강화 — 욕설(PROFANITY) 판별 예시 및 중요 판별 기준 추가
  * 신고 상태 체계 개선 — 상태가 보다 명확한 열거형으로 변경되어 처리 흐름이 명확해짐
  * 자동 블라인드 로직 보완 — 자동 블라인드 판단 기준과 블랙리스트 검토 흐름 최적화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->