### PR TITLE
[FEATURE] chat-service 이벤트 위치 검증 

### DIFF
--- a/chat-service/src/main/java/com/ojosama/chatservice/application/dto/command/VerifyEventLocationCommand.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/application/dto/command/VerifyEventLocationCommand.java
@@ -1,0 +1,11 @@
+package com.ojosama.chatservice.application.dto.command;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+public record VerifyEventLocationCommand(
+        UUID eventId,
+        BigDecimal currentLatitude,
+        BigDecimal currentLongitude
+) {
+}

--- a/chat-service/src/main/java/com/ojosama/chatservice/application/dto/result/EventLocationVerificationResult.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/application/dto/result/EventLocationVerificationResult.java
@@ -1,0 +1,9 @@
+package com.ojosama.chatservice.application.dto.result;
+
+import java.util.UUID;
+
+public record EventLocationVerificationResult(
+        UUID eventId,
+        boolean nearEvent
+) {
+}

--- a/chat-service/src/main/java/com/ojosama/chatservice/application/service/EventLocationVerificationService.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/application/service/EventLocationVerificationService.java
@@ -1,0 +1,88 @@
+package com.ojosama.chatservice.application.service;
+
+import com.ojosama.chatservice.application.dto.command.VerifyEventLocationCommand;
+import com.ojosama.chatservice.application.dto.result.EventLocationVerificationResult;
+import com.ojosama.chatservice.domain.exception.ChatErrorCode;
+import com.ojosama.chatservice.domain.exception.ChatException;
+import com.ojosama.chatservice.infrastructure.client.EventClient;
+import com.ojosama.chatservice.infrastructure.client.dto.InternalEventLocationResponse;
+import feign.FeignException;
+import java.math.BigDecimal;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class EventLocationVerificationService {
+
+    private static final double METERS_PER_LATITUDE_DEGREE = 111_320.0;
+
+    private final EventClient eventClient;
+
+    // 사용자의 위치 정보를 받아서 거리 검증
+    public EventLocationVerificationResult verify(VerifyEventLocationCommand command) {
+        validate(command);
+
+        InternalEventLocationResponse event = loadEventLocation(command.eventId());
+        // 이벤트 반경 정보 없으면 1000m
+        int radiusMeters = event.radiusMeters() != null ? event.radiusMeters() : 1000;
+        boolean nearEvent = isNearEvent(
+                command.currentLatitude(),
+                command.currentLongitude(),
+                event.latitude(),
+                event.longitude(),
+                radiusMeters
+        );
+        return new EventLocationVerificationResult(
+                event.eventId(),
+                nearEvent
+        );
+    }
+
+    private void validate(VerifyEventLocationCommand command) {
+        if (command == null || command.eventId() == null
+                || command.currentLatitude() == null || command.currentLongitude() == null) {
+            throw new ChatException(ChatErrorCode.INVALID_LOCATION_REQUEST);
+        }
+    }
+
+    private InternalEventLocationResponse loadEventLocation(UUID eventId) {
+        try {
+            InternalEventLocationResponse event = eventClient.getInternalEventLocation(eventId);
+            if (event == null || event.eventId() == null || event.latitude() == null || event.longitude() == null) {
+                throw new ChatException(ChatErrorCode.EVENT_LOCATION_LOOKUP_FAILED);
+            }
+            return event;
+        } catch (FeignException.NotFound e) {
+            throw new ChatException(ChatErrorCode.EVENT_LOCATION_NOT_FOUND);
+        } catch (FeignException e) {
+            throw new ChatException(ChatErrorCode.EVENT_LOCATION_LOOKUP_FAILED);
+        }
+    }
+
+    private boolean isNearEvent(
+            BigDecimal currentLatitude,
+            BigDecimal currentLongitude,
+            BigDecimal eventLatitude,
+            BigDecimal eventLongitude,
+            int radiusMeters
+    ) {
+        // 위도/경도는 "미터"가 아니어서 그대로 비교할 수 없다.
+        // 대신 위도 1도는 대략 111.32km라는 점을 이용해,
+        // 위도 차이와 경도 차이를 각각 미터로 바꾼 뒤 단순한 직선 거리로 근사한다.
+        double userLat = currentLatitude.doubleValue();
+        double userLng = currentLongitude.doubleValue();
+        double eventLat = eventLatitude.doubleValue();
+        double eventLng = eventLongitude.doubleValue();
+
+        double latDiffMeters = Math.abs(userLat - eventLat) * METERS_PER_LATITUDE_DEGREE;
+        double lngMetersPerDegree = METERS_PER_LATITUDE_DEGREE * Math.cos(Math.toRadians(eventLat));
+        double lngDiffMeters = Math.abs(userLng - eventLng) * lngMetersPerDegree;
+
+        double distanceMeters = Math.sqrt(latDiffMeters * latDiffMeters + lngDiffMeters * lngDiffMeters);
+        return distanceMeters <= radiusMeters; // true or false
+    }
+}

