### PR TITLE
[FEATURE] chat-servcie 블라인드 해제 이벤트, 헤더 기반 필터 적용

### DIFF
--- a/chat-service/src/main/java/com/ojosama/chatservice/application/service/MessageService.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/application/service/MessageService.java
@@ -166,6 +166,13 @@ public class MessageService {
         changeMessageStatus(new ChangeMessageStatusCommand(messageId, SYSTEM_BLINDER_ID, MessageStatus.BLINDED));
     }
 
+    public void unblindMessageBySystem(UUID messageId) {
+        if (messageId == null) {
+            throw new ChatException(CommonErrorCode.INVALID_REQUEST);
+        }
+        changeMessageStatus(new ChangeMessageStatusCommand(messageId, SYSTEM_BLINDER_ID, MessageStatus.ACTIVE));
+    }
+
     @Transactional(readOnly = true)
     public ReportedMessageResult getReportedMessage(UUID messageId) {
         if (messageId == null) {

--- a/chat-service/src/main/java/com/ojosama/chatservice/config/CustomHandshakeHandler.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/config/CustomHandshakeHandler.java
@@ -1,0 +1,28 @@
+package com.ojosama.chatservice.config;
+
+import java.security.Principal;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.WebSocketHandler;
+import org.springframework.web.socket.server.support.DefaultHandshakeHandler;
+
+@Component
+@RequiredArgsConstructor
+public class CustomHandshakeHandler extends DefaultHandshakeHandler {
+
+    @Override
+    protected Principal determineUser(
+            org.springframework.http.server.ServerHttpRequest request,
+            WebSocketHandler wsHandler,
+            Map<String, Object> attributes
+    ) {
+        // CustomHandshakeHandler 가 Principal 생성
+        // MessageWsController는 Principal.getName()으로 userId 사용
+        Object userId = attributes.get(WebSocketAuthInterceptor.ATTR_USER_ID);
+        if (userId == null) {
+            return null;
+        }
+        return () -> userId.toString();
+    }
+}

--- a/chat-service/src/main/java/com/ojosama/chatservice/config/HeaderAuthenticationFilter.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/config/HeaderAuthenticationFilter.java
@@ -1,0 +1,48 @@
+package com.ojosama.chatservice.config;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class HeaderAuthenticationFilter extends OncePerRequestFilter {
+
+    private static final String USER_ID_HEADER = "X-User-Id";
+    private static final String USER_ROLE_HEADER = "X-User-Role";
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+        String userId = request.getHeader(USER_ID_HEADER);
+        String role = request.getHeader(USER_ROLE_HEADER);
+
+        log.debug("HeaderAuthenticationFilter - userId: {}, role: {}", userId, role);
+
+        if (userId != null && !userId.isBlank() && role != null && !role.isBlank()) {
+            UsernamePasswordAuthenticationToken authentication =
+                    new UsernamePasswordAuthenticationToken(
+                            userId.trim(),
+                            null,
+                            List.of(new SimpleGrantedAuthority("ROLE_" + role.trim()))
+                    );
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/chat-service/src/main/java/com/ojosama/chatservice/config/SecurityConfig.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/config/SecurityConfig.java
@@ -5,13 +5,22 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableMethodSecurity
+@EnableWebSecurity
 public class SecurityConfig {
+
+    private final HeaderAuthenticationFilter headerAuthenticationFilter;
+
+    public SecurityConfig(HeaderAuthenticationFilter headerAuthenticationFilter) {
+        this.headerAuthenticationFilter = headerAuthenticationFilter;
+    }
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -28,11 +37,12 @@ public class SecurityConfig {
                         .requestMatchers("/css/**", "/js/**", "/images/**", "/webjars/**").permitAll()
                         .requestMatchers("/ws", "/ws/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/actuator/health").permitAll()
-                        //.requestMatchers("/v1/chat/admin/**").authenticated()
+                        .requestMatchers("/v1/chat/admin/**").authenticated()
                         .requestMatchers("/v1/chat/**").permitAll()
                         .requestMatchers("/internal/v1/chat/**").permitAll()
                         .anyRequest().authenticated()
                 )
+                .addFilterBefore(headerAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
                 .build();
     }
 }

--- a/chat-service/src/main/java/com/ojosama/chatservice/config/WebSocketAuthInterceptor.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/config/WebSocketAuthInterceptor.java
@@ -1,0 +1,65 @@
+package com.ojosama.chatservice.config;
+
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.WebSocketHandler;
+import org.springframework.web.socket.server.HandshakeInterceptor;
+
+@Slf4j
+@Component
+public class WebSocketAuthInterceptor implements HandshakeInterceptor {
+
+    private static final String USER_ID_HEADER = "X-User-Id";
+    private static final String USER_ROLE_HEADER = "X-User-Role";
+    private static final String USER_EMAIL_HEADER = "X-User-Email";
+    private static final String USER_NICKNAME_HEADER = "X-User-Nickname";
+
+    public static final String ATTR_USER_ID = "wsUserId";
+    public static final String ATTR_USER_ROLE = "wsUserRole";
+    public static final String ATTR_USER_EMAIL = "wsUserEmail";
+    public static final String ATTR_USER_NICKNAME = "wsUserNickname";
+
+    @Override
+    public boolean beforeHandshake(
+            ServerHttpRequest request,
+            ServerHttpResponse response,
+            WebSocketHandler wsHandler,
+            Map<String, Object> attributes
+    ) {
+        // handshake 시점에 X-User-Id, X-User-Role 읽기
+        String userId = request.getHeaders().getFirst(USER_ID_HEADER);
+        String role = request.getHeaders().getFirst(USER_ROLE_HEADER);
+        String email = request.getHeaders().getFirst(USER_EMAIL_HEADER);
+        String nickname = request.getHeaders().getFirst(USER_NICKNAME_HEADER);
+
+        if (userId == null || userId.isBlank() || role == null || role.isBlank()) {
+            log.warn("웹소켓 인증 헤더가 누락되어 연결을 거절합니다. userId={}, role={}", userId, role);
+            return false;
+        }
+
+        // WebSocketAuthInterceptor 가 session attributes 에 저장
+        attributes.put(ATTR_USER_ID, userId.trim());
+        attributes.put(ATTR_USER_ROLE, role.trim());
+        if (email != null && !email.isBlank()) {
+            attributes.put(ATTR_USER_EMAIL, email.trim());
+        }
+        if (nickname != null && !nickname.isBlank()) {
+            attributes.put(ATTR_USER_NICKNAME, nickname.trim());
+        }
+
+        return true;
+    }
+
+    @Override
+    public void afterHandshake(
+            ServerHttpRequest request,
+            ServerHttpResponse response,
+            WebSocketHandler wsHandler,
+            Exception exception
+    ) {
+        // noop
+    }
+}

--- a/chat-service/src/main/java/com/ojosama/chatservice/config/WebSocketConfig.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/config/WebSocketConfig.java
@@ -12,19 +12,29 @@ import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerCo
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     private final String[] allowedOriginPatterns;
+    private final WebSocketAuthInterceptor webSocketAuthInterceptor;
+    private final CustomHandshakeHandler customHandshakeHandler;
 
     public WebSocketConfig(
-            @Value("${app.websocket.allowed-origin-patterns:http://localhost:*,http://127.0.0.1:*}") String[] allowedOriginPatterns
+            @Value("${app.websocket.allowed-origin-patterns:http://localhost:*,http://127.0.0.1:*}") String[] allowedOriginPatterns,
+            WebSocketAuthInterceptor webSocketAuthInterceptor,
+            CustomHandshakeHandler customHandshakeHandler
     ) {
         this.allowedOriginPatterns = allowedOriginPatterns;
+        this.webSocketAuthInterceptor = webSocketAuthInterceptor;
+        this.customHandshakeHandler = customHandshakeHandler;
     }
 
     /* 클라이언트가 웹 소켓 서버에 연결하는데 사용할 웹 소켓 엔드포인트 등록
      * /ws: 클라이언트가 최초 연결하는 주소
+     * WebSocket handshake interceptor : X-User-Id, X-User-Role 읽고 session attributes 에 저장
+     * custom handshake handler : 핸드셰이크가 성공할 때 Principal 을 만들어서 연결에 붙여줌
      * */
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         registry.addEndpoint("/ws")
+                .addInterceptors(webSocketAuthInterceptor)
+                .setHandshakeHandler(customHandshakeHandler)
                 .setAllowedOriginPatterns(allowedOriginPatterns)
                 .withSockJS();
     }
@@ -41,4 +51,5 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
         config.setApplicationDestinationPrefixes("/app");
         config.setUserDestinationPrefix("/user");
     }
+
 }

--- a/chat-service/src/main/java/com/ojosama/chatservice/infrastructure/messaging/kafka/consumer/TargetUnblindedConsumer.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/infrastructure/messaging/kafka/consumer/TargetUnblindedConsumer.java
@@ -1,0 +1,97 @@
+package com.ojosama.chatservice.infrastructure.messaging.kafka.consumer;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ojosama.chatservice.application.service.MessageService;
+import com.ojosama.chatservice.domain.exception.ChatException;
+import com.ojosama.chatservice.infrastructure.messaging.kafka.dto.TargetUnblindedEvent;
+import com.ojosama.common.kafka.domain.EventType;
+import com.ojosama.common.kafka.domain.IdempotentEventHandler;
+import java.util.Locale;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.http.HttpStatus;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class TargetUnblindedConsumer {
+
+    private static final String CONSUMER_GROUP = "chat-service-group";
+    private static final String EVENT_TYPE = EventType.REPORT_UNBLINDED.getValue();
+    private static final String TARGET_TYPE_CHAT = "CHAT";
+
+    private final ObjectMapper objectMapper;
+    private final IdempotentEventHandler idempotentHandler;
+    private final MessageService messageService;
+
+    @KafkaListener(
+            topics = "${spring.kafka.topic.report-unblinded}",
+            groupId = CONSUMER_GROUP,
+            containerFactory = "kafkaListenerContainerFactory"
+    )
+    public void onMessage(ConsumerRecord<String, String> record) {
+        UUID messageKey;
+        TargetUnblindedEvent event;
+
+        try {
+            messageKey = UUID.fromString(record.key());
+            event = parse(record.value());
+            idempotentHandler.handle(
+                    messageKey,
+                    CONSUMER_GROUP,
+                    record.topic(),
+                    EVENT_TYPE,
+                    () -> dispatch(event)
+            );
+            log.info("블라인드 해제 이벤트 처리를 완료했습니다. key={}, topic={}, targetType={}, targetId={}, reason={}",
+                    record.key(), record.topic(), event.targetType(), event.targetId(), event.reason());
+        } catch (RuntimeException e) {
+            log.error("블라인드 해제 이벤트 처리에 실패했습니다. key={}, payload={}",
+                    record.key(), record.value(), e);
+            throw e;
+        }
+    }
+
+    private void dispatch(TargetUnblindedEvent event) {
+        if (event.targetId() == null || event.targetType() == null) {
+            log.warn("블라인드 해제 이벤트 필수 필드 누락으로 스킵합니다. event={}", event);
+            return;
+        }
+
+        String normalizedTargetType = event.targetType().trim().toUpperCase(Locale.ROOT);
+        if (!TARGET_TYPE_CHAT.equals(normalizedTargetType)) {
+            log.debug("chat-service 대상이 아닌 블라인드 해제 이벤트라 스킵합니다. targetType={}, targetId={}",
+                    event.targetType(), event.targetId());
+            return;
+        }
+
+        try {
+            messageService.unblindMessageBySystem(event.targetId());
+            if (event.reason() != null && !event.reason().isBlank()) {
+                log.info("메시지 블라인드 해제 완료. targetId={}, reason={}", event.targetId(), event.reason());
+            } else {
+                log.info("메시지 블라인드 해제 완료. targetId={}", event.targetId());
+            }
+        } catch (ChatException e) {
+            if (HttpStatus.NOT_FOUND.equals(e.getStatus()) || HttpStatus.BAD_REQUEST.equals(e.getStatus())) {
+                log.warn("블라인드 해제 대상 메시지를 적용할 수 없어 스킵합니다. targetId={}, status={}, message={}",
+                        event.targetId(), e.getStatus(), e.getMessage());
+                return;
+            }
+            throw e;
+        }
+    }
+
+    private TargetUnblindedEvent parse(String payload) {
+        try {
+            return objectMapper.readValue(payload, TargetUnblindedEvent.class);
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException("블라인드 해제 이벤트 페이로드 파싱에 실패했습니다.", e);
+        }
+    }
+}

--- a/chat-service/src/main/java/com/ojosama/chatservice/infrastructure/messaging/kafka/consumer/TargetUnblindedConsumer.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/infrastructure/messaging/kafka/consumer/TargetUnblindedConsumer.java
@@ -51,8 +51,11 @@ public class TargetUnblindedConsumer {
             log.info("블라인드 해제 이벤트 처리를 완료했습니다. key={}, topic={}, targetType={}, targetId={}, reason={}",
                     record.key(), record.topic(), event.targetType(), event.targetId(), event.reason());
         } catch (RuntimeException e) {
-            log.error("블라인드 해제 이벤트 처리에 실패했습니다. key={}, payload={}",
-                    record.key(), record.value(), e);
+            log.error("블라인드 해제 이벤트 처리에 실패했습니다. key={}, topic={}, payloadLength={}",
+                    record.key(),
+                    record.topic(),
+                    record.value() == null ? 0 : record.value().length(),
+                    e);
             throw e;
         }
     }

