### PR TITLE
[FEATURE] chat-service 인기 채팅방 구현  

### DIFF
--- a/chat-service/build.gradle
+++ b/chat-service/build.gradle
@@ -13,6 +13,7 @@ dependencies {
     // 커먼 모듈
     implementation project(':common')
 
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.kafka:spring-kafka'
 
     // 웹소켓

--- a/chat-service/src/main/java/com/ojosama/chatservice/application/dto/result/PopularChatRoomResult.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/application/dto/result/PopularChatRoomResult.java
@@ -1,0 +1,15 @@
+package com.ojosama.chatservice.application.dto.result;
+
+import com.ojosama.chatservice.domain.model.ChatRoom;
+
+public record PopularChatRoomResult(
+        ChatRoomResult chatRoom,
+        int currentViewerCount
+) {
+    public static PopularChatRoomResult from(ChatRoom chatRoom, int currentViewerCount) {
+        return new PopularChatRoomResult(
+                ChatRoomResult.from(chatRoom),
+                currentViewerCount
+        );
+    }
+}

--- a/chat-service/src/main/java/com/ojosama/chatservice/application/service/ChatRoomPopularityEventListener.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/application/service/ChatRoomPopularityEventListener.java
@@ -1,0 +1,43 @@
+package com.ojosama.chatservice.application.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+import org.springframework.web.socket.messaging.SessionSubscribeEvent;
+import org.springframework.web.socket.messaging.SessionUnsubscribeEvent;
+
+@Component
+@RequiredArgsConstructor
+public class ChatRoomPopularityEventListener {
+    // 웹소켓에서 뭔가 바뀌면 여기로 들어옴
+    private final ChatRoomPopularityTracker popularityTracker;
+
+    // 방 구독 시작
+    @EventListener
+    public void handleSessionSubscribe(SessionSubscribeEvent event) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.wrap(event.getMessage());
+        popularityTracker.markSubscribed(
+                accessor.getSessionId(),
+                accessor.getSubscriptionId(),
+                accessor.getDestination()
+        );
+    }
+
+    // 방 구독 취소
+    @EventListener
+    public void handleSessionUnsubscribe(SessionUnsubscribeEvent event) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.wrap(event.getMessage());
+        popularityTracker.markUnsubscribed(
+                accessor.getSessionId(),
+                accessor.getSubscriptionId()
+        );
+    }
+
+    // 연결이 끊기면 세션 값 다 지움
+    @EventListener
+    public void handleSessionDisconnect(SessionDisconnectEvent event) {
+        popularityTracker.clearSession(event.getSessionId());
+    }
+}

--- a/chat-service/src/main/java/com/ojosama/chatservice/application/service/ChatRoomPopularityTracker.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/application/service/ChatRoomPopularityTracker.java
@@ -1,60 +1,65 @@
 package com.ojosama.chatservice.application.service;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.HashOperations;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.stereotype.Component;
 
 @Component
