### PR TITLE
[FEATURE] chat-service 스케줄러 중복 실행 방지 -동시성,분산 락

### DIFF
--- a/chat-service/src/main/java/com/ojosama/chatservice/application/scheduler/ChatRoomScheduler.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/application/scheduler/ChatRoomScheduler.java
@@ -2,11 +2,13 @@ package com.ojosama.chatservice.application.scheduler;
 
 import com.ojosama.chatservice.application.service.ChatRoomService;
 import java.time.LocalDateTime;
+import java.util.Collections;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -17,6 +19,12 @@ public class ChatRoomScheduler {
 
     private static final String LOCK_KEY = "chat:scheduler:chat-room-status";
     private static final long LOCK_TTL_SECONDS = 90L;
+    private static final DefaultRedisScript<Long> UNLOCK_SCRIPT = new DefaultRedisScript<>(
+            "if redis.call('get', KEYS[1]) == ARGV[1] then "
+                    + "return redis.call('del', KEYS[1]) "
+                    + "else return 0 end",
+            Long.class
+    );
 
     private final ChatRoomService chatRoomService;
     private final StringRedisTemplate redisTemplate;
@@ -64,9 +72,9 @@ public class ChatRoomScheduler {
     }
 
     private void releaseLock(String token) {
-        String currentToken = redisTemplate.opsForValue().get(LOCK_KEY);
-        if (token != null && token.equals(currentToken)) {
-            redisTemplate.delete(LOCK_KEY);
+        if (token == null) {
+            return;
         }
+        redisTemplate.execute(UNLOCK_SCRIPT, Collections.singletonList(LOCK_KEY), token);
     }
 }

--- a/chat-service/src/main/java/com/ojosama/chatservice/application/scheduler/ChatRoomScheduler.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/application/scheduler/ChatRoomScheduler.java
@@ -2,8 +2,11 @@ package com.ojosama.chatservice.application.scheduler;
 
 import com.ojosama.chatservice.application.service.ChatRoomService;
 import java.time.LocalDateTime;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -12,27 +15,58 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class ChatRoomScheduler {
 
+    private static final String LOCK_KEY = "chat:scheduler:chat-room-status";
+    private static final long LOCK_TTL_SECONDS = 90L;
+
     private final ChatRoomService chatRoomService;
+    private final StringRedisTemplate redisTemplate;
 
     @Scheduled(fixedDelay = 60000) // 1 min
     public void syncChatRoomStatus() {
+        String lockToken = acquireLock();
+        if (lockToken == null) { // 락 성공 토큰을 받지 못하면 null
+            log.info("채팅방 스케쥴러가 이미 다른 인스턴스에서 실행 중입니다.");
+            return;
+        }
+
         LocalDateTime now = LocalDateTime.now();
         int openedCount = 0;
         int closedCount = 0;
 
         try {
-            openedCount = chatRoomService.openScheduledChatRooms(now);
-        } catch (Exception e) {
-            log.error("스케쥴러가 채팅방 오픈에 실패했습니다. now={}", now, e);
-        }
+            try { // try-finally 추가, 락 건거 해제하는걸 finally
+                openedCount = chatRoomService.openScheduledChatRooms(now);
+            } catch (Exception e) {
+                log.error("스케쥴러가 채팅방 오픈에 실패했습니다. now={}", now, e);
+            }
 
-        try {
-            closedCount = chatRoomService.closeScheduledChatRooms(now);
-        } catch (Exception e) {
-            log.error("스케쥴러가 채팅방 종료에 실패했습니다. now={}", now, e);
-        }
+            try {
+                closedCount = chatRoomService.closeScheduledChatRooms(now);
+            } catch (Exception e) {
+                log.error("스케쥴러가 채팅방 종료에 실패했습니다. now={}", now, e);
+            }
 
-        log.info("채팅방 스케쥴러가 실행되었습니다. openedCount={}, closedCount={}, now={}",
-                openedCount, closedCount, now);
+            log.info("채팅방 스케쥴러가 실행되었습니다. openedCount={}, closedCount={}, now={}",
+                    openedCount, closedCount, now);
+        } finally { // 락 해제 (락토큰)
+            releaseLock(lockToken);
+        }
+    }
+
+    private String acquireLock() {
+        String token = UUID.randomUUID().toString();
+        Boolean locked = redisTemplate.opsForValue()
+                .setIfAbsent(LOCK_KEY, token, LOCK_TTL_SECONDS, TimeUnit.SECONDS);
+        if (!Boolean.TRUE.equals(locked)) {
+            return null;
+        }
+        return token;
+    }
+
+    private void releaseLock(String token) {
+        String currentToken = redisTemplate.opsForValue().get(LOCK_KEY);
+        if (token != null && token.equals(currentToken)) {
+            redisTemplate.delete(LOCK_KEY);
+        }
     }
 }