--- a/chat-service/src/main/java/com/ojosama/chatservice/infrastructure/messaging/kafka/dto/TargetUnblindedEvent.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/infrastructure/messaging/kafka/dto/TargetUnblindedEvent.java
@@ -1,0 +1,12 @@
+package com.ojosama.chatservice.infrastructure.messaging.kafka.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.UUID;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record TargetUnblindedEvent(
+        UUID targetId,
+        String targetType,
+        String reason
+) {
+}

--- a/chat-service/src/main/java/com/ojosama/chatservice/presentation/controller/AdminChatRoomController.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/presentation/controller/AdminChatRoomController.java
@@ -1,0 +1,73 @@
+package com.ojosama.chatservice.presentation.controller;
+
+import com.ojosama.chatservice.application.dto.command.ChangeChatRoomStatusCommand;
+import com.ojosama.chatservice.application.dto.command.ChatRoomStatusAction;
+import com.ojosama.chatservice.application.dto.command.CreateChatRoomCommand;
+import com.ojosama.chatservice.application.dto.result.ChatRoomResult;
+import com.ojosama.chatservice.application.service.ChatRoomService;
+import com.ojosama.chatservice.presentation.dto.request.ChangeChatRoomStatusRequest;
+import com.ojosama.chatservice.presentation.dto.request.ChatRoomStatusActionRequest;
+import com.ojosama.chatservice.presentation.dto.request.CreateChatRoomRequest;
+import com.ojosama.chatservice.presentation.dto.response.ChatRoomResponse;
+import com.ojosama.common.response.ApiResponse;
+import jakarta.validation.Valid;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/chat/admin/rooms")
+@PreAuthorize("hasAnyRole('ADMIN', 'CONCERT_MANAGER', 'FESTIVAL_MANAGER', 'FANMEETING_MANAGER', 'POPUP_MANAGER')")
+public class AdminChatRoomController {
+
+    private final ChatRoomService chatRoomService;
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<ChatRoomResponse>> createChatRoom(
+            @Valid @RequestBody CreateChatRoomRequest request
+    ) {
+        ChatRoomResult result = chatRoomService.createChatRoom(
+                new CreateChatRoomCommand(
+                        request.eventId(),
+                        request.eventName(),
+                        request.category(),
+                        request.scheduledOpenAt(),
+                        request.scheduledCloseAt()
+                )
+        );
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.created(ChatRoomResponse.from(result)));
+    }
+
+    @PatchMapping("/{chatRoomId}/status")
+    public ResponseEntity<ApiResponse<ChatRoomResponse>> changeChatRoomStatus(
+            @PathVariable UUID chatRoomId,
+            @AuthenticationPrincipal String adminId,
+            @Valid @RequestBody ChangeChatRoomStatusRequest request
+    ) {
+        ChatRoomResult result = chatRoomService.changeChatRoomStatus(
+                new ChangeChatRoomStatusCommand(
+                        chatRoomId,
+                        toAction(request.action()),
+                        UUID.fromString(adminId)
+                )
+        );
+        return ResponseEntity.ok(ApiResponse.success(ChatRoomResponse.from(result)));
+    }
+
+    private ChatRoomStatusAction toAction(ChatRoomStatusActionRequest action) {
+        return switch (action) {
+            case FORCE_OPEN -> ChatRoomStatusAction.FORCE_OPEN;
+            case FORCE_CLOSE -> ChatRoomStatusAction.FORCE_CLOSE;
+        };
+    }
+}

