### PR TITLE
[FEATURE] 행사 상태 변경 이벤트 발행 및 행사 취소 API

### DIFF
--- a/common/src/main/java/com/ojosama/common/kafka/domain/EventType.java
+++ b/common/src/main/java/com/ojosama/common/kafka/domain/EventType.java
@@ -15,6 +15,7 @@ public enum EventType {
     EVENT_DELETED("EventDeleted"),
     EVENT_UPDATED("EventUpdated"),
     EVENT_SCHEDULE_CHANGED("EventScheduleChanged"),
+    EVENT_STATUS_CHANGED("EventStatusChanged"),
 
     EVENT_REQUEST_CREATED("EventRequestCreated"),
     EVENT_REQUEST_RESULT("EventRequestResultCreated"),

--- a/event-service/src/main/java/com/ojosama/eventservice/event/application/service/EventCommandService.java
+++ b/event-service/src/main/java/com/ojosama/eventservice/event/application/service/EventCommandService.java
@@ -6,23 +6,26 @@ import com.ojosama.eventservice.event.application.dto.result.EventResult;
 import com.ojosama.eventservice.event.domain.event.payload.EventCreatedMessage;
 import com.ojosama.eventservice.event.domain.event.payload.EventDeletedMessage;
 import com.ojosama.eventservice.event.domain.event.payload.EventScheduleChangedMessage;
+import com.ojosama.eventservice.event.domain.event.payload.EventStatusChangedMessage;
 import com.ojosama.eventservice.event.domain.exception.EventErrorCode;
 import com.ojosama.eventservice.event.domain.exception.EventException;
 import com.ojosama.eventservice.event.domain.model.Event;
+import com.ojosama.eventservice.event.domain.model.EventAction;
 import com.ojosama.eventservice.event.domain.model.EventCategory;
+import com.ojosama.eventservice.event.domain.model.EventSchedule;
+import com.ojosama.eventservice.event.domain.model.EventScheduleAction;
+import com.ojosama.eventservice.event.domain.model.ScheduleActionStatus;
 import com.ojosama.eventservice.event.domain.model.vo.EventFee;
 import com.ojosama.eventservice.event.domain.model.vo.EventLocation;
 import com.ojosama.eventservice.event.domain.model.vo.EventTicketing;
 import com.ojosama.eventservice.event.domain.model.vo.EventTime;
 import com.ojosama.eventservice.event.domain.repository.EventCategoryRepository;
 import com.ojosama.eventservice.event.domain.repository.EventRepository;
+import com.ojosama.eventservice.event.domain.repository.EventScheduleActionRepository;
 import com.ojosama.eventservice.event.domain.support.EventChanges;
 import com.ojosama.eventservice.event.domain.support.EventSnapshot;
-import com.ojosama.eventservice.event.domain.model.EventScheduleAction;
-import com.ojosama.eventservice.event.domain.model.EventAction;
-import com.ojosama.eventservice.event.domain.model.ScheduleActionStatus;
-import com.ojosama.eventservice.event.domain.repository.EventScheduleActionRepository;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
@@ -150,30 +153,58 @@ public class EventCommandService {
         applicationEventPublisher.publishEvent(new EventDeletedMessage(event.getId(), event.getName()));
     }
 
+    public EventResult cancelEvent(UUID eventId, UUID userId) {
+        Event event = eventRepository.findById(eventId)
+                .orElseThrow(() -> new EventException(EventErrorCode.EVENT_NOT_FOUND));
+
+        String beforeStatus = event.getStatus().name();
+        event.markCancelled();
+
+        scheduleActionRepository.findPendingByEventId(eventId).forEach(EventScheduleAction::markCancelled);
+
+        List<UUID> deletedScheduleIds = event.getSchedules().stream()
+                .filter(schedule -> !schedule.getScheduleTime().isScheduleEnded())
+                .peek(schedule -> schedule.deleted(userId))
+                .map(EventSchedule::getId)
+                .toList();
+
+        eventRepository.save(event);
+
+        applicationEventPublisher.publishEvent(new EventStatusChangedMessage(
+                event.getId(),
+                event.getName(),
+                beforeStatus,
+                event.getStatus().name(),
+                deletedScheduleIds
+        ));
+
+        return EventResult.from(event);
+    }
+
     private void registerScheduleActions(Event event) {
         LocalDateTime now = LocalDateTime.now();
 
         if (event.getEventTime().getStartAt() != null &&
-            event.getEventTime().getStartAt().isAfter(now)) {
+                event.getEventTime().getStartAt().isAfter(now)) {
             EventScheduleAction startAction = EventScheduleAction.builder()
-                .eventId(event.getId())
-                .action(EventAction.MARK_IN_PROGRESS)
-                .scheduledAt(event.getEventTime().getStartAt())
-                .status(ScheduleActionStatus.PENDING)
-                .createdAt(LocalDateTime.now())
-                .build();
+                    .eventId(event.getId())
+                    .action(EventAction.MARK_IN_PROGRESS)
+                    .scheduledAt(event.getEventTime().getStartAt())
+                    .status(ScheduleActionStatus.PENDING)
+                    .createdAt(LocalDateTime.now())
+                    .build();
             scheduleActionRepository.save(startAction);
         }
 
         if (event.getEventTime().getEndAt() != null &&
-            event.getEventTime().getEndAt().isAfter(now)) {
+                event.getEventTime().getEndAt().isAfter(now)) {
             EventScheduleAction endAction = EventScheduleAction.builder()
-                .eventId(event.getId())
-                .action(EventAction.MARK_COMPLETED)
-                .scheduledAt(event.getEventTime().getEndAt())
-                .status(ScheduleActionStatus.PENDING)
-                .createdAt(LocalDateTime.now())
-                .build();
+                    .eventId(event.getId())
+                    .action(EventAction.MARK_COMPLETED)
+                    .scheduledAt(event.getEventTime().getEndAt())
+                    .status(ScheduleActionStatus.PENDING)
+                    .createdAt(LocalDateTime.now())
+                    .build();
             scheduleActionRepository.save(endAction);
         }
     }

--- a/event-service/src/main/java/com/ojosama/eventservice/event/domain/event/payload/EventStatusChangedMessage.java
+++ b/event-service/src/main/java/com/ojosama/eventservice/event/domain/event/payload/EventStatusChangedMessage.java
@@ -9,4 +9,5 @@ public record EventStatusChangedMessage(
         String beforeStatus,
         String afterStatus,
         List<UUID> deletedScheduleIds
-) {}
+) {
+}