--- a/chat-service/src/test/java/com/ojosama/chatservice/application/scheduler/ChatRoomSchedulerTest.java
+++ b/chat-service/src/test/java/com/ojosama/chatservice/application/scheduler/ChatRoomSchedulerTest.java
@@ -3,6 +3,7 @@ package com.ojosama.chatservice.application.scheduler;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -22,6 +23,7 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
 import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
@@ -64,10 +66,16 @@ class ChatRoomSchedulerTest {
             String key = invocation.getArgument(0, String.class);
             return values.get(key);
         });
-        when(redisTemplate.delete(anyString())).thenAnswer(invocation -> {
-            String key = invocation.getArgument(0, String.class);
-            return values.remove(key) != null;
-        });
+        when(redisTemplate.execute(any(DefaultRedisScript.class), anyList(), anyString()))
+                .thenAnswer(invocation -> {
+                    String key = invocation.getArgument(1, java.util.List.class).get(0).toString();
+                    String token = invocation.getArgument(2, String.class);
+                    if (token != null && token.equals(values.get(key))) {
+                        values.remove(key);
+                        return 1L;
+                    }
+                    return 0L;
+                });
     }
 
     @Test

--- a/chat-service/src/test/java/com/ojosama/chatservice/application/scheduler/ChatRoomSchedulerTest.java
+++ b/chat-service/src/test/java/com/ojosama/chatservice/application/scheduler/ChatRoomSchedulerTest.java
@@ -1,0 +1,96 @@
+package com.ojosama.chatservice.application.scheduler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.ojosama.chatservice.application.service.ChatRoomService;
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class ChatRoomSchedulerTest {
+
+    @Mock
+    private ChatRoomService chatRoomService;
+
+    @Mock
+    private StringRedisTemplate redisTemplate;
+
+    @Mock
+    private ValueOperations<String, String> valueOperations;
+
+    private final Map<String, String> values = new HashMap<>();
+
+    private ChatRoomScheduler scheduler;
+    private String lockKey;
+
+    @BeforeEach
+    void setUp() {
+        // Redis를 진짜로 붙이지 않고, 메모리 Map으로 락 상태만
+        // 그래서 "락이 있으면 스킵 / 없으면 실행" 흐름만 테스트
+        scheduler = new ChatRoomScheduler(chatRoomService, redisTemplate);
+        lockKey = (String) ReflectionTestUtils.getField(ChatRoomScheduler.class, "LOCK_KEY");
+
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        when(valueOperations.setIfAbsent(anyString(), anyString(), anyLong(), any(TimeUnit.class)))
+                .thenAnswer(invocation -> {
+                    String key = invocation.getArgument(0, String.class);
+                    String token = invocation.getArgument(1, String.class);
+                    if (values.containsKey(key)) {
+                        return false;
+                    }
+                    values.put(key, token);
+                    return true;
+                });
+        when(valueOperations.get(anyString())).thenAnswer(invocation -> {
+            String key = invocation.getArgument(0, String.class);
+            return values.get(key);
+        });
+        when(redisTemplate.delete(anyString())).thenAnswer(invocation -> {
+            String key = invocation.getArgument(0, String.class);
+            return values.remove(key) != null;
+        });
+    }
+
+    @Test
+    void shouldRunScheduleWhenLockIsAvailable() {
+        // 락이 비어 있으면 스케줄러가 정상적으로 실행되는거 확인
+        when(chatRoomService.openScheduledChatRooms(any(LocalDateTime.class))).thenReturn(2);
+        when(chatRoomService.closeScheduledChatRooms(any(LocalDateTime.class))).thenReturn(1);
+
+        scheduler.syncChatRoomStatus();
+
+        verify(chatRoomService).openScheduledChatRooms(any(LocalDateTime.class));
+        verify(chatRoomService).closeScheduledChatRooms(any(LocalDateTime.class));
+        assertThat(values).doesNotContainKey(lockKey);
+    }
+
+    @Test
+    void shouldSkipScheduleWhenLockIsAlreadyHeld() {
+        // 이미 다른 인스턴스가 락을 잡고 있으면 이번 실행은 바로 건너뜀
+        values.put(lockKey, "other-token");
+
+        scheduler.syncChatRoomStatus();
+
+        verifyNoInteractions(chatRoomService);
+        assertThat(values).containsKey(lockKey);
+    }
+}