--- a/chat-service/src/main/java/com/ojosama/chatservice/presentation/controller/AdminMessageController.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/presentation/controller/AdminMessageController.java
@@ -49,7 +49,7 @@ public class AdminMessageController {
         return ResponseEntity.ok(ApiResponse.success(MessageSliceResponse.from(result, false)));
     }
 
-    @GetMapping("/messages/{messageId}")
+    @GetMapping("/{messageId}")
     public ResponseEntity<ApiResponse<MessageResponse>> getMessage(@PathVariable UUID messageId) {
         MessageResult result = messageService.getMessage(new FindMessageQuery(messageId));
         return ResponseEntity.ok(ApiResponse.success(MessageResponse.from(result)));

--- a/chat-service/src/main/java/com/ojosama/chatservice/presentation/controller/AdminMessageController.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/presentation/controller/AdminMessageController.java
@@ -1,15 +1,29 @@
 package com.ojosama.chatservice.presentation.controller;
 
+import com.ojosama.chatservice.application.dto.command.ChangeMessageStatusCommand;
 import com.ojosama.chatservice.application.dto.query.FindAdminMessagesQuery;
+import com.ojosama.chatservice.application.dto.query.FindMessageQuery;
+import com.ojosama.chatservice.application.dto.result.MessageResult;
 import com.ojosama.chatservice.application.dto.result.MessageSliceResult;
 import com.ojosama.chatservice.application.service.MessageService;
 import com.ojosama.chatservice.domain.model.EventCategory;
 import com.ojosama.chatservice.domain.model.MessageStatus;
+import com.ojosama.chatservice.presentation.dto.request.ChangeMessageStatusActionRequest;
+import com.ojosama.chatservice.presentation.dto.request.ChangeMessageStatusRequest;
+import com.ojosama.chatservice.presentation.dto.response.ChangeMessageStatusResponse;
+import com.ojosama.chatservice.presentation.dto.response.MessageResponse;
 import com.ojosama.chatservice.presentation.dto.response.MessageSliceResponse;
 import com.ojosama.common.response.ApiResponse;
+import jakarta.validation.Valid;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -17,12 +31,12 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/v1/chat/admin/messages")
+@PreAuthorize("hasAnyRole('ADMIN', 'CONCERT_MANAGER', 'FESTIVAL_MANAGER', 'FANMEETING_MANAGER', 'POPUP_MANAGER')")
 public class AdminMessageController {
 
     private final MessageService messageService;
 
     @GetMapping
-    //@PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<ApiResponse<MessageSliceResponse>> getMessagesForAdmin(
             @RequestParam(required = false) MessageStatus status,
             @RequestParam(required = false) EventCategory category,
@@ -33,5 +47,32 @@ public class AdminMessageController {
                 new FindAdminMessagesQuery(status, category, page, size)
         );
         return ResponseEntity.ok(ApiResponse.success(MessageSliceResponse.from(result, false)));
+    }
+
+    @GetMapping("/messages/{messageId}")
+    public ResponseEntity<ApiResponse<MessageResponse>> getMessage(@PathVariable UUID messageId) {
+        MessageResult result = messageService.getMessage(new FindMessageQuery(messageId));
+        return ResponseEntity.ok(ApiResponse.success(MessageResponse.from(result)));
+    }
+
+    @PatchMapping("/{messageId}/status")
+    public ResponseEntity<ApiResponse<ChangeMessageStatusResponse>> changeMessageStatus(
+            @PathVariable UUID messageId,
+            @AuthenticationPrincipal String adminId,
+            @Valid @RequestBody ChangeMessageStatusRequest request
+    ) {
+        MessageStatus status = toMessageStatus(request.status());
+        MessageResult result = messageService.changeMessageStatus(
+                new ChangeMessageStatusCommand(messageId, UUID.fromString(adminId), status)
+        );
+        return ResponseEntity.ok(
+                ApiResponse.success(ChangeMessageStatusResponse.from(result, UUID.fromString(adminId))));
+    }
+
+    private MessageStatus toMessageStatus(ChangeMessageStatusActionRequest status) {
+        return switch (status) {
+            case ACTIVE -> MessageStatus.ACTIVE;
+            case BLINDED -> MessageStatus.BLINDED;
+        };
     }
 }