--- a/event-service/src/main/java/com/ojosama/eventservice/event/domain/event/payload/EventStatusChangedMessage.java
+++ b/event-service/src/main/java/com/ojosama/eventservice/event/domain/event/payload/EventStatusChangedMessage.java
@@ -1,0 +1,10 @@
+package com.ojosama.eventservice.event.domain.event.payload;
+
+import java.util.UUID;
+
+public record EventStatusChangedMessage(
+        UUID eventId,
+        String eventName,
+        String beforeStatus,
+        String afterStatus
+) {}

--- a/event-service/src/main/java/com/ojosama/eventservice/event/domain/event/payload/EventStatusChangedMessage.java
+++ b/event-service/src/main/java/com/ojosama/eventservice/event/domain/event/payload/EventStatusChangedMessage.java
@@ -1,10 +1,12 @@
 package com.ojosama.eventservice.event.domain.event.payload;
 
+import java.util.List;
 import java.util.UUID;
 
 public record EventStatusChangedMessage(
         UUID eventId,
         String eventName,
         String beforeStatus,
-        String afterStatus
+        String afterStatus,
+        List<UUID> deletedScheduleIds
 ) {}

--- a/event-service/src/main/java/com/ojosama/eventservice/event/domain/exception/EventErrorCode.java
+++ b/event-service/src/main/java/com/ojosama/eventservice/event/domain/exception/EventErrorCode.java
@@ -7,26 +7,26 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum EventErrorCode implements ErrorCode {
     // Event 관련 에러
-    EVENT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 이벤트를 찾을 수 없습니다."),
-    EVENT_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 존재하는 이벤트입니다."),
-    EVENT_INVALID_TIME(HttpStatus.BAD_REQUEST, "이벤트 시간이 유효하지 않습니다. 시작 시간이 종료 시간보다 작아야 합니다."),
+    EVENT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 행사를 찾을 수 없습니다."),
+    EVENT_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 존재하는 행사입니다."),
+    EVENT_INVALID_TIME(HttpStatus.BAD_REQUEST, "행사 시간이 유효하지 않습니다. 시작 시간이 종료 시간보다 작아야 합니다."),
     EVENT_PAST_START_TIME(HttpStatus.BAD_REQUEST, "시작 시간은 현재 시간 이후여야 합니다."),
-    EVENT_INVALID_NAME(HttpStatus.BAD_REQUEST, "이벤트 이름이 유효하지 않습니다."),
-    EVENT_INVALID_DESCRIPTION(HttpStatus.BAD_REQUEST, "이벤트 설명이 유효하지 않습니다."),
-    EVENT_INVALID_LOCATION(HttpStatus.BAD_REQUEST, "이벤트 위치 정보가 유효하지 않습니다."),
-    EVENT_INVALID_FEE(HttpStatus.BAD_REQUEST, "이벤트 수수료가 유효하지 않습니다. 최소 수수료가 최대 수수료보다 클 수 없습니다."),
-    EVENT_INVALID_IMAGE(HttpStatus.BAD_REQUEST, "이벤트 이미지가 유효하지 않습니다."),
+    EVENT_INVALID_NAME(HttpStatus.BAD_REQUEST, "행사 이름이 유효하지 않습니다."),
+    EVENT_INVALID_DESCRIPTION(HttpStatus.BAD_REQUEST, "행사 설명이 유효하지 않습니다."),
+    EVENT_INVALID_LOCATION(HttpStatus.BAD_REQUEST, "행사 위치 정보가 유효하지 않습니다."),
+    EVENT_INVALID_FEE(HttpStatus.BAD_REQUEST, "행사 수수료가 유효하지 않습니다. 최소 수수료가 최대 수수료보다 클 수 없습니다."),
+    EVENT_INVALID_IMAGE(HttpStatus.BAD_REQUEST, "행사 이미지가 유효하지 않습니다."),
 
     // EventCategory 관련 에러
     EVENT_CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 카테고리를 찾을 수 없습니다."),
-    EVENT_CATEGORY_INVALID(HttpStatus.BAD_REQUEST, "이벤트 카테고리가 유효하지 않습니다."),
+    EVENT_CATEGORY_INVALID(HttpStatus.BAD_REQUEST, "행사 카테고리가 유효하지 않습니다."),
     EVENT_CATEGORY_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 존재하는 카테고리 이름입니다."),
 
     // EventSchedule 관련 에러
-    EVENT_SCHEDULE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 스케줄을 찾을 수 없습니다."),
-    EVENT_SCHEDULE_INVALID_TIME(HttpStatus.BAD_REQUEST, "스케줄 시간이 유효하지 않습니다."),
-    EVENT_SCHEDULE_INVALID_NAME(HttpStatus.BAD_REQUEST, "스케줄 이름이 유효하지 않습니다. (비어있거나 100자 초과)"),
-    EVENT_SCHEDULE_CONFLICT(HttpStatus.CONFLICT, "해당 시간에 다른 스케줄이 존재합니다."),
+    EVENT_SCHEDULE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 행사 일정을 찾을 수 없습니다."),
+    EVENT_SCHEDULE_INVALID_TIME(HttpStatus.BAD_REQUEST, "행사 일정 시간이 유효하지 않습니다."),
+    EVENT_SCHEDULE_INVALID_NAME(HttpStatus.BAD_REQUEST, "행사 일정 이름이 유효하지 않습니다. (비어있거나 100자 초과)"),
+    EVENT_SCHEDULE_CONFLICT(HttpStatus.CONFLICT, "해당 시간에 다른 행사 일정이 존재합니다."),
 
     // EventScheduleAction 관련 에러
     EVENT_SCHEDULE_ACTION_INVALID_STATE(HttpStatus.CONFLICT, "시작 전인 행사 일정만 취소할 수 있습니다."),
@@ -42,10 +42,10 @@ public enum EventErrorCode implements ErrorCode {
     INVALID_LONGITUDE(HttpStatus.BAD_REQUEST, "경도는 -180 ~ 180 범위여야 합니다."),
 
     // 권한 관련 에러
-    EVENT_UNAUTHORIZED(HttpStatus.FORBIDDEN, "이 이벤트에 대한 권한이 없습니다."),
-    EVENT_INVALID_STATE(HttpStatus.CONFLICT, "이벤트 상태가 유효하지 않습니다."),
-    EVENT_CANNOT_DELETE(HttpStatus.CONFLICT, "이 상태의 이벤트는 삭제할 수 없습니다."),
-    EVENT_CANNOT_UPDATE(HttpStatus.CONFLICT, "이 상태의 이벤트는 수정할 수 없습니다."),
+    EVENT_UNAUTHORIZED(HttpStatus.FORBIDDEN, "이 행사에 대한 권한이 없습니다."),
+    EVENT_INVALID_STATE(HttpStatus.CONFLICT, "행사 상태가 유효하지 않습니다."),
+    EVENT_CANNOT_DELETE(HttpStatus.CONFLICT, "이 상태의 행사는 삭제할 수 없습니다."),
+    EVENT_CANNOT_UPDATE(HttpStatus.CONFLICT, "이 상태의 행사는 수정할 수 없습니다."),
 
     // Kafka 에러
     EVENT_PUBLISH_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "이벤트 발행에 실패했습니다."),

--- a/event-service/src/main/java/com/ojosama/eventservice/event/domain/exception/EventErrorCode.java
+++ b/event-service/src/main/java/com/ojosama/eventservice/event/domain/exception/EventErrorCode.java
@@ -28,6 +28,9 @@ public enum EventErrorCode implements ErrorCode {
     EVENT_SCHEDULE_INVALID_NAME(HttpStatus.BAD_REQUEST, "스케줄 이름이 유효하지 않습니다. (비어있거나 100자 초과)"),
     EVENT_SCHEDULE_CONFLICT(HttpStatus.CONFLICT, "해당 시간에 다른 스케줄이 존재합니다."),
 
+    // EventScheduleAction 관련 에러
+    EVENT_SCHEDULE_ACTION_INVALID_STATE(HttpStatus.CONFLICT, "시작 전인 행사 일정만 취소할 수 있습니다."),
+
     // Ticketing 관련 에러
     TICKETING_NOT_AVAILABLE(HttpStatus.BAD_REQUEST, "현재 티켓팅이 불가능합니다."),
     TICKETING_CLOSED(HttpStatus.BAD_REQUEST, "티켓팅 기간이 종료되었습니다."),

--- a/event-service/src/main/java/com/ojosama/eventservice/event/domain/model/Event.java
+++ b/event-service/src/main/java/com/ojosama/eventservice/event/domain/model/Event.java
@@ -224,4 +224,11 @@ public class Event extends BaseUserEntity {
         }
         this.status = EventStatus.COMPLETED;
     }
+
+    public void markCancelled() {
+        if (this.status == EventStatus.COMPLETED || this.status == EventStatus.CANCELLED) {
+            throw new EventException(EventErrorCode.VALIDATION_ERROR);
+        }
+        this.status = EventStatus.CANCELLED;
+    }
 }