--- a/chat-service/src/main/java/com/ojosama/chatservice/application/service/MessageService.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/application/service/MessageService.java
@@ -105,7 +105,6 @@ public class MessageService {
             throw new ChatException(CommonErrorCode.INVALID_REQUEST);
         }
 
-        findChatRoom(query.chatRoomId());
         return getMessageSlice(
                 messageRepository.findByChatRoomIdAndStatuses(
                         query.chatRoomId(),

--- a/chat-service/src/main/java/com/ojosama/chatservice/domain/exception/ChatErrorCode.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/domain/exception/ChatErrorCode.java
@@ -34,7 +34,12 @@ public enum ChatErrorCode implements ErrorCode {
     INVALID_ADMIN_ID(HttpStatus.BAD_REQUEST, "adminId는 필수입니다."),
     MESSAGE_DELETE_FORBIDDEN(HttpStatus.FORBIDDEN, "본인의 메시지만 삭제할 수 있습니다."),
     MESSAGE_BLIND_FORBIDDEN(HttpStatus.FORBIDDEN, "메시지 블라인드 권한이 없습니다."),
-    CHAT_ROOM_CLOSE_FORBIDDEN(HttpStatus.FORBIDDEN, "채팅방 종료 권한이 없습니다.");
+    CHAT_ROOM_CLOSE_FORBIDDEN(HttpStatus.FORBIDDEN, "채팅방 종료 권한이 없습니다."),
+
+    // Location
+    EVENT_LOCATION_NOT_FOUND(HttpStatus.NOT_FOUND, "행사 위치 정보를 찾을 수 없습니다."),
+    EVENT_LOCATION_LOOKUP_FAILED(HttpStatus.BAD_GATEWAY, "행사 위치 정보를 가져오는 데 실패했습니다."),
+    INVALID_LOCATION_REQUEST(HttpStatus.BAD_REQUEST, "현재 위치 정보는 필수입니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/chat-service/src/main/java/com/ojosama/chatservice/infrastructure/client/EventClient.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/infrastructure/client/EventClient.java
@@ -1,0 +1,14 @@
+package com.ojosama.chatservice.infrastructure.client;
+
+import com.ojosama.chatservice.infrastructure.client.dto.InternalEventLocationResponse;
+import java.util.UUID;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@FeignClient(name = "event-service")
+public interface EventClient {
+
+    @GetMapping("/internal/v1/events/{eventId}/location")
+    InternalEventLocationResponse getInternalEventLocation(@PathVariable("eventId") UUID eventId);
+}

--- a/chat-service/src/main/java/com/ojosama/chatservice/infrastructure/client/dto/InternalEventLocationResponse.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/infrastructure/client/dto/InternalEventLocationResponse.java
@@ -1,0 +1,16 @@
+package com.ojosama.chatservice.infrastructure.client.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.math.BigDecimal;
+import java.util.UUID;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record InternalEventLocationResponse(
+        UUID eventId,
+        String eventName,
+        String place,
+        BigDecimal latitude,
+        BigDecimal longitude,
+        Integer radiusMeters
+) {
+}

--- a/chat-service/src/main/java/com/ojosama/chatservice/presentation/controller/EventLocationVerificationController.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/presentation/controller/EventLocationVerificationController.java
@@ -1,0 +1,39 @@
+package com.ojosama.chatservice.presentation.controller;
+
+import com.ojosama.chatservice.application.dto.command.VerifyEventLocationCommand;
+import com.ojosama.chatservice.application.service.EventLocationVerificationService;
+import com.ojosama.chatservice.presentation.dto.request.VerifyEventLocationRequest;
+import com.ojosama.chatservice.presentation.dto.response.EventLocationVerificationResponse;
+import com.ojosama.common.response.ApiResponse;
+import jakarta.validation.Valid;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/chat")
+public class EventLocationVerificationController {
+
+    private final EventLocationVerificationService eventLocationVerificationService;
+
+    @PostMapping("/events/{eventId}/location/verify")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ApiResponse<EventLocationVerificationResponse>> verifyLocation(
+            @PathVariable UUID eventId,
+            @Valid @RequestBody VerifyEventLocationRequest request
+    ) {
+        var result = eventLocationVerificationService.verify(new VerifyEventLocationCommand(
+                eventId,
+                request.currentLatitude(),
+                request.currentLongitude()
+        ));
+        return ResponseEntity.ok(ApiResponse.success(EventLocationVerificationResponse.from(result)));
+    }
+}

--- a/chat-service/src/main/java/com/ojosama/chatservice/presentation/dto/request/VerifyEventLocationRequest.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/presentation/dto/request/VerifyEventLocationRequest.java
@@ -1,10 +1,19 @@
 package com.ojosama.chatservice.presentation.dto.request;
 
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.NotNull;
 import java.math.BigDecimal;
 
 public record VerifyEventLocationRequest(
-        @NotNull BigDecimal currentLatitude,
-        @NotNull BigDecimal currentLongitude
+        @NotNull
+        @DecimalMin(value = "-90.0")
+        @DecimalMax(value = "90.0")
+        BigDecimal currentLatitude,
+
+        @NotNull
+        @DecimalMin(value = "-180.0")
+        @DecimalMax(value = "180.0")
+        BigDecimal currentLongitude
 ) {
 }

--- a/chat-service/src/main/java/com/ojosama/chatservice/presentation/dto/request/VerifyEventLocationRequest.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/presentation/dto/request/VerifyEventLocationRequest.java
@@ -1,0 +1,10 @@
+package com.ojosama.chatservice.presentation.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import java.math.BigDecimal;
+
+public record VerifyEventLocationRequest(
+        @NotNull BigDecimal currentLatitude,
+        @NotNull BigDecimal currentLongitude
+) {
+}

--- a/chat-service/src/main/java/com/ojosama/chatservice/presentation/dto/response/EventLocationVerificationResponse.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/presentation/dto/response/EventLocationVerificationResponse.java
@@ -1,11 +1,12 @@
 package com.ojosama.chatservice.presentation.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.ojosama.chatservice.application.dto.result.EventLocationVerificationResult;
 import java.util.UUID;
 
 public record EventLocationVerificationResponse(
         UUID eventId,
-        boolean isNearEvent
+        @JsonProperty("isNearEvent") boolean isNearEvent
 ) {
     public static EventLocationVerificationResponse from(EventLocationVerificationResult result) {
         return new EventLocationVerificationResponse(

--- a/chat-service/src/main/java/com/ojosama/chatservice/presentation/dto/response/EventLocationVerificationResponse.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/presentation/dto/response/EventLocationVerificationResponse.java
@@ -1,0 +1,16 @@
+package com.ojosama.chatservice.presentation.dto.response;
+
+import com.ojosama.chatservice.application.dto.result.EventLocationVerificationResult;
+import java.util.UUID;
+
+public record EventLocationVerificationResponse(
+        UUID eventId,
+        boolean isNearEvent
+) {
+    public static EventLocationVerificationResponse from(EventLocationVerificationResult result) {
+        return new EventLocationVerificationResponse(
+                result.eventId(),
+                result.nearEvent()
+        );
+    }
+}


### PR DESCRIPTION
## 🔗 Issue Number
- close #183 

## 📝 작업 내역

- chat-service에 행사 위치 검증 API 추가
- 클라이언트가 보낸 현재 위도/경도와 행사 위치/반경을 비교하는 로직 구현
- event-service 내부 API [GET /internal/v1/events/{eventId}/location] 연동
- 행사별 반경(radiusMeters)을 기준으로 isNearEvent 판정
- Haversine 대신 읽기 쉬운 근사 거리 계산 방식 적용
- 위치 검증 실패 케이스에 대한 에러코드 추가

## 💡 PR 특이사항

- 위치 데이터는 저장하지 않고, 요청 시점에만 판정한다
- 응답은 eventId, isNearEvent만 내림.
- 행사별 반경이 다를 수 있어서, 고정값이 아니라 내부 API에서 내려준 radiusMeters를 사용한다 만약없으면 1000
- 프론트에서 현장 배지/표시 여부를 이 응답(isNearEvent)으로 결정하면 된다

## 추후 작업
행사 상세 페이지 진입 시 현재 위치 권한 요청
위치 권한이 허용되면 location/verify API 호출
isNearEvent=true면 닉네임 옆에 현장 표시 배지 노출
위치 권한 거부/실패 시 배지 없이 기본 UI 유지
같은 행사 페이지에서는 결과 캐시해서 재호출 줄이기


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **새로운 기능**
  * 이벤트 위치 확인 기능 추가
  * 사용자의 현재 위치 기반 이벤트 근처 여부를 확인하는 새로운 API 엔드포인트 제공
  * 이벤트 서비스와의 위치 데이터 연동 추가

* **버그 수정**
  * 메시지 조회 시 불필요한 채팅방 조회 작업 제거

<!-- end of auto-generated comment: release notes by coderabbit.ai -->