--- a/chat-service/src/main/java/com/ojosama/chatservice/presentation/controller/ChatRoomController.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/presentation/controller/ChatRoomController.java
@@ -1,28 +1,16 @@
 package com.ojosama.chatservice.presentation.controller;
 
-import com.ojosama.chatservice.application.dto.command.ChangeChatRoomStatusCommand;
-import com.ojosama.chatservice.application.dto.command.ChatRoomStatusAction;
-import com.ojosama.chatservice.application.dto.command.CreateChatRoomCommand;
 import com.ojosama.chatservice.application.dto.query.FindChatRoomByEventIdQuery;
 import com.ojosama.chatservice.application.dto.query.FindChatRoomQuery;
 import com.ojosama.chatservice.application.dto.result.ChatRoomResult;
 import com.ojosama.chatservice.application.service.ChatRoomService;
-import com.ojosama.chatservice.presentation.dto.request.ChangeChatRoomStatusRequest;
-import com.ojosama.chatservice.presentation.dto.request.ChatRoomStatusActionRequest;
-import com.ojosama.chatservice.presentation.dto.request.CreateChatRoomRequest;
 import com.ojosama.chatservice.presentation.dto.response.ChatRoomResponse;
 import com.ojosama.common.response.ApiResponse;
-import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -34,36 +22,8 @@ public class ChatRoomController {
 
     private final ChatRoomService chatRoomService;
 
-    // 관리자의 채팅방 강제 생성
-    @PostMapping
-    public ResponseEntity<ApiResponse<ChatRoomResponse>> createChatRoom(
-            // TODO: 추후 인증/인가 추가
-            //  - 매니저/관리자만 ChatRoom 생성 가능
-            //  - @PreAuthorize("hasAnyRole('ADMIN', 'FESTIVAL_MANAGER','CONCERT_MANAGER','FANMETTING_MANAGER','POPUPSTORE_MANAGER',)")
-            //  - @AuthenticationPrincipal String adminId,
-            //  - @RequestHeader(value = "X-User-Role", required = true) String role,
-            @RequestHeader("X-User-Id") UUID adminId,
-            @Valid @RequestBody CreateChatRoomRequest request
-    ) {
-        ChatRoomResult result = chatRoomService.createChatRoom(
-                new CreateChatRoomCommand(
-                        request.eventId(),
-                        request.eventName(),
-                        request.category(),
-                        request.scheduledOpenAt(),
-                        request.scheduledCloseAt()
-                )
-        );
-        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.created(ChatRoomResponse.from(result)));
-    }
-
     @GetMapping("/{chatRoomId}")
     public ResponseEntity<ApiResponse<ChatRoomResponse>> getChatRoom(
-            // TODO: 추후 인증/인가 추가
-            //  - 매니저/관리자의 ChatRoomId로 채팅방 상세 조회
-            //  - @PreAuthorize("hasAnyRole('ADMIN', 'FESTIVAL_MANAGER','CONCERT_MANAGER','FANMETTING_MANAGER','POPUPSTORE_MANAGER',)")
-            //  - @AuthenticationPrincipal String adminId,
-            //  - @RequestHeader(value = "X-User-Role", required = true) String role,
             @PathVariable UUID chatRoomId
     ) {
         ChatRoomResult result = chatRoomService.getChatRoom(new FindChatRoomQuery(chatRoomId));
@@ -76,33 +36,5 @@ public class ChatRoomController {
     ) {
         ChatRoomResult result = chatRoomService.getChatRoomByEventId(new FindChatRoomByEventIdQuery(eventId));
         return ResponseEntity.ok(ApiResponse.success(ChatRoomResponse.from(result)));
-    }
-
-    @PatchMapping("/{chatRoomId}/status")
-    public ResponseEntity<ApiResponse<ChatRoomResponse>> changeChatRoomStatus(
-            // TODO: 추후 인증/인가 추가
-            //  - 매니저/관리자만 채팅방 상태 변경 가능
-            //  - @PreAuthorize("hasAnyRole('ADMIN', 'FESTIVAL_MANAGER','CONCERT_MANAGER','FANMETTING_MANAGER','POPUPSTORE_MANAGER',)")
-            //  - @AuthenticationPrincipal String adminId,
-            //  - @RequestHeader(value = "X-User-Role", required = true) String role,
-            @RequestHeader("X-User-Id") UUID adminId,
-            @PathVariable UUID chatRoomId,
-            @Valid @RequestBody ChangeChatRoomStatusRequest request
-    ) {
-        ChatRoomResult result = chatRoomService.changeChatRoomStatus(
-                new ChangeChatRoomStatusCommand(
-                        chatRoomId,
-                        toAction(request.action()),
-                        adminId
-                )
-        );
-        return ResponseEntity.ok(ApiResponse.success(ChatRoomResponse.from(result)));
-    }
-
-    private ChatRoomStatusAction toAction(ChatRoomStatusActionRequest action) {
-        return switch (action) {
-            case FORCE_OPEN -> ChatRoomStatusAction.FORCE_OPEN;
-            case FORCE_CLOSE -> ChatRoomStatusAction.FORCE_CLOSE;
-        };
     }
 }