--- a/event-service/src/main/java/com/ojosama/eventservice/event/domain/model/EventScheduleAction.java
+++ b/event-service/src/main/java/com/ojosama/eventservice/event/domain/model/EventScheduleAction.java
@@ -77,4 +77,8 @@ public class EventScheduleAction {
                 : errorMessage;
     }
 
+    public void markCancelled() {
+        this.status = ScheduleActionStatus.CANCELLED;
+    }
+
 }

--- a/event-service/src/main/java/com/ojosama/eventservice/event/domain/model/EventScheduleAction.java
+++ b/event-service/src/main/java/com/ojosama/eventservice/event/domain/model/EventScheduleAction.java
@@ -1,5 +1,7 @@
 package com.ojosama.eventservice.event.domain.model;
 
+import com.ojosama.eventservice.event.domain.exception.EventErrorCode;
+import com.ojosama.eventservice.event.domain.exception.EventException;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -78,7 +80,11 @@ public class EventScheduleAction {
     }
 
     public void markCancelled() {
+        if (this.status != ScheduleActionStatus.PENDING) {
+            throw new EventException(EventErrorCode.EVENT_SCHEDULE_ACTION_INVALID_STATE);
+        }
         this.status = ScheduleActionStatus.CANCELLED;
+        this.errorMessage = null;
     }
 
 }