--- a/chat-service/src/test/java/com/ojosama/chatservice/application/service/ChatRoomPopularityTrackerTest.java
+++ b/chat-service/src/test/java/com/ojosama/chatservice/application/service/ChatRoomPopularityTrackerTest.java
@@ -1,0 +1,251 @@
+package com.ojosama.chatservice.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.data.redis.core.DefaultTypedTuple;
+import org.springframework.data.redis.core.HashOperations;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.data.redis.core.ZSetOperations;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class ChatRoomPopularityTrackerTest {
+
+    private static final String TOPIC_PREFIX = "/topic/rooms/";
+    private static final String TOPIC_SUFFIX = "/messages";
+
+    @Mock
+    private StringRedisTemplate redisTemplate;
+
+    @Mock
+    private HashOperations<String, Object, Object> hashOperations;
+
+    @Mock
+    private ZSetOperations<String, String> zSetOperations;
+
+    @Mock
+    private ValueOperations<String, String> valueOperations;
+
+    private final Map<String, Map<String, String>> hashes = new HashMap<>();
+    private final Map<String, String> stringValues = new HashMap<>();
+    private final Map<String, Double> scores = new HashMap<>();
+
+    private ChatRoomPopularityTracker tracker;
+    private String lockKeyPrefix;
+
+    @BeforeEach
+    void setUp() {
+        // Redis 구조를 테스트용 메모리 Map으로 대체
+        // 세션 락 / 구독 수 / 인기 점수만 집중해서 검증할 수 있다.
+        tracker = new ChatRoomPopularityTracker(redisTemplate);
+        lockKeyPrefix = (String) ReflectionTestUtils.getField(
+                ChatRoomPopularityTracker.class,
+                "SESSION_LOCK_KEY_PREFIX"
+        );
+
+        when(redisTemplate.opsForHash()).thenReturn(hashOperations);
+        when(redisTemplate.opsForZSet()).thenReturn(zSetOperations);
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        when(redisTemplate.delete(anyString())).thenAnswer(invocation -> {
+            String key = invocation.getArgument(0, String.class);
+            boolean removed = hashes.remove(key) != null;
+            removed = stringValues.remove(key) != null || removed;
+            return removed;
+        });
+
+        when(hashOperations.putIfAbsent(anyString(), any(), any())).thenAnswer(invocation -> {
+            String key = invocation.getArgument(0, String.class);
+            String field = String.valueOf(invocation.getArgument(1, Object.class));
+            String value = String.valueOf(invocation.getArgument(2, Object.class));
+            Map<String, String> hash = hashes.computeIfAbsent(key, ignored -> new HashMap<>());
+            return hash.putIfAbsent(field, value) == null;
+        });
+
+        when(hashOperations.get(anyString(), any())).thenAnswer(invocation -> {
+            String key = invocation.getArgument(0, String.class);
+            String field = String.valueOf(invocation.getArgument(1, Object.class));
+            Map<String, String> hash = hashes.get(key);
+            return hash == null ? null : hash.get(field);
+        });
+
+        when(hashOperations.increment(anyString(), any(), anyLong())).thenAnswer(invocation -> {
+            String key = invocation.getArgument(0, String.class);
+            String field = String.valueOf(invocation.getArgument(1, Object.class));
+            long delta = invocation.getArgument(2, Long.class);
+            Map<String, String> hash = hashes.computeIfAbsent(key, ignored -> new HashMap<>());
+            long current = parseLong(hash.get(field));
+            long next = current + delta;
+            hash.put(field, Long.toString(next));
+            return next;
+        });
+
+        when(hashOperations.delete(anyString(), any())).thenAnswer(invocation -> {
+            String key = invocation.getArgument(0, String.class);
+            String field = String.valueOf(invocation.getArgument(1, Object.class));
+            Map<String, String> hash = hashes.get(key);
+            if (hash == null) {
+                return 0L;
+            }
+            return hash.remove(field) != null ? 1L : 0L;
+        });
+
+        when(hashOperations.entries(anyString())).thenAnswer(invocation -> {
+            String key = invocation.getArgument(0, String.class);
+            Map<String, String> hash = hashes.get(key);
+            if (hash == null) {
+                return Collections.emptyMap();
+            }
+            return new HashMap<>(hash);
+        });
+
+        when(zSetOperations.incrementScore(anyString(), anyString(), anyDouble())).thenAnswer(invocation -> {
+            String member = invocation.getArgument(1, String.class);
+            double delta = invocation.getArgument(2, Double.class);
+            double next = scores.getOrDefault(member, 0D) + delta;
+            scores.put(member, next);
+            return next;
+        });
+
+        when(zSetOperations.remove(anyString(), anyString())).thenAnswer(invocation -> {
+            String member = invocation.getArgument(1, String.class);
+            return scores.remove(member) == null ? 0L : 1L;
+        });
+
+        when(zSetOperations.score(anyString(), anyString())).thenAnswer(invocation -> {
+            String member = invocation.getArgument(1, String.class);
+            return scores.get(member);
+        });
+
+        when(zSetOperations.reverseRangeWithScores(anyString(), anyLong(), anyLong())).thenAnswer(invocation -> {
+            List<Map.Entry<String, Double>> ordered = new ArrayList<>(scores.entrySet());
+            ordered.sort(Map.Entry.<String, Double>comparingByValue().reversed());
+
+            Set<ZSetOperations.TypedTuple<String>> tuples = new java.util.LinkedHashSet<>();
+            ordered.forEach(entry -> {
+                if (entry.getValue() != null && entry.getValue() > 0D) {
+                    tuples.add(new DefaultTypedTuple<>(entry.getKey(), entry.getValue()));
+                }
+            });
+            return tuples;
+        });
+
+        when(valueOperations.setIfAbsent(anyString(), anyString(), anyLong(), any(TimeUnit.class))).thenAnswer(
+                invocation -> {
+                    String key = invocation.getArgument(0, String.class);
+                    String value = invocation.getArgument(1, String.class);
+                    if (stringValues.containsKey(key)) {
+                        return false;
+                    }
+                    stringValues.put(key, value);
+                    return true;
+                });
+
+        when(valueOperations.get(anyString())).thenAnswer(invocation -> {
+            String key = invocation.getArgument(0, String.class);
+            return stringValues.get(key);
+        });
+    }
+
+    @Test
+    void shouldCountOneViewerPerSessionForSameRoom() {
+        // 같은 세션이 같은 방을 여러 번 구독해도 viewer는 1명으로만 세기.
+        UUID roomId = UUID.randomUUID();
+
+        tracker.markSubscribed("session-1", "sub-1", topic(roomId));
+        tracker.markSubscribed("session-1", "sub-2", topic(roomId));
+        tracker.markSubscribed("session-2", "sub-3", topic(roomId));
+
+        assertThat(tracker.getViewerCount(roomId)).isEqualTo(2);
+
+        tracker.markUnsubscribed("session-1", "sub-1");
+        assertThat(tracker.getViewerCount(roomId)).isEqualTo(2);
+
+        tracker.markUnsubscribed("session-1", "sub-2");
+        assertThat(tracker.getViewerCount(roomId)).isEqualTo(1);
+
+        tracker.clearSession("session-2");
+        assertThat(tracker.getViewerCount(roomId)).isZero();
+    }
+
+    @Test
+    void shouldSkipSessionUpdateWhenLockIsAlreadyHeld() {
+        // 세션 락이 이미 있으면 이 세션의 구독/해제 처리는 건너뜀
+        UUID roomId = UUID.randomUUID();
+        String sessionId = "session-1";
+        String sessionLockKey = sessionLockKey(sessionId);
+        stringValues.put(sessionLockKey, "other-token");
+
+        tracker.markSubscribed(sessionId, "sub-1", topic(roomId));
+
+        assertThat(tracker.getViewerCount(roomId)).isZero();
+        assertThat(hashes).isEmpty();
+    }
+
+    @Test
+    void shouldReturnViewerCountsInDescendingOrder() {
+        // Redis에 쌓인 인기 순서가 그대로 TOP 순서
+        UUID room1 = UUID.randomUUID();
+        UUID room2 = UUID.randomUUID();
+        UUID room3 = UUID.randomUUID();
+
+        tracker.markSubscribed("session-1", "sub-1", topic(room1));
+        tracker.markSubscribed("session-2", "sub-2", topic(room1));
+        tracker.markSubscribed("session-3", "sub-3", topic(room2));
+        tracker.markSubscribed("session-4", "sub-4", topic(room2));
+        tracker.markSubscribed("session-5", "sub-5", topic(room2));
+        tracker.markSubscribed("session-6", "sub-6", topic(room3));
+
+        Map<UUID, Integer> snapshot = tracker.snapshotViewerCounts();
+
+        assertThat(snapshot.keySet()).containsExactly(room2, room1, room3);
+        assertThat(snapshot.get(room2)).isEqualTo(3);
+        assertThat(snapshot.get(room1)).isEqualTo(2);
+        assertThat(snapshot.get(room3)).isEqualTo(1);
+    }
+
+    @Test
+    void shouldIgnoreInvalidDestination() {
+        // 채팅방 topic 형식이 아니면 집계에 넣지 않음
+        tracker.markSubscribed("session-1", "sub-1", "/topic/not-a-room");
+        tracker.markSubscribed("session-1", "sub-2", null);
+
+        assertThat(tracker.snapshotViewerCounts()).isEmpty();
+    }
+
+    private String topic(UUID roomId) {
+        return TOPIC_PREFIX + roomId + TOPIC_SUFFIX;
+    }
+
+    private String sessionLockKey(String sessionId) {
+        return lockKeyPrefix.formatted(sessionId);
+    }
+
+    private long parseLong(String value) {
+        if (value == null || value.isBlank()) {
+            return 0L;
+        }
+        return Long.parseLong(value);
+    }
+}


### PR DESCRIPTION
## 🔗 Issue Number
- close #201

## 📝 작업 내역 요약 
- 채팅방 자동 오픈/종료 스케줄러가 멀티 인스턴스 환경에서 중복 실행될 수 있는 문제를 막기 위해 Redis 분산락을 추가
- 락이 실제로 동작하는지 확인할 수 있도록 테스트도 함께 추가

## 💡 작업 내용

- 채팅방 스케줄러에 Redis 기반 분산락 추가
- 스케줄러 실행 전 락 획득
- 이미 다른 인스턴스가 락을 잡고 있으면 이번 실행은 스킵
- 작업이 끝나면 토큰 비교 후 락 해제
- 락이 정상적으로 동작하는지 테스트 추가

테스트는 AI의 도움을 많이받았습니다 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * Redis 기반 분산 잠금으로 다중 인스턴스 환경에서의 동시 실행 방지 및 채팅방 상태 동기화 안정성 강화

* **테스트**
  * 채팅방 스케줄러의 잠금 메커니즘 및 인기도 추적 기능에 대한 테스트 추가로 신뢰성 향상

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/55josama/festie/pull/203)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->