--- a/chat-service/src/main/java/com/ojosama/chatservice/presentation/controller/MessageController.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/presentation/controller/MessageController.java
@@ -1,18 +1,12 @@
 package com.ojosama.chatservice.presentation.controller;
 
-import com.ojosama.chatservice.application.dto.command.ChangeMessageStatusCommand;
 import com.ojosama.chatservice.application.dto.command.CreateMessageCommand;
 import com.ojosama.chatservice.application.dto.command.DeleteMessageCommand;
-import com.ojosama.chatservice.application.dto.query.FindMessageQuery;
 import com.ojosama.chatservice.application.dto.query.FindMessagesByChatRoomQuery;
 import com.ojosama.chatservice.application.dto.result.MessageResult;
 import com.ojosama.chatservice.application.dto.result.MessageSliceResult;
 import com.ojosama.chatservice.application.service.MessageService;
-import com.ojosama.chatservice.domain.model.MessageStatus;
-import com.ojosama.chatservice.presentation.dto.request.ChangeMessageStatusActionRequest;
-import com.ojosama.chatservice.presentation.dto.request.ChangeMessageStatusRequest;
 import com.ojosama.chatservice.presentation.dto.request.CreateMessageRequest;
-import com.ojosama.chatservice.presentation.dto.response.ChangeMessageStatusResponse;
 import com.ojosama.chatservice.presentation.dto.response.MessageResponse;
 import com.ojosama.chatservice.presentation.dto.response.MessageSliceResponse;
 import com.ojosama.common.response.ApiResponse;