--- a/event-service/src/main/java/com/ojosama/eventservice/event/domain/model/ScheduleActionStatus.java
+++ b/event-service/src/main/java/com/ojosama/eventservice/event/domain/model/ScheduleActionStatus.java
@@ -8,7 +8,8 @@ import lombok.RequiredArgsConstructor;
 public enum ScheduleActionStatus {
     PENDING("대기"),
     EXECUTED("실행됨"),
-    FAILED("실패");
+    FAILED("실패"),
+    CANCELLED("취소됨");
 
     private final String description;
 }

--- a/event-service/src/main/java/com/ojosama/eventservice/event/domain/repository/EventScheduleActionRepository.java
+++ b/event-service/src/main/java/com/ojosama/eventservice/event/domain/repository/EventScheduleActionRepository.java
@@ -3,9 +3,11 @@ package com.ojosama.eventservice.event.domain.repository;
 import com.ojosama.eventservice.event.domain.model.EventScheduleAction;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.UUID;
 import org.springframework.data.domain.Pageable;
 
 public interface EventScheduleActionRepository {
     EventScheduleAction save(EventScheduleAction action);
     List<EventScheduleAction> findPendingByScheduledAtBefore(LocalDateTime now, Pageable pageable);
+    List<EventScheduleAction> findPendingByEventId(UUID eventId);
 }