+@RequiredArgsConstructor
 public class ChatRoomPopularityTracker {
-    // /topic/rooms/{roomId}/messages 에서 roomId만 뽑기
-    private static final Pattern ROOM_TOPIC_PATTERN = Pattern.compile("^/topic/rooms/([0-9a-fA-F-]{36})/messages$");
+    // 웹소켓 구독 주소에서 roomId만 꺼내려고 씀
+    private static final Pattern ROOM_TOPIC_PATTERN =
+            Pattern.compile("^/topic/rooms/([0-9a-fA-F-]{36})/messages$");
 
-    // 방별 지금 접속자 수
-    private final ConcurrentMap<UUID, AtomicInteger> roomViewerCounts = new ConcurrentHashMap<>();
-    // 세션이 어떤 방을 어떤 구독으로 보고 있는지
-    private final ConcurrentMap<String, ConcurrentMap<String, UUID>> subscriptionsBySession = new ConcurrentHashMap<>();
-    // 세션 안에서 방별 구독 횟수
-    private final ConcurrentMap<String, ConcurrentMap<UUID, AtomicInteger>> roomCountsBySession = new ConcurrentHashMap<>();
+    // 전체 방 인원수를 Redis에 모아두는 칸
+    private static final String POPULAR_ROOM_KEY = "chat:popular:rooms";
+    // 이 세션이 어떤 구독을 했는지 적어두는 칸
+    private static final String SESSION_SUBSCRIPTIONS_KEY_PREFIX = "chat:popular:sessions:%s:subs";
+    // 이 세션이 방마다 몇 번 붙어있는지 적어두는 칸
+    private static final String SESSION_ROOM_COUNTS_KEY_PREFIX = "chat:popular:sessions:%s:rooms";
 
-    // 구독 시작
+    private final StringRedisTemplate redisTemplate;
+
+    // 이벤트 리스너에서 호출 됨 (파라미터 값 전달되어서 옴)
     public void markSubscribed(String sessionId, String subscriptionId, String destination) {
         if (isBlank(sessionId) || isBlank(subscriptionId)) {
             return;
         }
 
-        // destination 에서 roomId를 꺼냄
+        // 주소에서 roomId가 안 나오면 그냥 끝
         UUID roomId = extractRoomId(destination);
         if (roomId == null) {
             return;
         }
 
-        // 이 세션의 구독 목록 저장
-        ConcurrentMap<String, UUID> sessionSubscriptions = subscriptionsBySession.computeIfAbsent(
-                sessionId,
-                key -> new ConcurrentHashMap<>()
-        );
-        if (sessionSubscriptions.putIfAbsent(subscriptionId, roomId) != null) {
+        // Redis에서 이 세션의 구독 기록부터 꺼냄
+        // redisTemplate 에서 해시 전용 기능... hashOperations 생성
+        HashOperations<String, String, String> hashOperations = redisTemplate.opsForHash();
+        String sessionSubscriptionsKey = sessionSubscriptionsKey(sessionId);
+        String sessionRoomCountsKey = sessionRoomCountsKey(sessionId);
+        String roomIdValue = roomId.toString();
+
+        // 같은 subscription이 또 오면 중복으로 안 셈
+        // putIfAbsent = 없을 때만 넣기, hashOperations 기능(Redis)
+        // 성공하면 true, 이미 있으면 false 반환 -> false 면 종료
+        Boolean inserted = hashOperations.putIfAbsent(sessionSubscriptionsKey, subscriptionId, roomIdValue);
+        if (Boolean.FALSE.equals(inserted)) {
             return;
         }
 
-        // 이 세션이 이 방을 몇 번 보고 있는지 저장
-        ConcurrentMap<UUID, AtomicInteger> sessionRoomCounts = roomCountsBySession.computeIfAbsent(
-                sessionId,
-                key -> new ConcurrentHashMap<>()
-        );
-        AtomicInteger sessionRoomCount = sessionRoomCounts.computeIfAbsent(
-                roomId, key -> new AtomicInteger(0)
-        );
-
-        // 처음 붙는 거면 방 전체 접속자 수도 +1
-        if (sessionRoomCount.incrementAndGet() == 1) {
-            roomViewerCounts.computeIfAbsent(roomId, key -> new AtomicInteger(0)).incrementAndGet();
+        // 이 세션이 이 방에 몇 번 붙었는지 +1
+        Long sessionRoomCount = hashOperations.increment(sessionRoomCountsKey, roomIdValue, 1L);
+        // 처음 붙은 거면 전체 인기 숫자도 +1
+        if (sessionRoomCount == 1L) {
+            incrementGlobal(roomId);
         }
     }
 
@@ -63,33 +68,30 @@ public class ChatRoomPopularityTracker {
             return;
         }
 
-        ConcurrentMap<String, UUID> sessionSubscriptions = subscriptionsBySession.get(sessionId);
-        if (sessionSubscriptions == null) {
+        // 이 세션이 어떤 방을 보고 있었는지 먼저 확인
+        HashOperations<String, String, String> hashOperations = redisTemplate.opsForHash();
+        String sessionSubscriptionsKey = sessionSubscriptionsKey(sessionId);
+        String sessionRoomCountsKey = sessionRoomCountsKey(sessionId);
+
+        // subscriptionId로 roomId를 찾음
+        String roomIdValue = hashOperations.get(sessionSubscriptionsKey, subscriptionId);
+        if (roomIdValue == null) {
             return;
         }
 
-        UUID roomId = sessionSubscriptions.remove(subscriptionId);
-        if (roomId == null) {
-            return;
+        // 구독 기록 하나 제거
+        hashOperations.delete(sessionSubscriptionsKey, subscriptionId);
+
+        // 이 세션에서 그 방을 하나 덜 보고 있다고 표시
+        Long sessionRoomCount = hashOperations.increment(sessionRoomCountsKey, roomIdValue, -1L);
+        // 이제 그 방을 완전히 안 보면 전체 숫자도 -1
+        if (sessionRoomCount <= 0L) {
+            hashOperations.delete(sessionRoomCountsKey, roomIdValue);
+            decrementGlobal(UUID.fromString(roomIdValue));
         }
 
-        ConcurrentMap<UUID, AtomicInteger> sessionRoomCounts = roomCountsBySession.get(sessionId);
-        if (sessionRoomCounts == null) {
-            return;
-        }
-
-        AtomicInteger sessionRoomCount = sessionRoomCounts.get(roomId);
-        if (sessionRoomCount == null) {
-            return;
-        }
-
-        // 이 세션에서 마지막 구독이 빠지면 전체 접속자 수도 -1
-        if (sessionRoomCount.decrementAndGet() <= 0) {
-            sessionRoomCounts.remove(roomId);
-            decrementGlobal(roomId);
-        }
-
-        cleanupSessionState(sessionId, sessionSubscriptions, sessionRoomCounts);
+        // 세션에 남은 게 없으면 Redis 값도 지움
+        cleanupSessionState(sessionSubscriptionsKey, sessionRoomCountsKey);
     }
 
     public void clearSession(String sessionId) {
@@ -97,42 +99,64 @@ public class ChatRoomPopularityTracker {
             return;
         }
 
-        // 연결이 끊기면 이 세션 값 전부 정리
-        ConcurrentMap<String, UUID> sessionSubscriptions = subscriptionsBySession.remove(sessionId);
-        ConcurrentMap<UUID, AtomicInteger> sessionRoomCounts = roomCountsBySession.remove(sessionId);
+        // 연결이 끊기면 이 세션이 잡고 있던 방들을 전부 정리
+        HashOperations<String, String, String> hashOperations = redisTemplate.opsForHash();
+        String sessionSubscriptionsKey = sessionSubscriptionsKey(sessionId);
+        String sessionRoomCountsKey = sessionRoomCountsKey(sessionId);
 
-        if (sessionRoomCounts == null) {
-            return;
+        // 세션이 보고 있던 방들만큼 전체 인기 숫자에서 빼줌
+        Map<String, String> sessionRoomCounts = hashOperations.entries(sessionRoomCountsKey);
+        if (!sessionRoomCounts.isEmpty()) {
+            sessionRoomCounts.forEach((roomIdValue, countValue) -> {
+                if (toPositiveLong(countValue) > 0) {
+                    decrementGlobal(UUID.fromString(roomIdValue));
+                }
+            });
         }
 
-        sessionRoomCounts.forEach((roomId, count) -> {
-            if (count != null && count.get() > 0) {
-                decrementGlobal(roomId);
-            }
-        });
-
-        if (sessionSubscriptions != null) {
-            sessionSubscriptions.clear();
-        }
+        redisTemplate.delete(sessionSubscriptionsKey);
+        redisTemplate.delete(sessionRoomCountsKey);
     }
 
     public int getViewerCount(UUID roomId) {
         if (roomId == null) {
             return 0;
         }
-        AtomicInteger count = roomViewerCounts.get(roomId);
-        return count == null ? 0 : Math.max(count.get(), 0);
+
+        // 이 방 지금 몇 명인지 바로 확인
+        Double score = redisTemplate.opsForZSet().score(POPULAR_ROOM_KEY, roomId.toString());
+        return score == null ? 0 : Math.max(score.intValue(), 0);
     }
 
     public Map<UUID, Integer> snapshotViewerCounts() {
-        // 지금 숫자들을 한번 복사해서 가져감
-        Map<UUID, Integer> snapshot = new HashMap<>();
-        roomViewerCounts.forEach((roomId, count) -> {
-            if (count != null && count.get() > 0) {
-                snapshot.put(roomId, count.get());
+        // 인기 순서대로 전체 목록을 한 번 가져옴
+        Set<ZSetOperations.TypedTuple<String>> topRooms =
+                redisTemplate.opsForZSet().reverseRangeWithScores(POPULAR_ROOM_KEY, 0, -1); // 0,-1 전체조회 내림차순
+        // 반환값이 Set<TypedTuple<String>>, roomId = String, score = Double 형태  -> 변환 필요
+
+        if (topRooms == null || topRooms.isEmpty()) {
+            return Map.of();
+        }
+
+        // Redis에서 가져온 순서 그대로 다시 담고, 타입 변환
+        Map<UUID, Integer> snapshot = new LinkedHashMap<>();
+        topRooms.forEach(tuple -> {
+            if (tuple == null || tuple.getValue() == null || tuple.getScore() == null) {
+                return;
+            }
+
+            try {
+                UUID roomId = UUID.fromString(tuple.getValue()); // roomId = String -> UUID
+                int count = Math.max(tuple.getScore().intValue(), 0); // score = Double -> int
+                if (count > 0) {
+                    snapshot.put(roomId, count); // 그리고나서 스냅샷에 넣기 (조회에 넘겨줄 값, Map<UUID, Integer>)
+                }
+            } catch (IllegalArgumentException ignored) {
+                // 잘못된 roomId 값은 그냥 무시
             }
         });
-        return Map.copyOf(snapshot);
+
+        return snapshot;
     }
 
     private UUID extractRoomId(String destination) {
@@ -140,7 +164,7 @@ public class ChatRoomPopularityTracker {
             return null;
         }
 
-        // destination 이 /topic/rooms/{roomId}/messages 형식인지 확인
+        // 우리가 쓰는 topic 형식인지 먼저 확인
         Matcher matcher = ROOM_TOPIC_PATTERN.matcher(destination.trim());
         if (!matcher.matches()) {
             return null;
@@ -153,26 +177,54 @@ public class ChatRoomPopularityTracker {
         }
     }
 
-    private void decrementGlobal(UUID roomId) {
-        // 전체 접속자 수에서 1 줄이고, 0이면 삭제
-        roomViewerCounts.computeIfPresent(roomId, (key, counter) -> counter.decrementAndGet() > 0 ? counter : null);
+    private void incrementGlobal(UUID roomId) {
+        // 전체 인기 점수에 +1
+        Double score = redisTemplate.opsForZSet().incrementScore(POPULAR_ROOM_KEY, roomId.toString(), 1D);
+        if (score != null && score <= 0D) {
+            redisTemplate.opsForZSet().remove(POPULAR_ROOM_KEY, roomId.toString());
+        }
     }
 
-    private void cleanupSessionState(
-            String sessionId,
-            ConcurrentMap<String, UUID> sessionSubscriptions,
-            ConcurrentMap<UUID, AtomicInteger> sessionRoomCounts
-    ) {
-        // 세션에 남은 값이 없으면 맵도 비움
-        if (sessionSubscriptions.isEmpty()) {
-            subscriptionsBySession.remove(sessionId);
+    private void decrementGlobal(UUID roomId) {
+        // 전체 인기 점수에 -1
+        Double score = redisTemplate.opsForZSet().incrementScore(POPULAR_ROOM_KEY, roomId.toString(), -1D);
+        if (score == null || score <= 0D) {
+            redisTemplate.opsForZSet().remove(POPULAR_ROOM_KEY, roomId.toString());
         }
-        if (sessionRoomCounts.isEmpty()) {
-            roomCountsBySession.remove(sessionId);
+    }
+
+    private void cleanupSessionState(String sessionSubscriptionsKey, String sessionRoomCountsKey) {
+        // 세션에 남은 데이터가 없으면 아예 지움
+        HashOperations<String, String, String> hashOperations = redisTemplate.opsForHash();
+        if (hashOperations.entries(sessionSubscriptionsKey).isEmpty()) {
+            redisTemplate.delete(sessionSubscriptionsKey);
         }
+        if (hashOperations.entries(sessionRoomCountsKey).isEmpty()) {
+            redisTemplate.delete(sessionRoomCountsKey);
+        }
+    }
+
+    private String sessionSubscriptionsKey(String sessionId) {
+        return SESSION_SUBSCRIPTIONS_KEY_PREFIX.formatted(sessionId);
+    }
+
+    private String sessionRoomCountsKey(String sessionId) {
+        return SESSION_ROOM_COUNTS_KEY_PREFIX.formatted(sessionId);
     }
 
     private boolean isBlank(String value) {
         return value == null || value.isBlank();
+    }
+
+    private long toPositiveLong(String value) {
+        if (value == null || value.isBlank()) {
+            return 0L;
+        }
+
+        try {
+            return Math.max(Long.parseLong(value), 0L);
+        } catch (NumberFormatException e) {
+            return 0L;
+        }
     }
 }

--- a/chat-service/src/main/java/com/ojosama/chatservice/application/service/ChatRoomPopularityTracker.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/application/service/ChatRoomPopularityTracker.java
@@ -6,6 +6,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.HashOperations;
 import org.springframework.data.redis.core.StringRedisTemplate;
@@ -25,11 +26,23 @@ public class ChatRoomPopularityTracker {
     private static final String SESSION_SUBSCRIPTIONS_KEY_PREFIX = "chat:popular:sessions:%s:subs";
     // 이 세션이 방마다 몇 번 붙어있는지 적어두는 칸
     private static final String SESSION_ROOM_COUNTS_KEY_PREFIX = "chat:popular:sessions:%s:rooms";
+    // 같은 세션 이벤트가 한 번에 두 개 들어오면 꼬일 수 있어서 잠깐 잠금
+    private static final String SESSION_LOCK_KEY_PREFIX = "chat:popular:sessions:%s:lock";
+    // 세션 기록은 한동안 안 움직이면 자동으로 지움
+    private static final long SESSION_TTL_MINUTES = 30L;
+    // 잠금은 금방 풀리게 짧게만 잡음
+    private static final long SESSION_LOCK_TTL_SECONDS = 5L;
 
     private final StringRedisTemplate redisTemplate;
 
     // 이벤트 리스너에서 호출 됨 (파라미터 값 전달되어서 옴)
     public void markSubscribed(String sessionId, String subscriptionId, String destination) {
+        if (!withSessionLock(sessionId, () -> markSubscribedInternal(sessionId, subscriptionId, destination))) {
+            return;
+        }
+    }
+
+    private void markSubscribedInternal(String sessionId, String subscriptionId, String destination) {
         if (isBlank(sessionId) || isBlank(subscriptionId)) {
             return;
         }
@@ -61,9 +74,18 @@ public class ChatRoomPopularityTracker {
         if (sessionRoomCount == 1L) {
             incrementGlobal(roomId);
         }
+
+        // 이 세션 기록은 잠깐씩 살아 있어야 하니까 TTL을 계속 연장
+        touchSession(sessionSubscriptionsKey, sessionRoomCountsKey);
     }
 
     public void markUnsubscribed(String sessionId, String subscriptionId) {
+        if (!withSessionLock(sessionId, () -> markUnsubscribedInternal(sessionId, subscriptionId))) {
+            return;
+        }
+    }
+
+    private void markUnsubscribedInternal(String sessionId, String subscriptionId) {
         if (isBlank(sessionId) || isBlank(subscriptionId)) {
             return;
         }
@@ -92,9 +114,16 @@ public class ChatRoomPopularityTracker {
 
         // 세션에 남은 게 없으면 Redis 값도 지움
         cleanupSessionState(sessionSubscriptionsKey, sessionRoomCountsKey);
+        touchSession(sessionSubscriptionsKey, sessionRoomCountsKey);
     }
 
     public void clearSession(String sessionId) {
+        if (!withSessionLock(sessionId, () -> clearSessionInternal(sessionId))) {
+            return;
+        }
+    }
+
+    private void clearSessionInternal(String sessionId) {
         if (isBlank(sessionId)) {
             return;
         }
@@ -116,6 +145,7 @@ public class ChatRoomPopularityTracker {
 
         redisTemplate.delete(sessionSubscriptionsKey);
         redisTemplate.delete(sessionRoomCountsKey);
+        redisTemplate.delete(sessionLockKey(sessionId));
     }
 
     public int getViewerCount(UUID roomId) {
@@ -210,6 +240,45 @@ public class ChatRoomPopularityTracker {
 
     private String sessionRoomCountsKey(String sessionId) {
         return SESSION_ROOM_COUNTS_KEY_PREFIX.formatted(sessionId);
+    }
+
+    private String sessionLockKey(String sessionId) {
+        return SESSION_LOCK_KEY_PREFIX.formatted(sessionId);
+    }
+
+    private void touchSession(String sessionSubscriptionsKey, String sessionRoomCountsKey) {
+        // 세션이 계속 움직이면 TTL도 계속 연장
+        redisTemplate.expire(sessionSubscriptionsKey, SESSION_TTL_MINUTES, TimeUnit.MINUTES);
+        redisTemplate.expire(sessionRoomCountsKey, SESSION_TTL_MINUTES, TimeUnit.MINUTES);
+    }
+
+    private boolean withSessionLock(String sessionId, Runnable action) {
+        if (isBlank(sessionId)) {
+            return false;
+        }
+
+        String lockKey = sessionLockKey(sessionId);
+        String token = UUID.randomUUID().toString();
+        Boolean locked = redisTemplate.opsForValue()
+                .setIfAbsent(lockKey, token, SESSION_LOCK_TTL_SECONDS, TimeUnit.SECONDS);
+
+        if (!Boolean.TRUE.equals(locked)) {
+            return false;
+        }
+
+        try {
+            action.run();
+            return true;
+        } finally {
+            releaseSessionLock(lockKey, token);
+        }
+    }
+
+    private void releaseSessionLock(String lockKey, String token) {
+        String currentToken = redisTemplate.opsForValue().get(lockKey);
+        if (token.equals(currentToken)) {
+            redisTemplate.delete(lockKey);
+        }
     }
 
     private boolean isBlank(String value) {

--- a/chat-service/src/main/java/com/ojosama/chatservice/application/service/ChatRoomPopularityTracker.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/application/service/ChatRoomPopularityTracker.java
@@ -1,0 +1,178 @@
+package com.ojosama.chatservice.application.service;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ChatRoomPopularityTracker {
+    // /topic/rooms/{roomId}/messages 에서 roomId만 뽑기
+    private static final Pattern ROOM_TOPIC_PATTERN = Pattern.compile("^/topic/rooms/([0-9a-fA-F-]{36})/messages$");
+
+    // 방별 지금 접속자 수
+    private final ConcurrentMap<UUID, AtomicInteger> roomViewerCounts = new ConcurrentHashMap<>();
+    // 세션이 어떤 방을 어떤 구독으로 보고 있는지
+    private final ConcurrentMap<String, ConcurrentMap<String, UUID>> subscriptionsBySession = new ConcurrentHashMap<>();
+    // 세션 안에서 방별 구독 횟수
+    private final ConcurrentMap<String, ConcurrentMap<UUID, AtomicInteger>> roomCountsBySession = new ConcurrentHashMap<>();
+
+    // 구독 시작
+    public void markSubscribed(String sessionId, String subscriptionId, String destination) {
+        if (isBlank(sessionId) || isBlank(subscriptionId)) {
+            return;
+        }
+
+        // destination 에서 roomId를 꺼냄
+        UUID roomId = extractRoomId(destination);
+        if (roomId == null) {
+            return;
+        }
+
+        // 이 세션의 구독 목록 저장
+        ConcurrentMap<String, UUID> sessionSubscriptions = subscriptionsBySession.computeIfAbsent(
+                sessionId,
+                key -> new ConcurrentHashMap<>()
+        );
+        if (sessionSubscriptions.putIfAbsent(subscriptionId, roomId) != null) {
+            return;
+        }
+
+        // 이 세션이 이 방을 몇 번 보고 있는지 저장
+        ConcurrentMap<UUID, AtomicInteger> sessionRoomCounts = roomCountsBySession.computeIfAbsent(
+                sessionId,
+                key -> new ConcurrentHashMap<>()
+        );
+        AtomicInteger sessionRoomCount = sessionRoomCounts.computeIfAbsent(
+                roomId, key -> new AtomicInteger(0)
+        );
+
+        // 처음 붙는 거면 방 전체 접속자 수도 +1
+        if (sessionRoomCount.incrementAndGet() == 1) {
+            roomViewerCounts.computeIfAbsent(roomId, key -> new AtomicInteger(0)).incrementAndGet();
+        }
+    }
+
+    public void markUnsubscribed(String sessionId, String subscriptionId) {
+        if (isBlank(sessionId) || isBlank(subscriptionId)) {
+            return;
+        }
+
+        ConcurrentMap<String, UUID> sessionSubscriptions = subscriptionsBySession.get(sessionId);
+        if (sessionSubscriptions == null) {
+            return;
+        }
+
+        UUID roomId = sessionSubscriptions.remove(subscriptionId);
+        if (roomId == null) {
+            return;
+        }
+
+        ConcurrentMap<UUID, AtomicInteger> sessionRoomCounts = roomCountsBySession.get(sessionId);
+        if (sessionRoomCounts == null) {
+            return;
+        }
+
+        AtomicInteger sessionRoomCount = sessionRoomCounts.get(roomId);
+        if (sessionRoomCount == null) {
+            return;
+        }
+
+        // 이 세션에서 마지막 구독이 빠지면 전체 접속자 수도 -1
+        if (sessionRoomCount.decrementAndGet() <= 0) {
+            sessionRoomCounts.remove(roomId);
+            decrementGlobal(roomId);
+        }
+
+        cleanupSessionState(sessionId, sessionSubscriptions, sessionRoomCounts);
+    }
+
+    public void clearSession(String sessionId) {
+        if (isBlank(sessionId)) {
+            return;
+        }
+
+        // 연결이 끊기면 이 세션 값 전부 정리
+        ConcurrentMap<String, UUID> sessionSubscriptions = subscriptionsBySession.remove(sessionId);
+        ConcurrentMap<UUID, AtomicInteger> sessionRoomCounts = roomCountsBySession.remove(sessionId);
+
+        if (sessionRoomCounts == null) {
+            return;
+        }
+
+        sessionRoomCounts.forEach((roomId, count) -> {
+            if (count != null && count.get() > 0) {
+                decrementGlobal(roomId);
+            }
+        });
+
+        if (sessionSubscriptions != null) {
+            sessionSubscriptions.clear();
+        }
+    }
+
+    public int getViewerCount(UUID roomId) {
+        if (roomId == null) {
+            return 0;
+        }
+        AtomicInteger count = roomViewerCounts.get(roomId);
+        return count == null ? 0 : Math.max(count.get(), 0);
+    }
+
+    public Map<UUID, Integer> snapshotViewerCounts() {
+        // 지금 숫자들을 한번 복사해서 가져감
+        Map<UUID, Integer> snapshot = new HashMap<>();
+        roomViewerCounts.forEach((roomId, count) -> {
+            if (count != null && count.get() > 0) {
+                snapshot.put(roomId, count.get());
+            }
+        });
+        return Map.copyOf(snapshot);
+    }
+
+    private UUID extractRoomId(String destination) {
+        if (isBlank(destination)) {
+            return null;
+        }
+
+        // destination 이 /topic/rooms/{roomId}/messages 형식인지 확인
+        Matcher matcher = ROOM_TOPIC_PATTERN.matcher(destination.trim());
+        if (!matcher.matches()) {
+            return null;
+        }
+
+        try {
+            return UUID.fromString(matcher.group(1));
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+    }
+
+    private void decrementGlobal(UUID roomId) {
+        // 전체 접속자 수에서 1 줄이고, 0이면 삭제
+        roomViewerCounts.computeIfPresent(roomId, (key, counter) -> counter.decrementAndGet() > 0 ? counter : null);
+    }
+
+    private void cleanupSessionState(
+            String sessionId,
+            ConcurrentMap<String, UUID> sessionSubscriptions,
+            ConcurrentMap<UUID, AtomicInteger> sessionRoomCounts
+    ) {
+        // 세션에 남은 값이 없으면 맵도 비움
+        if (sessionSubscriptions.isEmpty()) {
+            subscriptionsBySession.remove(sessionId);
+        }
+        if (sessionRoomCounts.isEmpty()) {
+            roomCountsBySession.remove(sessionId);
+        }
+    }
+
+    private boolean isBlank(String value) {
+        return value == null || value.isBlank();
+    }
+}

--- a/chat-service/src/main/java/com/ojosama/chatservice/application/service/PopularChatRoomQueryService.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/application/service/PopularChatRoomQueryService.java
@@ -5,10 +5,10 @@ import com.ojosama.chatservice.domain.exception.ChatException;
 import com.ojosama.chatservice.domain.model.ChatRoom;
 import com.ojosama.chatservice.domain.repository.ChatRoomRepository;
 import com.ojosama.common.exception.CommonErrorCode;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,7 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
-public class PopularChatRoomService {
+public class PopularChatRoomQueryService {
 
     private static final int DEFAULT_LIMIT = 3;
     private static final int MAX_LIMIT = 10;
@@ -31,22 +31,22 @@ public class PopularChatRoomService {
             return List.of();
         }
 
-        List<ChatRoom> chatRooms = chatRoomRepository.findAllByIds(viewerCounts.keySet());
+        // ChatRoomId 로 ChatRoom 맵으로 변환 <채팅방id,채팅방정보> 형태
+        Map<UUID, ChatRoom> chatRoomsById = chatRoomRepository.findAllByIds(viewerCounts.keySet()).stream()
+                .collect(Collectors.toMap(ChatRoom::getId, chatRoom -> chatRoom));
 
-        return chatRooms.stream()
-                .filter(ChatRoom::isOpen) // 열린 채팅방만
-                .map(chatRoom -> PopularChatRoomResult.from(
-                        chatRoom,
-                        viewerCounts.getOrDefault(chatRoom.getId(), 0)
-                ))
-                .filter(result -> result.currentViewerCount() > 0)
-                .sorted(Comparator
-                        .comparingInt(PopularChatRoomResult::currentViewerCount).reversed()
-                        .thenComparing(result -> result.chatRoom().openedAt(),
-                                Comparator.nullsLast(Comparator.reverseOrder()))
-                        .thenComparing(result -> result.chatRoom().chatRoomId()))
+        return viewerCounts.entrySet().stream()
+                .map(entry -> buildPopularRoom(chatRoomsById.get(entry.getKey()), entry.getValue()))
+                .filter(result -> result != null && result.currentViewerCount() > 0)
                 .limit(resolvedLimit)
                 .toList();
+    }
+
+    private PopularChatRoomResult buildPopularRoom(ChatRoom chatRoom, Integer viewerCount) {
+        if (chatRoom == null || !chatRoom.isOpen() || viewerCount == null || viewerCount <= 0) {
+            return null;
+        }
+        return PopularChatRoomResult.from(chatRoom, viewerCount);
     }
 
     private int resolveLimit(Integer limit) {

--- a/chat-service/src/main/java/com/ojosama/chatservice/application/service/PopularChatRoomService.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/application/service/PopularChatRoomService.java
@@ -1,0 +1,59 @@
+package com.ojosama.chatservice.application.service;
+
+import com.ojosama.chatservice.application.dto.result.PopularChatRoomResult;
+import com.ojosama.chatservice.domain.exception.ChatException;
+import com.ojosama.chatservice.domain.model.ChatRoom;
+import com.ojosama.chatservice.domain.repository.ChatRoomRepository;
+import com.ojosama.common.exception.CommonErrorCode;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PopularChatRoomService {
+
+    private static final int DEFAULT_LIMIT = 3;
+    private static final int MAX_LIMIT = 10;
+
+    private final ChatRoomRepository chatRoomRepository;
+    private final ChatRoomPopularityTracker popularityTracker;
+
+    public List<PopularChatRoomResult> getPopularChatRooms(Integer limit) {
+        int resolvedLimit = resolveLimit(limit);
+        Map<UUID, Integer> viewerCounts = popularityTracker.snapshotViewerCounts();
+        if (viewerCounts.isEmpty()) {
+            return List.of();
+        }
+
+        List<ChatRoom> chatRooms = chatRoomRepository.findAllByIds(viewerCounts.keySet());
+
+        return chatRooms.stream()
+                .filter(ChatRoom::isOpen) // 열린 채팅방만
+                .map(chatRoom -> PopularChatRoomResult.from(
+                        chatRoom,
+                        viewerCounts.getOrDefault(chatRoom.getId(), 0)
+                ))
+                .filter(result -> result.currentViewerCount() > 0)
+                .sorted(Comparator
+                        .comparingInt(PopularChatRoomResult::currentViewerCount).reversed()
+                        .thenComparing(result -> result.chatRoom().openedAt(),
+                                Comparator.nullsLast(Comparator.reverseOrder()))
+                        .thenComparing(result -> result.chatRoom().chatRoomId()))
+                .limit(resolvedLimit)
+                .toList();
+    }
+
+    private int resolveLimit(Integer limit) {
+        int resolvedLimit = limit == null ? DEFAULT_LIMIT : limit;
+        if (resolvedLimit <= 0 || resolvedLimit > MAX_LIMIT) {
+            throw new ChatException(CommonErrorCode.INVALID_REQUEST);
+        }
+        return resolvedLimit;
+    }
+}

--- a/chat-service/src/main/java/com/ojosama/chatservice/domain/repository/ChatRoomRepository.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/domain/repository/ChatRoomRepository.java
@@ -3,6 +3,7 @@ package com.ojosama.chatservice.domain.repository;
 import com.ojosama.chatservice.domain.model.ChatRoom;
 import com.ojosama.chatservice.domain.model.ChatRoomStatus;
 import java.time.LocalDateTime;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -14,6 +15,8 @@ public interface ChatRoomRepository {
     Optional<ChatRoom> findById(UUID id);
 
     Optional<ChatRoom> findByEventId(UUID eventId);
+
+    List<ChatRoom> findAllByIds(Collection<UUID> ids);
 
     List<ChatRoom> findAllByStatus(ChatRoomStatus status);
 

--- a/chat-service/src/main/java/com/ojosama/chatservice/infrastructure/persistence/ChatRoomRepositoryImpl.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/infrastructure/persistence/ChatRoomRepositoryImpl.java
@@ -4,6 +4,7 @@ import com.ojosama.chatservice.domain.model.ChatRoom;
 import com.ojosama.chatservice.domain.model.ChatRoomStatus;
 import com.ojosama.chatservice.domain.repository.ChatRoomRepository;
 import java.time.LocalDateTime;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -29,6 +30,11 @@ public class ChatRoomRepositoryImpl implements ChatRoomRepository {
     @Override
     public Optional<ChatRoom> findByEventId(UUID eventId) {
         return ChatRoomJpaRepository.findByEventId(eventId);
+    }
+
+    @Override
+    public List<ChatRoom> findAllByIds(Collection<UUID> ids) {
+        return ChatRoomJpaRepository.findAllById(ids);
     }
 
     @Override

--- a/chat-service/src/main/java/com/ojosama/chatservice/presentation/controller/ChatRoomController.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/presentation/controller/ChatRoomController.java
@@ -3,9 +3,13 @@ package com.ojosama.chatservice.presentation.controller;
 import com.ojosama.chatservice.application.dto.query.FindChatRoomByEventIdQuery;
 import com.ojosama.chatservice.application.dto.query.FindChatRoomQuery;
 import com.ojosama.chatservice.application.dto.result.ChatRoomResult;
+import com.ojosama.chatservice.application.dto.result.PopularChatRoomResult;
 import com.ojosama.chatservice.application.service.ChatRoomService;
+import com.ojosama.chatservice.application.service.PopularChatRoomService;
 import com.ojosama.chatservice.presentation.dto.response.ChatRoomResponse;
+import com.ojosama.chatservice.presentation.dto.response.PopularChatRoomResponse;
 import com.ojosama.common.response.ApiResponse;
+import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -21,6 +25,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class ChatRoomController {
 
     private final ChatRoomService chatRoomService;
+    private final PopularChatRoomService popularChatRoomService;
 
     @GetMapping("/{chatRoomId}")
     public ResponseEntity<ApiResponse<ChatRoomResponse>> getChatRoom(
@@ -36,5 +41,17 @@ public class ChatRoomController {
     ) {
         ChatRoomResult result = chatRoomService.getChatRoomByEventId(new FindChatRoomByEventIdQuery(eventId));
         return ResponseEntity.ok(ApiResponse.success(ChatRoomResponse.from(result)));
+    }
+
+    @GetMapping("/popular")
+    public ResponseEntity<ApiResponse<List<PopularChatRoomResponse>>> getPopularChatRooms(
+            @RequestParam(defaultValue = "3") int limit
+    ) {
+        List<PopularChatRoomResult> results = popularChatRoomService.getPopularChatRooms(limit);
+        return ResponseEntity.ok(ApiResponse.success(
+                results.stream()
+                        .map(PopularChatRoomResponse::from)
+                        .toList()
+        ));
     }
 }

--- a/chat-service/src/main/java/com/ojosama/chatservice/presentation/controller/ChatRoomController.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/presentation/controller/ChatRoomController.java
@@ -5,7 +5,7 @@ import com.ojosama.chatservice.application.dto.query.FindChatRoomQuery;
 import com.ojosama.chatservice.application.dto.result.ChatRoomResult;
 import com.ojosama.chatservice.application.dto.result.PopularChatRoomResult;
 import com.ojosama.chatservice.application.service.ChatRoomService;
-import com.ojosama.chatservice.application.service.PopularChatRoomService;
+import com.ojosama.chatservice.application.service.PopularChatRoomQueryService;
 import com.ojosama.chatservice.presentation.dto.response.ChatRoomResponse;
 import com.ojosama.chatservice.presentation.dto.response.PopularChatRoomResponse;
 import com.ojosama.common.response.ApiResponse;
@@ -25,7 +25,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class ChatRoomController {
 
     private final ChatRoomService chatRoomService;
-    private final PopularChatRoomService popularChatRoomService;
+    private final PopularChatRoomQueryService popularChatRoomQueryService;
 
     @GetMapping("/{chatRoomId}")
     public ResponseEntity<ApiResponse<ChatRoomResponse>> getChatRoom(
@@ -47,7 +47,7 @@ public class ChatRoomController {
     public ResponseEntity<ApiResponse<List<PopularChatRoomResponse>>> getPopularChatRooms(
             @RequestParam(defaultValue = "3") int limit
     ) {
-        List<PopularChatRoomResult> results = popularChatRoomService.getPopularChatRooms(limit);
+        List<PopularChatRoomResult> results = popularChatRoomQueryService.getPopularChatRooms(limit);
         return ResponseEntity.ok(ApiResponse.success(
                 results.stream()
                         .map(PopularChatRoomResponse::from)

--- a/chat-service/src/main/java/com/ojosama/chatservice/presentation/dto/response/PopularChatRoomResponse.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/presentation/dto/response/PopularChatRoomResponse.java
@@ -1,0 +1,35 @@
+package com.ojosama.chatservice.presentation.dto.response;
+
+import com.ojosama.chatservice.application.dto.result.PopularChatRoomResult;
+import com.ojosama.chatservice.domain.model.ChatRoomStatus;
+import com.ojosama.chatservice.domain.model.EventCategory;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record PopularChatRoomResponse(
+        UUID chatRoomId,
+        UUID eventId,
+        String eventName,
+        EventCategory category,
+        ChatRoomStatus status,
+        LocalDateTime scheduledOpenAt,
+        LocalDateTime scheduledCloseAt,
+        LocalDateTime openedAt,
+        LocalDateTime closedAt,
+        int currentViewerCount
+) {
+    public static PopularChatRoomResponse from(PopularChatRoomResult result) {
+        return new PopularChatRoomResponse(
+                result.chatRoom().chatRoomId(),
+                result.chatRoom().eventId(),
+                result.chatRoom().eventName(),
+                result.chatRoom().category(),
+                result.chatRoom().status(),
+                result.chatRoom().scheduledOpenAt(),
+                result.chatRoom().scheduledCloseAt(),
+                result.chatRoom().openedAt(),
+                result.chatRoom().closedAt(),
+                result.currentViewerCount()
+        );
+    }
+}


### PR DESCRIPTION
## 🔗 Issue Number
- close #193

## 📝 작업 내역

웹소켓 구독 수를 기준으로 실시간 인기 채팅방 TOP3를 조회
현재는 `chat-service` 내부에서 웹소켓 `SUBSCRIBE / UNSUBSCRIBE / DISCONNECT` 이벤트를 받고 채팅방별 현재 접속자 수를 메모리에서 집계하고, 그 값을 기준으로 인기 순위를 계산

## 동작 흐름
1. 사용자가 채팅방에 접속해서 웹소켓 구독을 시작하면 `SUBSCRIBE` 이벤트가 발생
2. `ChatRoomPopularityEventListener`가 이 이벤트를 받아 `ChatRoomPopularityTracker`에 전달
3. `ChatRoomPopularityTracker`가 roomId별 접속자 수를 메모리에 누적
4. `/v1/chat/rooms/popular?limit=3` 호출 시, 현재 접속자 수를 기준으로 TOP N 채팅방을 정렬
5. 채팅방 정보는 `ChatRoomRepository`에서 한 번에 조회하고, 응답은 인기 순서대로 반환

## 💡 PR 특이사항

- 근데 이렇게 구현하고 나니까 이게 ..서버1대일때는 괜찮은데 2대이상이되면 정확히나오지 않게되어서 레디스를 쓰는 방식으로 추가할거같습니다 ( 이 피알에서 바로 진행 )

## 추가

같은 세션 이벤트가 겹쳐도 한번에 하나씩만 처리
세션이 계속 살아 있으면 TTL 연장
세션이 죽으면 키가 오래 안 남게 됨

- 웹소켓 접속 집계 :같은 세션에서 중복으로 들어오는 웹소켓 이벤트를 안전하게 처리
- 채팅방 인기 집계가 중복 계산되지 않도록 정합성을 보장한다.
**웹소켓/집계 동시성**
- [x] 인기 채팅방 집계 로직의 세션 단위 경합 여부 점검
- [x] SUBSCRIBE / UNSUBSCRIBE / DISCONNECT 이벤트가 겹칠 때 중복 집계 방지
- [x] Redis 세션 키 TTL 정리 방식 검토
- [x] 세션 단위 락 또는 직렬화 방식 적용 여부 확정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 새로운 기능
* 인기 채팅방 조회 기능 추가 - 시청자가 가장 많은 채팅방을 실시간으로 확인할 수 있습니다
* 각 채팅방의 현재 시청자 수, 상태, 개최 일정 정보를 함께 제공합니다
* API 요청 시 조회할 채팅방의 개수를 제한할 수 있습니다 (기본값: 3개)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->