@@ -21,13 +15,13 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -40,22 +34,17 @@ public class MessageController {
     private final MessageService messageService;
 
     @PostMapping("/rooms/{chatRoomId}/messages")
+    @PreAuthorize("isAuthenticated()")
     public ResponseEntity<ApiResponse<MessageResponse>> createMessage(
             @PathVariable UUID chatRoomId,
-            @RequestHeader("X-User-Id") UUID userId,
+            @AuthenticationPrincipal String userId,
             @Valid @RequestBody CreateMessageRequest request
     ) {
         MessageResult result = messageService.createMessage(
-                new CreateMessageCommand(chatRoomId, userId, request.content())
+                new CreateMessageCommand(chatRoomId, UUID.fromString(userId), request.content())
         );
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(ApiResponse.created(MessageResponse.from(result)));
-    }
-
-    @GetMapping("/messages/{messageId}")
-    public ResponseEntity<ApiResponse<MessageResponse>> getMessage(@PathVariable UUID messageId) {
-        MessageResult result = messageService.getMessage(new FindMessageQuery(messageId));
-        return ResponseEntity.ok(ApiResponse.success(MessageResponse.from(result)));
     }
 
     @GetMapping("/rooms/{chatRoomId}/messages")
@@ -71,31 +60,12 @@ public class MessageController {
     }
 
     @DeleteMapping("/messages/{messageId}")
+    @PreAuthorize("isAuthenticated()")
     public ResponseEntity<ApiResponse<Void>> deleteMessage(
             @PathVariable UUID messageId,
-            @RequestHeader("X-User-Id") UUID userId
+            @AuthenticationPrincipal String userId
     ) {
-        messageService.deleteMessage(new DeleteMessageCommand(messageId, userId));
+        messageService.deleteMessage(new DeleteMessageCommand(messageId, UUID.fromString(userId)));
         return ResponseEntity.ok(ApiResponse.deleted());
-    }
-
-    @PatchMapping("/messages/{messageId}/status")
-    public ResponseEntity<ApiResponse<ChangeMessageStatusResponse>> changeMessageStatus(
-            @PathVariable UUID messageId,
-            @RequestHeader("X-User-Id") UUID adminId,
-            @Valid @RequestBody ChangeMessageStatusRequest request
-    ) {
-        MessageStatus status = toMessageStatus(request.status());
-        MessageResult result = messageService.changeMessageStatus(
-                new ChangeMessageStatusCommand(messageId, adminId, status)
-        );
-        return ResponseEntity.ok(ApiResponse.success(ChangeMessageStatusResponse.from(result, adminId)));
-    }
-
-    private MessageStatus toMessageStatus(ChangeMessageStatusActionRequest status) {
-        return switch (status) {
-            case ACTIVE -> MessageStatus.ACTIVE;
-            case BLINDED -> MessageStatus.BLINDED;
-        };
     }
 }