--- a/event-service/src/main/java/com/ojosama/eventservice/event/infrastructure/messaging/kafka/producer/KafkaEventMessagePublisher.java
+++ b/event-service/src/main/java/com/ojosama/eventservice/event/infrastructure/messaging/kafka/producer/KafkaEventMessagePublisher.java
@@ -5,6 +5,7 @@ import com.ojosama.common.kafka.domain.OutboxEventPublisher;
 import com.ojosama.eventservice.event.domain.event.payload.EventCreatedMessage;
 import com.ojosama.eventservice.event.domain.event.payload.EventDeletedMessage;
 import com.ojosama.eventservice.event.domain.event.payload.EventScheduleChangedMessage;
+import com.ojosama.eventservice.event.domain.event.payload.EventStatusChangedMessage;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -26,6 +27,9 @@ public class KafkaEventMessagePublisher {
     @Value("${spring.kafka.topic.event-changed:event.schedule.changed.v1}")
     private String eventChangedTopic;
 
+    @Value("${spring.kafka.topic.event-status-changed:event.status.changed.v1}")
+    private String eventStatusChangedTopic;
+
     @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
     public void publishEventCreated(EventCreatedMessage message) {
         outboxEventPublisher.publish("Event", message.eventId(), EventType.EVENT_CREATED, eventCreatedTopic, message);
@@ -40,5 +44,10 @@ public class KafkaEventMessagePublisher {
     public void publishScheduleChanged(EventScheduleChangedMessage message) {
         outboxEventPublisher.publish("Event", message.eventId(), EventType.EVENT_SCHEDULE_CHANGED, eventChangedTopic,
                 message);
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
+    public void publishStatusChanged(EventStatusChangedMessage message) {
+        outboxEventPublisher.publish("Event", message.eventId(), EventType.EVENT_STATUS_CHANGED, eventStatusChangedTopic, message);
     }
 }

--- a/event-service/src/main/java/com/ojosama/eventservice/event/infrastructure/persistence/EventScheduleActionExecutor.java
+++ b/event-service/src/main/java/com/ojosama/eventservice/event/infrastructure/persistence/EventScheduleActionExecutor.java
@@ -57,7 +57,8 @@ public class EventScheduleActionExecutor {
                     event.getId(),
                     event.getName(),
                     beforeStatus,
-                    event.getStatus().name()
+                    event.getStatus().name(),
+                    java.util.Collections.emptyList()
                 ));
                 break;
 
@@ -68,7 +69,8 @@ public class EventScheduleActionExecutor {
                     event.getId(),
                     event.getName(),
                     beforeStatus,
-                    event.getStatus().name()
+                    event.getStatus().name(),
+                    java.util.Collections.emptyList()
                 ));
                 break;
         }

