### PR TITLE
167 fix user service 공통 응답 예외 처리

### DIFF
--- a/user-service/src/main/java/com/ojosama/userservice/application/service/AuthService.java
+++ b/user-service/src/main/java/com/ojosama/userservice/application/service/AuthService.java
@@ -4,6 +4,8 @@ import com.ojosama.userservice.application.dto.command.LoginCommand;
 import com.ojosama.userservice.application.dto.command.ReissueTokenCommand;
 import com.ojosama.userservice.application.dto.result.LoginResult;
 import com.ojosama.userservice.application.dto.result.LogoutResult;
+import com.ojosama.userservice.domain.exception.UserErrorCode;
+import com.ojosama.userservice.domain.exception.UserException;
 import com.ojosama.userservice.domain.model.User;
 import com.ojosama.userservice.domain.model.UserStatus;
 import com.ojosama.userservice.domain.repository.UserRepository;
@@ -28,10 +30,10 @@ public class AuthService {
     @Transactional
     public LoginResult login(LoginCommand command) {
         User user = userRepository.findByEmailAndDeletedAtIsNull(command.email())
-                .orElseThrow(() -> new IllegalArgumentException("이메일 혹은 비밀번호가 올바르지 않습니다."));
+                .orElseThrow(() -> new UserException(UserErrorCode.INVALID_LOGIN_INFO));
 
         if (!passwordEncoder.matches(command.password(), user.getPassword())) {
-            throw new IllegalArgumentException("이메일 혹은 비밀번호가 올바르지 않습니다.");
+            throw new UserException(UserErrorCode.INVALID_LOGIN_INFO);
         }
 
         validateActiveUser(user);
@@ -56,13 +58,13 @@ public class AuthService {
 
         if (!jwtTokenProvider.validateToken(refreshToken)
                 || !jwtTokenProvider.isRefreshToken(refreshToken)) {
-            throw new IllegalArgumentException("유효하지 않은 Refresh Token입니다.");
+            throw new UserException(UserErrorCode.INVALID_REFRESH_TOKEN);
         }
 
         UUID userId = jwtTokenProvider.getUserId(refreshToken);
 
         User user = userRepository.findByIdAndDeletedAtIsNull(userId)
-                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
 
         validateActiveUser(user);
 
@@ -79,7 +81,7 @@ public class AuthService {
         );
 
         if (updatedCount != 1) {
-            throw new IllegalArgumentException("Refresh Token이 일치하지 않습니다.");
+            throw new UserException(UserErrorCode.REFRESH_TOKEN_MISMATCH);
         }
 
         return new LoginResult(
@@ -92,7 +94,7 @@ public class AuthService {
     @Transactional
     public LogoutResult logout(UUID userId) {
         User user = userRepository.findByIdAndDeletedAtIsNull(userId)
-                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
 
         user.clearRefreshTokenHash();
 
@@ -101,7 +103,7 @@ public class AuthService {
 
     private void validateActiveUser(User user) {
         if (user.getStatus() == UserStatus.BLOCKED) {
-            throw new IllegalArgumentException("Blocked user cannot login.");
+            throw new UserException(UserErrorCode.BLOCKED_USER);
         }
     }
 }

--- a/user-service/src/main/java/com/ojosama/userservice/application/service/UserAdminService.java
+++ b/user-service/src/main/java/com/ojosama/userservice/application/service/UserAdminService.java
@@ -6,6 +6,8 @@ import com.ojosama.userservice.application.dto.query.AdminUserListQuery;
 import com.ojosama.userservice.application.dto.result.AdminChangeUserRoleResult;
 import com.ojosama.userservice.application.dto.result.AdminUserDetailResult;
 import com.ojosama.userservice.application.dto.result.AdminUserListResult;
+import com.ojosama.userservice.domain.exception.UserErrorCode;
+import com.ojosama.userservice.domain.exception.UserException;
 import com.ojosama.userservice.domain.model.User;
 import com.ojosama.userservice.domain.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -31,7 +33,7 @@ public class UserAdminService {
     @Transactional(readOnly = true)
     public AdminUserDetailResult getDetailUser(AdminDetailUserQuery query) {
         User user = userRepository.findByIdAndDeletedAtIsNull(query.userId())
-                .orElseThrow(() -> new IllegalArgumentException("유저를 찾을 수 없습니다."));
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
 
         return new AdminUserDetailResult(
                 user.getId(),
@@ -48,7 +50,7 @@ public class UserAdminService {
     @Transactional
     public AdminChangeUserRoleResult changeUserRole(AdminChangeUserRoleCommand command) {
         User user = userRepository.findByIdAndDeletedAtIsNull(command.userId())
-                .orElseThrow(() -> new IllegalArgumentException("유저를 찾을 수 없습니다."));
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
 
         user.changeRole(command.role());
 

--- a/user-service/src/main/java/com/ojosama/userservice/application/service/UserService.java
+++ b/user-service/src/main/java/com/ojosama/userservice/application/service/UserService.java
@@ -12,6 +12,8 @@ import com.ojosama.userservice.application.dto.result.GetCategoryManagerIdResult
 import com.ojosama.userservice.application.dto.result.GetUserResult;
 import com.ojosama.userservice.application.dto.result.InternalUserEmailResult;
 import com.ojosama.userservice.application.dto.result.UpdateUserResult;
+import com.ojosama.userservice.domain.exception.UserErrorCode;
+import com.ojosama.userservice.domain.exception.UserException;
 import com.ojosama.userservice.domain.model.Category;
 import com.ojosama.userservice.domain.model.User;
 import com.ojosama.userservice.domain.model.UserRole;
@@ -39,11 +41,11 @@ public class UserService {
     @Transactional
     public CreateUserResult createUser(CreateUserCommand command) {
         if (userRepository.existsByEmailAndDeletedAtIsNull(command.email())) {
-            throw new IllegalArgumentException("이미 사용 중인 이메일입니다.");
+            throw new UserException(UserErrorCode.DUPLICATE_EMAIL);
         }
 
         if (userRepository.existsByNicknameAndDeletedAtIsNull(command.nickname())) {
-            throw new IllegalArgumentException("이미 사용 중인 닉네임입니다.");
+            throw new UserException(UserErrorCode.DUPLICATE_NICKNAME);
         }
 
         String encodedPassword = passwordEncoder.encode(command.password());
@@ -68,11 +70,11 @@ public class UserService {
             );
         } catch (DataIntegrityViolationException e) {
             if (isEmailUniqueViolation(e)) {
-                throw new IllegalArgumentException("중복 이메일입니다.", e);
+                throw new UserException(UserErrorCode.DUPLICATE_EMAIL);
             }
 
             if (isNicknameUniqueViolation(e)) {
-                throw new IllegalArgumentException("중복 닉네임입니다.", e);
+                throw new UserException(UserErrorCode.DUPLICATE_NICKNAME);
             }
 
             throw e;
@@ -84,7 +86,7 @@ public class UserService {
     public GetUserResult getUser(GetUserQuery query) {
         User user = userRepository.findByIdAndDeletedAtIsNull(query.userId())
                 //todo 임시 오류 처리
-                .orElseThrow(() -> new IllegalArgumentException("회원을 찾을 수 없습니다"));
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
 
         return new GetUserResult(
                 user.getId(),
@@ -102,10 +104,10 @@ public class UserService {
     @Transactional
     public UpdateUserResult updateUser(UpdateUserCommand command) {
         User savedUser = userRepository.findByIdAndDeletedAtIsNull(command.userId())
-                .orElseThrow(() -> new IllegalArgumentException("회원을 찾을 수 없습니다."));
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
 
         if (userRepository.existsByNicknameAndIdNotAndDeletedAtIsNull(command.nickname(), command.userId())) {
-            throw new IllegalArgumentException("중복 닉네임입니다.");
+            throw new UserException(UserErrorCode.DUPLICATE_NICKNAME);
         }
 
         savedUser.update(
@@ -128,7 +130,7 @@ public class UserService {
     @Transactional
     public void deleteUser(DeleteUserCommand command) {
         User user = userRepository.findByIdAndDeletedAtIsNull(command.userId())
-                .orElseThrow(() -> new IllegalArgumentException("유저를 찾을 수 없습니다."));
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
 
         user.deleted(user.getId());
     }
@@ -157,7 +159,7 @@ public class UserService {
     @Transactional(readOnly = true)
     public InternalUserEmailResult getInternalUserEmail(GetInternalUserEmailQuery query) {
         User user = userRepository.findByIdAndDeletedAtIsNull(query.userId())
-                .orElseThrow(() -> new IllegalArgumentException("회원을 찾을 수 없습니다."));
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
 
         return new InternalUserEmailResult(
                 user.getId(),
@@ -179,7 +181,7 @@ public class UserService {
     @Transactional(readOnly = true)
     public GetAdminIdResult getInternalAdminId() {
         User admin = userRepository.findFirstByRoleAndDeletedAtIsNull(UserRole.ADMIN)
-                .orElseThrow(() -> new IllegalArgumentException("시스템 관리자를 찾을 수 없습니다."));
+                .orElseThrow(() -> new UserException(UserErrorCode.ADMIN_NOT_FOUND));
 
         return new GetAdminIdResult(admin.getId());
     }
@@ -189,7 +191,7 @@ public class UserService {
         UserRole managerRole = Category.from(query.category()).getManagerRole();
 
         User manager = userRepository.findFirstByRoleAndDeletedAtIsNull(managerRole)
-                .orElseThrow(() -> new IllegalArgumentException("해당 카테고리 담당자를 찾을 수 없습니다."));
+                .orElseThrow(() -> new UserException(UserErrorCode.CATEGORY_MANAGER_NOT_FOUND));
 
         return new GetCategoryManagerIdResult(manager.getId());
     }
@@ -198,7 +200,7 @@ public class UserService {
     @Transactional(readOnly = true)
     public String getInternalUserNickname(UUID userId) {
         User user = userRepository.findByIdAndDeletedAtIsNull(userId)
-                .orElseThrow(() -> new IllegalArgumentException("회원을 찾을 수 없습니다."));
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
 
         return user.getNickname();
     }

--- a/user-service/src/main/java/com/ojosama/userservice/domain/exception/UserErrorCode.java
+++ b/user-service/src/main/java/com/ojosama/userservice/domain/exception/UserErrorCode.java
@@ -20,6 +20,7 @@ public enum UserErrorCode implements ErrorCode {
     REFRESH_TOKEN_HASH_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "Refresh Token 해시 생성에 실패했습니다."),
 
 
+    INVALID_BLACKLIST_STATUS(HttpStatus.BAD_REQUEST, "알 수 없는 블랙리스트 상태입니다."),
     BLOCKED_USER(HttpStatus.FORBIDDEN, "차단된 사용자는 로그인할 수 없습니다."),
     INVALID_CATEGORY(HttpStatus.BAD_REQUEST, "존재하지 않는 카테고리입니다.");
 

--- a/user-service/src/main/java/com/ojosama/userservice/domain/exception/UserErrorCode.java
+++ b/user-service/src/main/java/com/ojosama/userservice/domain/exception/UserErrorCode.java
@@ -17,6 +17,8 @@ public enum UserErrorCode implements ErrorCode {
     INVALID_LOGIN_INFO(HttpStatus.BAD_REQUEST, "이메일 혹은 비밀번호가 올바르지 않습니다."),
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 Refresh Token입니다."),
     REFRESH_TOKEN_MISMATCH(HttpStatus.UNAUTHORIZED, "Refresh Token이 일치하지 않습니다."),
+    REFRESH_TOKEN_HASH_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "Refresh Token 해시 생성에 실패했습니다."),
+
 
     BLOCKED_USER(HttpStatus.FORBIDDEN, "차단된 사용자는 로그인할 수 없습니다."),
     INVALID_CATEGORY(HttpStatus.BAD_REQUEST, "존재하지 않는 카테고리입니다.");

--- a/user-service/src/main/java/com/ojosama/userservice/domain/exception/UserErrorCode.java
+++ b/user-service/src/main/java/com/ojosama/userservice/domain/exception/UserErrorCode.java
@@ -1,0 +1,36 @@
+package com.ojosama.userservice.domain.exception;
+
+import com.ojosama.common.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum UserErrorCode implements ErrorCode {
+
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "회원을 찾을 수 없습니다."),
+    ADMIN_NOT_FOUND(HttpStatus.NOT_FOUND, "시스템 관리자를 찾을 수 없습니다."),
+    CATEGORY_MANAGER_NOT_FOUND(HttpStatus.NOT_FOUND, "카테고리 담당자를 찾을 수 없습니다."),
+
+    DUPLICATE_EMAIL(HttpStatus.CONFLICT, "이미 사용 중인 이메일입니다."),
+    DUPLICATE_NICKNAME(HttpStatus.CONFLICT, "이미 사용 중인 닉네임입니다."),
+
+    INVALID_LOGIN_INFO(HttpStatus.BAD_REQUEST, "이메일 혹은 비밀번호가 올바르지 않습니다."),
+    INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 Refresh Token입니다."),
+    REFRESH_TOKEN_MISMATCH(HttpStatus.UNAUTHORIZED, "Refresh Token이 일치하지 않습니다."),
+
+    BLOCKED_USER(HttpStatus.FORBIDDEN, "차단된 사용자는 로그인할 수 없습니다."),
+    INVALID_CATEGORY(HttpStatus.BAD_REQUEST, "존재하지 않는 카테고리입니다.");
+
+    private final HttpStatus status;
+    private final String message;
+
+    @Override
+    public HttpStatus getStatus() {
+        return status;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/user-service/src/main/java/com/ojosama/userservice/domain/exception/UserException.java
+++ b/user-service/src/main/java/com/ojosama/userservice/domain/exception/UserException.java
@@ -1,0 +1,11 @@
+package com.ojosama.userservice.domain.exception;
+
+import com.ojosama.common.exception.CustomException;
+import com.ojosama.common.exception.ErrorCode;
+
+public class UserException extends CustomException {
+
+    public UserException(ErrorCode code) {
+        super(code);
+    }
+}

--- a/user-service/src/main/java/com/ojosama/userservice/domain/model/Category.java
+++ b/user-service/src/main/java/com/ojosama/userservice/domain/model/Category.java
@@ -1,5 +1,7 @@
 package com.ojosama.userservice.domain.model;
 
+import com.ojosama.userservice.domain.exception.UserErrorCode;
+import com.ojosama.userservice.domain.exception.UserException;
 import java.util.Locale;
 
 public enum Category {
@@ -20,13 +22,13 @@ public enum Category {
 
     public static Category from(String value) {
         if (value == null || value.isBlank()) {
-            throw new IllegalArgumentException("존재하지 않는 카테고리입니다.");
+            throw new UserException(UserErrorCode.INVALID_CATEGORY);
         }
 
         try {
             return Category.valueOf(value.trim().toUpperCase(Locale.ROOT));
         } catch (IllegalArgumentException e) {
-            throw new IllegalArgumentException("존재하지 않는 카테고리입니다.");
+            throw new UserException(UserErrorCode.INVALID_CATEGORY);
         }
     }
 }

--- a/user-service/src/main/java/com/ojosama/userservice/global/security/RefreshTokenHasher.java
+++ b/user-service/src/main/java/com/ojosama/userservice/global/security/RefreshTokenHasher.java
@@ -1,5 +1,7 @@
 package com.ojosama.userservice.global.security;
 
+import com.ojosama.userservice.domain.exception.UserErrorCode;
+import com.ojosama.userservice.domain.exception.UserException;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -21,7 +23,8 @@ public class RefreshTokenHasher {
 
             return hexString.toString();
         } catch (NoSuchAlgorithmException e) {
-            throw new IllegalStateException("Refresh Token 해시 생성에 실패했습니다.", e);
+            throw new UserException(UserErrorCode.REFRESH_TOKEN_HASH_FAILED);
+
         }
     }
 }

--- a/user-service/src/main/java/com/ojosama/userservice/infrastructure/messaging/kafka/consumer/UserBlacklistStatusEventConsumer.java
+++ b/user-service/src/main/java/com/ojosama/userservice/infrastructure/messaging/kafka/consumer/UserBlacklistStatusEventConsumer.java
@@ -3,6 +3,8 @@ package com.ojosama.userservice.infrastructure.messaging.kafka.consumer;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ojosama.common.kafka.domain.EventType;
 import com.ojosama.common.kafka.domain.IdempotentEventHandler;
+import com.ojosama.userservice.domain.exception.UserErrorCode;
+import com.ojosama.userservice.domain.exception.UserException;
 import com.ojosama.userservice.domain.model.User;
 import com.ojosama.userservice.domain.model.UserStatus;
 import com.ojosama.userservice.domain.repository.UserRepository;
@@ -57,18 +59,20 @@ public class UserBlacklistStatusEventConsumer {
 
     private void changeUserStatus(UserBlacklistStatusEvent event) {
         User user = userRepository.findByIdAndDeletedAtIsNull(event.userId())
-                .orElseThrow(() -> new IllegalArgumentException(
-                        "블랙리스트 상태 변경 대상 사용자를 찾을 수 없습니다. userId=" + event.userId()
-                ));
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
 
         user.changeStatus(toUserStatus(event.status()));
     }
 
     private UserStatus toUserStatus(String blacklistStatus) {
+        if (blacklistStatus == null || blacklistStatus.isBlank()) {
+            throw new UserException(UserErrorCode.INVALID_BLACKLIST_STATUS);
+        }
+
         return switch (blacklistStatus) {
             case "ACTIVE" -> UserStatus.BLOCKED;
             case "INACTIVE" -> UserStatus.ACTIVE;
-            default -> throw new IllegalArgumentException("알 수 없는 블랙리스트 상태입니다: " + blacklistStatus);
+            default -> throw new UserException(UserErrorCode.INVALID_BLACKLIST_STATUS);
         };
     }
 }

--- a/user-service/src/main/java/com/ojosama/userservice/presentation/controller/AdminUserController.java
+++ b/user-service/src/main/java/com/ojosama/userservice/presentation/controller/AdminUserController.java
@@ -42,7 +42,7 @@ public class AdminUserController {
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
-    // 회원 상세 조회
+    // 회원 상세 조회 1
     @GetMapping("/{userId}")
     public ResponseEntity<ApiResponse<AdminDetailUserResponseDto>> getDetailUser(
             @PathVariable UUID userId

--- a/user-service/src/main/java/com/ojosama/userservice/presentation/controller/AdminUserController.java
+++ b/user-service/src/main/java/com/ojosama/userservice/presentation/controller/AdminUserController.java
@@ -13,6 +13,7 @@ import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -32,36 +33,36 @@ public class AdminUserController {
 
     // 회원 목록 조회
     @GetMapping
-    public ApiResponse<Page<AdminUserListResponseDto>> getUsers(
+    public ResponseEntity<ApiResponse<Page<AdminUserListResponseDto>>> getUsers(
             @ModelAttribute AdminUserListRequestDto request
     ) {
         Page<AdminUserListResponseDto> response = adminUserService.getUsers(request.toQuery())
                 .map(AdminUserListResponseDto::from);
 
-        return ApiResponse.success(response);
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     // 회원 상세 조회
     @GetMapping("/{userId}")
-    public ApiResponse<AdminDetailUserResponseDto> getDetailUser(
+    public ResponseEntity<ApiResponse<AdminDetailUserResponseDto>> getDetailUser(
             @PathVariable UUID userId
     ) {
         AdminDetailUserQuery query = new AdminDetailUserQuery(userId);
         AdminUserDetailResult result = adminUserService.getDetailUser(query);
 
-        return ApiResponse.success(AdminDetailUserResponseDto.from(result));
+        return ResponseEntity.ok(ApiResponse.success(AdminDetailUserResponseDto.from(result)));
     }
 
     // 유저 권한 수정
     @PatchMapping("/{userId}/role")
-    public ApiResponse<AdminChangeUserRoleResponseDto> changeUserRole(
+    public ResponseEntity<ApiResponse<AdminChangeUserRoleResponseDto>> changeUserRole(
             @PathVariable UUID userId,
             @Valid @RequestBody AdminChangeUserRoleRequestDto request
     ) {
-        return ApiResponse.success(
-                AdminChangeUserRoleResponseDto.from(
-                        adminUserService.changeUserRole(request.toCommand(userId))
-                )
+        AdminChangeUserRoleResponseDto response = AdminChangeUserRoleResponseDto.from(
+                adminUserService.changeUserRole(request.toCommand(userId))
         );
+
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 }

--- a/user-service/src/main/java/com/ojosama/userservice/presentation/controller/AdminUserController.java
+++ b/user-service/src/main/java/com/ojosama/userservice/presentation/controller/AdminUserController.java
@@ -1,5 +1,6 @@
 package com.ojosama.userservice.presentation.controller;
 
+import com.ojosama.common.response.ApiResponse;
 import com.ojosama.userservice.application.dto.query.AdminDetailUserQuery;
 import com.ojosama.userservice.application.dto.result.AdminUserDetailResult;
 import com.ojosama.userservice.application.service.UserAdminService;
@@ -8,6 +9,7 @@ import com.ojosama.userservice.presentation.dto.request.AdminUserListRequestDto;
 import com.ojosama.userservice.presentation.dto.response.AdminChangeUserRoleResponseDto;
 import com.ojosama.userservice.presentation.dto.response.AdminDetailUserResponseDto;
 import com.ojosama.userservice.presentation.dto.response.AdminUserListResponseDto;
+import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -30,32 +32,36 @@ public class AdminUserController {
 
     // 회원 목록 조회
     @GetMapping
-    public Page<AdminUserListResponseDto> getUsers(
+    public ApiResponse<Page<AdminUserListResponseDto>> getUsers(
             @ModelAttribute AdminUserListRequestDto request
     ) {
-        return adminUserService.getUsers(request.toQuery())
+        Page<AdminUserListResponseDto> response = adminUserService.getUsers(request.toQuery())
                 .map(AdminUserListResponseDto::from);
+
+        return ApiResponse.success(response);
     }
 
     // 회원 상세 조회
     @GetMapping("/{userId}")
-    public AdminDetailUserResponseDto getDetailUser(
+    public ApiResponse<AdminDetailUserResponseDto> getDetailUser(
             @PathVariable UUID userId
     ) {
         AdminDetailUserQuery query = new AdminDetailUserQuery(userId);
         AdminUserDetailResult result = adminUserService.getDetailUser(query);
 
-        return AdminDetailUserResponseDto.from(result);
+        return ApiResponse.success(AdminDetailUserResponseDto.from(result));
     }
 
     // 유저 권한 수정
     @PatchMapping("/{userId}/role")
-    public AdminChangeUserRoleResponseDto changeUserRole(
+    public ApiResponse<AdminChangeUserRoleResponseDto> changeUserRole(
             @PathVariable UUID userId,
-            @RequestBody AdminChangeUserRoleRequestDto request
+            @Valid @RequestBody AdminChangeUserRoleRequestDto request
     ) {
-        return AdminChangeUserRoleResponseDto.from(
-                adminUserService.changeUserRole(request.toCommand(userId))
+        return ApiResponse.success(
+                AdminChangeUserRoleResponseDto.from(
+                        adminUserService.changeUserRole(request.toCommand(userId))
+                )
         );
     }
 }

--- a/user-service/src/main/java/com/ojosama/userservice/presentation/controller/AuthController.java
+++ b/user-service/src/main/java/com/ojosama/userservice/presentation/controller/AuthController.java
@@ -1,5 +1,6 @@
 package com.ojosama.userservice.presentation.controller;
 
+import com.ojosama.common.response.ApiResponse;
 import com.ojosama.userservice.application.dto.result.LoginResult;
 import com.ojosama.userservice.application.dto.result.LogoutResult;
 import com.ojosama.userservice.application.service.AuthService;
@@ -10,12 +11,11 @@ import com.ojosama.userservice.presentation.dto.response.LogoutResponseDto;
 import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -27,30 +27,34 @@ public class AuthController {
 
     // 로그인
     @PostMapping("/login")
-    @ResponseStatus(HttpStatus.OK)
-    public LoginResponseDto login(@Valid @RequestBody LoginRequestDto requestDto) {
+    public ResponseEntity<ApiResponse<LoginResponseDto>> login(
+            @Valid @RequestBody LoginRequestDto requestDto
+    ) {
         LoginResult result = authService.login(requestDto.toCommand());
+        LoginResponseDto response = LoginResponseDto.from(result);
 
-        return LoginResponseDto.from(result);
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     // 토큰 재발급
     @PostMapping("/reissue")
-    @ResponseStatus(HttpStatus.OK)
-    public LoginResponseDto reissue(@Valid @RequestBody ReissueTokenRequestDto requestDto) {
+    public ResponseEntity<ApiResponse<LoginResponseDto>> reissue(
+            @Valid @RequestBody ReissueTokenRequestDto requestDto
+    ) {
         LoginResult result = authService.reissue(requestDto.toCommand());
+        LoginResponseDto response = LoginResponseDto.from(result);
 
-        return LoginResponseDto.from(result);
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     // 로그아웃
     @PostMapping("/logout")
-    @ResponseStatus(HttpStatus.OK)
-    public LogoutResponseDto logout(Authentication authentication) {
+    public ResponseEntity<ApiResponse<LogoutResponseDto>> logout(Authentication authentication) {
         UUID userId = UUID.fromString(authentication.getName());
 
         LogoutResult result = authService.logout(userId);
+        LogoutResponseDto response = LogoutResponseDto.from(result);
 
-        return LogoutResponseDto.from(result);
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 }

--- a/user-service/src/main/java/com/ojosama/userservice/presentation/controller/DevUserController.java
+++ b/user-service/src/main/java/com/ojosama/userservice/presentation/controller/DevUserController.java
@@ -1,5 +1,8 @@
 package com.ojosama.userservice.presentation.controller;
 
+import com.ojosama.common.response.ApiResponse;
+import com.ojosama.userservice.domain.exception.UserErrorCode;
+import com.ojosama.userservice.domain.exception.UserException;
 import com.ojosama.userservice.domain.model.User;
 import com.ojosama.userservice.domain.model.UserRole;
 import com.ojosama.userservice.domain.repository.UserRepository;
@@ -9,11 +12,11 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @Profile({"local", "test"})
@@ -26,12 +29,11 @@ public class DevUserController {
     private final PasswordEncoder passwordEncoder;
 
     @PostMapping("/admin")
-    @ResponseStatus(HttpStatus.CREATED)
-    public CreateUserResponseDto createAdminUser(
+    public ResponseEntity<ApiResponse<CreateUserResponseDto>> createAdminUser(
             @Valid @RequestBody CreateUserRequestDto request
     ) {
         if (userRepository.existsByEmail(request.email())) {
-            throw new IllegalArgumentException("중복 이메일입니다.");
+            throw new UserException(UserErrorCode.DUPLICATE_EMAIL);
         }
 
         User adminUser = User.create(
@@ -46,12 +48,16 @@ public class DevUserController {
 
         User savedUser = userRepository.save(adminUser);
 
-        return new CreateUserResponseDto(
+        CreateUserResponseDto response = new CreateUserResponseDto(
                 savedUser.getId(),
                 savedUser.getEmail(),
                 savedUser.getNickname(),
                 savedUser.getName(),
                 savedUser.getRole()
         );
+
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(ApiResponse.created(response));
     }
 }

--- a/user-service/src/main/java/com/ojosama/userservice/presentation/controller/DevUserController.java
+++ b/user-service/src/main/java/com/ojosama/userservice/presentation/controller/DevUserController.java
@@ -32,8 +32,12 @@ public class DevUserController {
     public ResponseEntity<ApiResponse<CreateUserResponseDto>> createAdminUser(
             @Valid @RequestBody CreateUserRequestDto request
     ) {
-        if (userRepository.existsByEmail(request.email())) {
+        if (userRepository.existsByEmailAndDeletedAtIsNull(request.email())) {
             throw new UserException(UserErrorCode.DUPLICATE_EMAIL);
+        }
+
+        if (userRepository.existsByNicknameAndDeletedAtIsNull(request.nickname())) {
+            throw new UserException(UserErrorCode.DUPLICATE_NICKNAME);
         }
 
         User adminUser = User.create(

--- a/user-service/src/main/java/com/ojosama/userservice/presentation/controller/UserController.java
+++ b/user-service/src/main/java/com/ojosama/userservice/presentation/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.ojosama.userservice.presentation.controller;
 
+import com.ojosama.common.response.ApiResponse;
 import com.ojosama.userservice.application.dto.command.DeleteUserCommand;
 import com.ojosama.userservice.application.dto.query.GetUserQuery;
 import com.ojosama.userservice.application.dto.result.CreateUserResult;
@@ -15,6 +16,7 @@ import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -22,7 +24,6 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -34,42 +35,49 @@ public class UserController {
 
     // 회원가입
     @PostMapping
-    @ResponseStatus(HttpStatus.CREATED)
-    public CreateUserResponseDto createUser(@Valid @RequestBody CreateUserRequestDto request) {
+    public ResponseEntity<ApiResponse<CreateUserResponseDto>> createUser(
+            @Valid @RequestBody CreateUserRequestDto request
+    ) {
         CreateUserResult result = userService.createUser(request.toCommand());
+        CreateUserResponseDto response = CreateUserResponseDto.from(result);
 
-        return CreateUserResponseDto.from(result);
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(ApiResponse.created(response));
     }
 
     // 내 정보 조회
     @GetMapping("/me")
-    public GetUserResponseDto getMyInfo(Authentication authentication) {
+    public ResponseEntity<ApiResponse<GetUserResponseDto>> getMyInfo(Authentication authentication) {
         UUID userId = UUID.fromString(authentication.getName());
 
         GetUserResult result = userService.getUser(new GetUserQuery(userId));
+        GetUserResponseDto response = GetUserResponseDto.from(result);
 
-        return GetUserResponseDto.from(result);
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     // 내 정보 수정
     @PatchMapping("/me")
-    public UpdateUserResponseDto updateMyInfo(
+    public ResponseEntity<ApiResponse<UpdateUserResponseDto>> updateMyInfo(
             Authentication authentication,
             @Valid @RequestBody UpdateUserRequestDto request
     ) {
         UUID userId = UUID.fromString(authentication.getName());
 
         UpdateUserResult result = userService.updateUser(request.toCommand(userId));
+        UpdateUserResponseDto response = UpdateUserResponseDto.from(result);
 
-        return UpdateUserResponseDto.from(result);
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     // 회원 탈퇴
     @DeleteMapping("/me")
-    @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void deleteMyInfo(Authentication authentication) {
+    public ResponseEntity<ApiResponse<Void>> deleteMyInfo(Authentication authentication) {
         UUID userId = UUID.fromString(authentication.getName());
 
         userService.deleteUser(new DeleteUserCommand(userId));
+
+        return ResponseEntity.ok(ApiResponse.deleted());
     }
 }

--- a/user-service/src/main/java/com/ojosama/userservice/presentation/dto/request/AdminChangeUserRoleRequestDto.java
+++ b/user-service/src/main/java/com/ojosama/userservice/presentation/dto/request/AdminChangeUserRoleRequestDto.java
@@ -2,9 +2,11 @@ package com.ojosama.userservice.presentation.dto.request;
 
 import com.ojosama.userservice.application.dto.command.AdminChangeUserRoleCommand;
 import com.ojosama.userservice.domain.model.UserRole;
+import jakarta.validation.constraints.NotNull;
 import java.util.UUID;
 
 public record AdminChangeUserRoleRequestDto(
+        @NotNull(message = "역할은 필수입니다.")
         UserRole role
 ) {
 


### PR DESCRIPTION
## 🔗 Issue Number
- close #167 

## 📝 작업 내역

- user-service에 공통 예외 처리 적용
  - `UserErrorCode`, `UserException` 추가
  - `AuthService`, `UserService`, `UserAdminService`의 주요 예외를 공통 예외 방식으로 변경
  - `Category.from()` null/공백/잘못된 카테고리 입력 방어 처리
  - `RefreshTokenHasher` 해시 생성 실패 예외를 공통 예외로 변경
  - `UserBlacklistStatusEventConsumer` 블랙리스트 상태 변경 예외를 공통 예외로 변경

- user-service 컨트롤러 공통 응답 포맷 적용
  - `AuthController` 로그인/재발급/로그아웃 응답을 `ResponseEntity<ApiResponse<T>>`로 변경
  - `UserController` 회원가입/내 정보 조회/내 정보 수정/회원 탈퇴 응답을 공통 응답으로 변경
  - `AdminUserController` 회원 목록 조회/상세 조회/역할 변경 응답을 공통 응답으로 변경
  - `DevUserController` 개발용 관리자 생성 API 응답을 공통 응답으로 변경

- 요청값 검증 보완
  - 관리자 권한 변경 요청에서 `role` null 입력 방어를 위해 `@NotNull` 추가
  - `AdminUserController` 권한 변경 요청에 `@Valid` 적용

- 내부 API 검토
  - `InternalUserController`는 다른 서비스와의 내부 호출 계약 유지를 위해 기존 응답 형태 유지

## 💡 PR 특이사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 정보

* **버그 수정**
  * 사용자 관련 작업에서 도메인 특화 예외 처리로 변경하여 더 정확한 오류 메시지 제공
  * 입력 값 유효성 검증 강화

* **기능 개선**
  * 모든 API 응답 형식을 표준화하여 일관된 응답 구조 제공
  * 사용자 인증, 권한 변경, 사용자 관리 등 작업에서 상세한 오류 정보 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->