--- a/chat-service/src/main/java/com/ojosama/chatservice/presentation/controller/MessageWsController.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/presentation/controller/MessageWsController.java
@@ -9,6 +9,8 @@ import com.ojosama.chatservice.presentation.dto.response.MessageWsResponse;
 import com.ojosama.chatservice.presentation.dto.response.WebSocketErrorResponse;
 import com.ojosama.common.exception.CommonErrorCode;
 import jakarta.validation.Valid;
+import java.security.Principal;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.handler.annotation.MessageExceptionHandler;
@@ -30,11 +32,15 @@ public class MessageWsController {
     private final SimpMessagingTemplate messagingTemplate;
 
     @MessageMapping("/chat.send")
-    public void sendMessage(@Valid SendMessageWsRequest request) {
+    public void sendMessage(@Valid SendMessageWsRequest request, Principal principal) {
+        if (principal == null || principal.getName() == null || principal.getName().isBlank()) {
+            throw new ChatException(CommonErrorCode.INVALID_REQUEST);
+        }
+        UUID userId = UUID.fromString(principal.getName());
         MessageResult result = messageService.createMessage(
                 new CreateMessageCommand(
                         request.chatRoomId(),
-                        request.userId(),
+                        userId,
                         request.content()
                 )
         );

--- a/chat-service/src/main/java/com/ojosama/chatservice/presentation/dto/request/SendMessageWsRequest.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/presentation/dto/request/SendMessageWsRequest.java
@@ -6,7 +6,6 @@ import java.util.UUID;
 
 public record SendMessageWsRequest(
         @NotNull UUID chatRoomId,
-        @NotNull UUID userId,
         @NotBlank String content
 ) {
 }

--- a/chat-service/src/test/resources/application.yml
+++ b/chat-service/src/test/resources/application.yml
@@ -9,6 +9,7 @@ spring:
       event-created: event.info.created.v1
       event-changed: event.schedule.changed.v1
       report-blinded: operation.report.blinded.v1
+      report-unblinded: operation.report.unblinded.v1
       chat-moderation-requested: chat.moderation.requested.v1
   datasource:
     url: jdbc:h2:mem:testdb;INIT=CREATE SCHEMA IF NOT EXISTS chat_schema

--- a/common/src/main/java/com/ojosama/common/kafka/domain/EventType.java
+++ b/common/src/main/java/com/ojosama/common/kafka/domain/EventType.java
@@ -18,7 +18,7 @@ public enum EventType {
     COMMENT_UPDATED("CommentUpdated"),
     POST_REPORTED("PostReported"),
     COMMENT_REPORTED("CommentReported"),
-    
+
     // event
     EVENT_CREATED("EventCreated"),
     EVENT_DELETED("EventDeleted"),
@@ -36,6 +36,7 @@ public enum EventType {
 
     // operation
     REPORT_BLINDED("ReportBlinded"),
+    REPORT_UNBLINDED("ReportUnblinded"),
     BLACKLIST_REGISTERED("BlacklistRegistered"),
     BLACKLIST_UPDATED("BlacklistUpdated"),
     BLACKLIST_REVIEW_REQUESTED("BlacklistReviewRequested"),


### PR DESCRIPTION
## 🔗 Issue Number
- close #170 
- close #107 

## 📝 작업 내역
요약

채팅 서비스의 블라인드 해제 이벤트 처리
- operation.report.unblinded.v1 이벤트를 수신
- chat-service에서 CHAT 대상만 블라인드 해제하도록 연결

인증/인가 전환을 위한 보안 필터 및 컨트롤러 분리를 진행
- Controller를 관리자/사용자 API를 역할에 맞게 분리
- @PreAuthorize 기반 권한 제어가 가능하도록 구조를 정리
- [x] HeaderAuthenticationFilter 추가
- [x] X-User-Id, X-User-Role 헤더를 읽어서 SecurityContext 세팅
- [x] 사용자용/관리자용 컨트롤러에 @PreAuthorize 적용
- [x] @AuthenticationPrincipal로 사용자 식별값을 받도록 전환

추가 + ws에서도 userId 클라이언트에서 받는걸 제거하고 헤더 또는 연결시점 정보로 변경

## 💡 PR 특이사항 또는 포인트

- HeaderAuthenticationFilter가 gateway 헤더만 신뢰하는 구조라서,
gateway 우회 접근이 불가능한지 배포 환경에서도 확인이 필요. 
( 클라이언트 -> gateway -> 서비스 )흐름이어야지만 가능
- reason은 현재 로그 중심 처리인데, 추후 감사 로그나 DB 저장이 필요하면 별도 이력 테이블로 확장은 가능


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 관리자용 메시지 및 채팅방 관리 엔드포인트 추가
  * 메시지 언블라인드 기능 추가

* **개선 사항**
  * 헤더 기반 인증 시스템 도입으로 보안 강화
  * 역할 기반 접근 제어(RBAC) 구현
  * 메시지 및 채팅방 상태 변경 작업을 관리자 전용 엔드포인트로 이관

* **변경 사항**
  * 사용자 인증 방식 업데이트로 API 보안성 향상

<!-- end of auto-generated comment: release notes by coderabbit.ai -->