--- a/event-service/src/main/java/com/ojosama/eventservice/event/infrastructure/persistence/EventScheduleActionExecutor.java
+++ b/event-service/src/main/java/com/ojosama/eventservice/event/infrastructure/persistence/EventScheduleActionExecutor.java
@@ -6,9 +6,11 @@ import com.ojosama.eventservice.event.domain.model.Event;
 import com.ojosama.eventservice.event.domain.model.EventScheduleAction;
 import com.ojosama.eventservice.event.domain.repository.EventRepository;
 import com.ojosama.eventservice.event.domain.repository.EventScheduleActionRepository;
+import com.ojosama.eventservice.event.domain.event.payload.EventStatusChangedMessage;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,6 +22,7 @@ public class EventScheduleActionExecutor {
 
     private final EventScheduleActionRepository scheduleActionRepo;
     private final EventRepository eventRepository;
+    private final ApplicationEventPublisher applicationEventPublisher;
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void processOne(EventScheduleAction action) {
@@ -44,15 +47,29 @@ public class EventScheduleActionExecutor {
     }
 
     private void executeAction(Event event, EventScheduleAction action) {
+        String beforeStatus = event.getStatus().name();
+
         switch (action.getAction()) {
             case MARK_IN_PROGRESS:
                 event.markInProgress();
                 eventRepository.save(event);
+                applicationEventPublisher.publishEvent(new EventStatusChangedMessage(
+                    event.getId(),
+                    event.getName(),
+                    beforeStatus,
+                    event.getStatus().name()
+                ));
                 break;
 
             case MARK_COMPLETED:
                 event.markCompleted();
                 eventRepository.save(event);
+                applicationEventPublisher.publishEvent(new EventStatusChangedMessage(
+                    event.getId(),
+                    event.getName(),
+                    beforeStatus,
+                    event.getStatus().name()
+                ));
                 break;
         }
     }

--- a/event-service/src/main/java/com/ojosama/eventservice/event/infrastructure/persistence/EventScheduleActionRepositoryImpl.java
+++ b/event-service/src/main/java/com/ojosama/eventservice/event/infrastructure/persistence/EventScheduleActionRepositoryImpl.java
@@ -5,6 +5,7 @@ import com.ojosama.eventservice.event.domain.model.ScheduleActionStatus;
 import com.ojosama.eventservice.event.domain.repository.EventScheduleActionRepository;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
@@ -23,5 +24,10 @@ public class EventScheduleActionRepositoryImpl implements EventScheduleActionRep
     @Override
     public List<EventScheduleAction> findPendingByScheduledAtBefore(LocalDateTime now, Pageable pageable) {
         return jpaRepo.findPendingByScheduledAt(ScheduleActionStatus.PENDING, now, pageable);
+    }
+
+    @Override
+    public List<EventScheduleAction> findPendingByEventId(UUID eventId) {
+        return jpaRepo.findByEventIdAndStatus(eventId, ScheduleActionStatus.PENDING);
     }
 }

--- a/event-service/src/main/java/com/ojosama/eventservice/event/infrastructure/persistence/JpaEventScheduleActionRepository.java
+++ b/event-service/src/main/java/com/ojosama/eventservice/event/infrastructure/persistence/JpaEventScheduleActionRepository.java
@@ -18,4 +18,6 @@ public interface JpaEventScheduleActionRepository extends JpaRepository<EventSch
             @Param("status") ScheduleActionStatus status,
             @Param("now") LocalDateTime now,
             Pageable pageable);
+
+    List<EventScheduleAction> findByEventIdAndStatus(UUID eventId, ScheduleActionStatus status);
 }

--- a/event-service/src/main/java/com/ojosama/eventservice/event/presentation/controller/EventController.java
+++ b/event-service/src/main/java/com/ojosama/eventservice/event/presentation/controller/EventController.java
@@ -114,6 +114,18 @@ public class EventController {
         return ResponseEntity.noContent().build();
     }
 
+    @PatchMapping("/{eventId}/cancel")
+//    @PreAuthorize("hasAnyRole('ADMIN', 'CONCERT_MANAGER', 'FESTIVAL_MANAGER', 'FANMEETING_MANAGER', 'POPUP_MANAGER')")
+    public ResponseEntity<ApiResponse<EventResponse>> cancelEvent(
+            @RequestHeader(value = "X-User-Id", required = false) UUID userId,
+            @RequestHeader(value = "X-User-Role", required = false) String userRole,
+            @PathVariable UUID eventId) {
+
+//        if (userId == null || userRole == null) { throw new CustomException(CommonErrorCode.INVALID_TOKEN); }
+        EventResult result = eventCommandService.cancelEvent(eventId, userId);
+        return ResponseEntity.ok(ApiResponse.success(EventResponse.from(result)));
+    }
+
     private void validateAuthHeaders(UUID userId, String userRole) {
 //        if (userId == null || !StringUtils.hasText(userRole)) { throw new CustomException(CommonErrorCode.INVALID_TOKEN); }
     }

--- a/event-service/src/main/resources/application-docker.yaml
+++ b/event-service/src/main/resources/application-docker.yaml
@@ -24,6 +24,7 @@ spring:
       event-created: ${KAFKA_TOPIC_EVENT_CREATED:event.info.created.v1}
       event-deleted: ${KAFKA_TOPIC_EVENT_DELETED:event.info.deleted.v1}
       event-changed: ${KAFKA_TOPIC_EVENT_CHANGED:event.schedule.changed.v1}
+      event-status-changed: ${KAFKA_TOPIC_EVENT_STATUS_CHANGED:event.status.changed.v1}
       event-request-created: ${KAFKA_TOPIC_EVENT_REQUEST_CREATED:event.request.created.v1}
       event-request-created-result: ${KAFKA_TOPIC_EVENT_REQUEST_CREATED_RESULT:event.request.processed.v1}
 


### PR DESCRIPTION
## 🔗 Issue Number
- close #198 

- close #199 

## 📝 작업 내역

  - 행사 취소 API 엔드포인트 구현 (PATCH /v1/events/{eventId}/cancel)                                                                                                                                                                                               
  - EventStatusChangedMessage에 deletedScheduleIds 필드 추가
  - 행사 취소 시 진행 예정 일정 soft delete 처리
  - EventScheduleAction 상태 CANCELLED 추가

## 💡 PR 특이사항

- 행사 도중에 취소되면 진행되지 않은 행사 일정은 삭제처리했고, 일정 도메인에서 삭제된 행사 일정 ID를 리스트로 Kafka로 넘겨주었습니다.
- 자동 상태 변경(MARK_IN_PROGRESS/COMPLETED) 시에는 삭제되는 행사 일정이 없으므로 빈 리스트 전달

구조
```
public record EventStatusChangedMessage(
        UUID eventId,
        String eventName,
        String beforeStatus,
        String afterStatus,
        List<UUID> deletedScheduleIds
) {}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 이벤트 취소 기능이 추가되어 관리자가 이벤트를 취소할 수 있습니다.
  * 이벤트 취소 시 관련 예정 작업과 일정이 자동으로 취소 및 제거됩니다.
  * 이벤트 상태 변경 시 상태 변경 알림(메시지)이 발행됩니다.
* **Enhancements**
  * 일정 작업 상태에 "실패", "취소됨" 상태가 추가되었습니다.
  * 오류/검증 메시지 문구가 일관된 한국어 표현으로 정비되었습니다.
* **Chores**
  * 이벤트 상태 변경용 메시지 전송 토픽이 구성에 추가되었습니다.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/55josama/festie/pull/202)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->