### PR TITLE
[FEATURE] chat-service 이벤트 취소 시 채팅방 종료 시간 자동 조정 및 시스템 안내 메시지 추가

### DIFF
--- a/chat-service/src/main/java/com/ojosama/chatservice/application/dto/result/MessageResult.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/application/dto/result/MessageResult.java
@@ -16,6 +16,8 @@ public record MessageResult(
         MessageStatus status,
         LocalDateTime createdAt
 ) {
+    private static final UUID SYSTEM_NOTICE_USER_ID = UUID.fromString("00000000-0000-0000-0000-000000000000");
+
     public static MessageResult from(Message message) {
         return new MessageResult(
                 message.getId(),
@@ -30,7 +32,7 @@ public record MessageResult(
     }
 
     private static MessageType resolveMessageType(Message message) {
-        if (message != null && "시스템".equals(message.getWriterNickname())) {
+        if (message != null && SYSTEM_NOTICE_USER_ID.equals(message.getUserId())) {
             return MessageType.SYSTEM;
         }
         return MessageType.USER;

--- a/chat-service/src/main/java/com/ojosama/chatservice/application/dto/result/MessageResult.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/application/dto/result/MessageResult.java
@@ -1,6 +1,7 @@
 package com.ojosama.chatservice.application.dto.result;
 
 import com.ojosama.chatservice.domain.model.Message;
+import com.ojosama.chatservice.domain.model.MessageType;
 import com.ojosama.chatservice.domain.model.MessageStatus;
 import java.time.LocalDateTime;
 import java.util.UUID;
@@ -10,6 +11,7 @@ public record MessageResult(
         UUID chatRoomId,
         UUID userId,
         String writerNickname,
+        MessageType messageType,
         String content,
         MessageStatus status,
         LocalDateTime createdAt
@@ -20,9 +22,17 @@ public record MessageResult(
                 message.getChatRoomId(),
                 message.getUserId(),
                 message.getWriterNickname(),
+                resolveMessageType(message),
                 message.getContent(),
                 message.getStatus(),
                 message.getCreatedAt()
         );
+    }
+
+    private static MessageType resolveMessageType(Message message) {
+        if (message != null && "시스템".equals(message.getWriterNickname())) {
+            return MessageType.SYSTEM;
+        }
+        return MessageType.USER;
     }
 }

--- a/chat-service/src/main/java/com/ojosama/chatservice/application/service/ChatRoomService.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/application/service/ChatRoomService.java
@@ -15,6 +15,7 @@ import com.ojosama.chatservice.domain.repository.ChatRoomRepository;
 import com.ojosama.common.exception.CommonErrorCode;
 import java.sql.SQLException;
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -104,6 +105,24 @@ public class ChatRoomService {
                 )
         );
 
+        return ChatRoomResult.from(chatRoomRepository.save(chatRoom));
+    }
+
+    public ChatRoomResult changeChatRoomScheduleForCancellation(UUID eventId, LocalDateTime cancelledAt) {
+        if (eventId == null || cancelledAt == null) {
+            throw new ChatException(CommonErrorCode.INVALID_REQUEST);
+        }
+
+        ChatRoom chatRoom = chatRoomRepository.findByEventId(eventId)
+                .orElseThrow(() -> new ChatException(ChatErrorCode.CHAT_ROOM_NOT_FOUND));
+
+        LocalDateTime scheduledCloseAt = cancelledAt.plusMinutes(10).truncatedTo(ChronoUnit.MINUTES);
+        LocalDateTime scheduledOpenAt = chatRoom.getSchedule().getScheduledOpenAt();
+        if (!scheduledCloseAt.isAfter(scheduledOpenAt)) {
+            scheduledOpenAt = cancelledAt.truncatedTo(ChronoUnit.MINUTES);
+        }
+
+        chatRoom.reschedule(new ChatRoomSchedule(scheduledOpenAt, scheduledCloseAt));
         return ChatRoomResult.from(chatRoomRepository.save(chatRoom));
     }
 

--- a/chat-service/src/main/java/com/ojosama/chatservice/application/service/ChatRoomService.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/application/service/ChatRoomService.java
@@ -1,7 +1,7 @@
 package com.ojosama.chatservice.application.service;
 
-import com.ojosama.chatservice.application.dto.command.ChangeChatRoomStatusCommand;
 import com.ojosama.chatservice.application.dto.command.ChangeChatRoomScheduleCommand;
+import com.ojosama.chatservice.application.dto.command.ChangeChatRoomStatusCommand;
 import com.ojosama.chatservice.application.dto.command.CreateChatRoomCommand;
 import com.ojosama.chatservice.application.dto.query.FindChatRoomByEventIdQuery;
 import com.ojosama.chatservice.application.dto.query.FindChatRoomQuery;
@@ -116,7 +116,11 @@ public class ChatRoomService {
         ChatRoom chatRoom = chatRoomRepository.findByEventId(eventId)
                 .orElseThrow(() -> new ChatException(ChatErrorCode.CHAT_ROOM_NOT_FOUND));
 
-        LocalDateTime scheduledCloseAt = cancelledAt.plusMinutes(10).truncatedTo(ChronoUnit.MINUTES);
+        LocalDateTime candidateCloseAt = cancelledAt.plusMinutes(10).truncatedTo(ChronoUnit.MINUTES);
+        LocalDateTime currentCloseAt = chatRoom.getSchedule().getScheduledCloseAt();
+        LocalDateTime scheduledCloseAt = currentCloseAt != null && currentCloseAt.isBefore(candidateCloseAt)
+                ? currentCloseAt
+                : candidateCloseAt;
         LocalDateTime scheduledOpenAt = chatRoom.getSchedule().getScheduledOpenAt();
         if (!scheduledCloseAt.isAfter(scheduledOpenAt)) {
             scheduledOpenAt = cancelledAt.truncatedTo(ChronoUnit.MINUTES);

--- a/chat-service/src/main/java/com/ojosama/chatservice/application/service/MessageService.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/application/service/MessageService.java
@@ -42,8 +42,8 @@ public class MessageService {
     private static final int MAX_MESSAGE_CONTENT_LENGTH = 1000;
     private static final int MAX_WRITER_NICKNAME_LENGTH = 50;
     private static final int MAX_PAGE_SIZE = 100;
-    private static final UUID SYSTEM_BLINDER_ID = UUID.fromString("00000000-0000-0000-0000-000000000001");
-    private static final UUID SYSTEM_NOTICE_USER_ID = UUID.fromString("00000000-0000-0000-0000-000000000002");
+    private static final UUID SYSTEM_BLINDER_ID = UUID.fromString("00000000-0000-0000-0000-000000000000");
+    private static final UUID SYSTEM_NOTICE_USER_ID = UUID.fromString("00000000-0000-0000-0000-000000000000");
     private static final String SYSTEM_WRITER_NICKNAME = "시스템";
     private static final String AGGREGATE_TYPE = "CHAT";
 

--- a/chat-service/src/main/java/com/ojosama/chatservice/application/service/MessageService.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/application/service/MessageService.java
@@ -43,6 +43,8 @@ public class MessageService {
     private static final int MAX_WRITER_NICKNAME_LENGTH = 50;
     private static final int MAX_PAGE_SIZE = 100;
     private static final UUID SYSTEM_BLINDER_ID = UUID.fromString("00000000-0000-0000-0000-000000000001");
+    private static final UUID SYSTEM_NOTICE_USER_ID = UUID.fromString("00000000-0000-0000-0000-000000000002");
+    private static final String SYSTEM_WRITER_NICKNAME = "시스템";
     private static final String AGGREGATE_TYPE = "CHAT";
 
     private final MessageRepository messageRepository;
@@ -84,6 +86,24 @@ public class MessageService {
         );
 
         return MessageResult.from(savedMessage);
+    }
+
+    public MessageResult createSystemNotice(UUID chatRoomId, String content) {
+        if (chatRoomId == null) {
+            throw new ChatException(CommonErrorCode.INVALID_REQUEST);
+        }
+        validateContent(content);
+
+        findChatRoom(chatRoomId);
+
+        Message message = Message.builder()
+                .chatRoomId(chatRoomId)
+                .userId(SYSTEM_NOTICE_USER_ID)
+                .writerNickname(SYSTEM_WRITER_NICKNAME)
+                .content(content.trim())
+                .build();
+
+        return MessageResult.from(messageRepository.save(message));
     }
 
     @Transactional(readOnly = true)

--- a/chat-service/src/main/java/com/ojosama/chatservice/domain/model/MessageType.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/domain/model/MessageType.java
@@ -1,0 +1,6 @@
+package com.ojosama.chatservice.domain.model;
+
+public enum MessageType {
+    USER,
+    SYSTEM
+}

--- a/chat-service/src/main/java/com/ojosama/chatservice/infrastructure/messaging/kafka/consumer/EventStatusChangedConsumer.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/infrastructure/messaging/kafka/consumer/EventStatusChangedConsumer.java
@@ -1,0 +1,145 @@
+package com.ojosama.chatservice.infrastructure.messaging.kafka.consumer;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ojosama.chatservice.application.dto.result.ChatRoomResult;
+import com.ojosama.chatservice.application.dto.result.MessageResult;
+import com.ojosama.chatservice.application.service.ChatRoomService;
+import com.ojosama.chatservice.application.service.MessageService;
+import com.ojosama.chatservice.domain.exception.ChatErrorCode;
+import com.ojosama.chatservice.domain.exception.ChatException;
+import com.ojosama.chatservice.infrastructure.messaging.kafka.dto.EventStatusChangedEvent;
+import com.ojosama.chatservice.presentation.dto.response.MessageWsResponse;
+import com.ojosama.common.kafka.domain.EventType;
+import com.ojosama.common.kafka.domain.IdempotentEventHandler;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.http.HttpStatus;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class EventStatusChangedConsumer {
+
+    private static final String CONSUMER_GROUP = "chat-service-group";
+    private static final String EVENT_TYPE = EventType.EVENT_STATUS_CHANGED.getValue();
+    private static final String ROOM_TOPIC_PREFIX = "/topic/rooms/";
+    private static final String ROOM_TOPIC_SUFFIX = "/messages";
+    private static final String CANCELLATION_NOTICE_TEMPLATE = "행사가 취소되어 채팅방이 %s에 닫힙니다";
+    private static final DateTimeFormatter NOTICE_TIME_FORMATTER =
+            DateTimeFormatter.ofPattern("MM월 dd일 HH시 mm분");
+
+    private final ObjectMapper objectMapper;
+    private final IdempotentEventHandler idempotentHandler;
+    private final ChatRoomService chatRoomService;
+    private final MessageService messageService;
+    private final SimpMessagingTemplate messagingTemplate;
+
+    @KafkaListener(
+            topics = "${spring.kafka.topic.event-status-changed:event.status.changed.v1}",
+            groupId = CONSUMER_GROUP,
+            containerFactory = "kafkaListenerContainerFactory"
+    )
+    public void onMessage(ConsumerRecord<String, String> record) {
+        try {
+            EventStatusChangedEvent event = parse(record.value(), record.topic());
+            if (event == null || event.eventId() == null) {
+                return;
+            }
+
+            UUID messageKey = parseMessageKey(record.key(), event.eventId(), record.topic());
+            if (messageKey == null) {
+                return;
+            }
+
+            idempotentHandler.handle(
+                    messageKey,
+                    CONSUMER_GROUP,
+                    record.topic(),
+                    EVENT_TYPE,
+                    () -> dispatch(event)
+            );
+            log.info("행사 상태 변경 메시지 처리를 완료했습니다. key={}, topic={}", record.key(), record.topic());
+        } catch (RuntimeException e) {
+            log.error("행사 상태 변경 이벤트 처리에 실패했습니다. key={}, topic={}",
+                    record.key(), record.topic(), e);
+            throw e;
+        }
+    }
+
+    private void dispatch(EventStatusChangedEvent event) {
+        if (!event.isCancelled()) {
+            log.info("취소 상태가 아니어서 채팅방 종료시간 조정을 건너뜁니다. eventId={}, afterStatus={}",
+                    event.eventId(), event.afterStatus());
+            return;
+        }
+
+        try {
+            // 현재 시간을 취소 시간으로 저장 (정확히는 이벤트 수신 시간)
+            LocalDateTime cancelledAt = LocalDateTime.now();
+            ChatRoomResult updatedRoom = chatRoomService.changeChatRoomScheduleForCancellation(
+                    event.eventId(),
+                    cancelledAt
+            );
+
+            // 종료 시간 안내 포맷
+            LocalDateTime closingAt = updatedRoom.scheduledCloseAt();
+            String notice = String.format(
+                    CANCELLATION_NOTICE_TEMPLATE,
+                    closingAt.format(NOTICE_TIME_FORMATTER)
+            );
+
+            // 관리자(시스템) 안내 메시지 자동 출력
+            MessageResult message = messageService.createSystemNotice(updatedRoom.chatRoomId(), notice);
+            messagingTemplate.convertAndSend(
+                    ROOM_TOPIC_PREFIX + updatedRoom.chatRoomId() + ROOM_TOPIC_SUFFIX,
+                    MessageWsResponse.from(message)
+            );
+
+            log.info("행사 취소를 반영해 채팅방 종료시간을 갱신하고 안내 메시지를 전송했습니다. eventId={}, chatRoomId={}, closeAt={}",
+                    event.eventId(), updatedRoom.chatRoomId(), closingAt);
+        } catch (ChatException e) {
+            if (HttpStatus.NOT_FOUND.equals(e.getStatus())
+                    || ChatErrorCode.CHAT_ROOM_NOT_FOUND.getStatus().equals(e.getStatus())) {
+                log.warn("채팅방이 없어 행사 취소 반영을 건너뜁니다. eventId={}", event.eventId());
+                return;
+            }
+            throw e;
+        } catch (RuntimeException e) {
+            log.error("행사 취소 채팅방 처리 중 오류가 발생했습니다. eventId={}", event.eventId(), e);
+            throw e;
+        }
+    }
+
+    private UUID parseMessageKey(String key, UUID fallbackEventId, String topic) {
+        if (key != null && !key.isBlank()) {
+            try {
+                return UUID.fromString(key);
+            } catch (IllegalArgumentException e) {
+                log.warn("행사 상태 변경 이벤트 key 형식이 올바르지 않아 payload eventId로 대체합니다. key={}, topic={}",
+                        key, topic);
+            }
+        }
+        return fallbackEventId;
+    }
+
+    private EventStatusChangedEvent parse(String payload, String topic) {
+        if (payload == null || payload.isBlank()) {
+            log.warn("행사 상태 변경 이벤트 payload가 비어 있어 건너뜁니다. topic={}", topic);
+            return null;
+        }
+        try {
+            return objectMapper.readValue(payload, EventStatusChangedEvent.class);
+        } catch (JsonProcessingException e) {
+            log.warn("행사 상태 변경 이벤트 페이로드 파싱에 실패해 건너뜁니다. topic={}", topic);
+            return null;
+        }
+    }
+}

--- a/chat-service/src/main/java/com/ojosama/chatservice/infrastructure/messaging/kafka/consumer/EventStatusChangedConsumer.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/infrastructure/messaging/kafka/consumer/EventStatusChangedConsumer.java
@@ -18,7 +18,6 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
-import org.springframework.http.HttpStatus;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Component;
@@ -106,8 +105,7 @@ public class EventStatusChangedConsumer {
             log.info("행사 취소를 반영해 채팅방 종료시간을 갱신하고 안내 메시지를 전송했습니다. eventId={}, chatRoomId={}, closeAt={}",
                     event.eventId(), updatedRoom.chatRoomId(), closingAt);
         } catch (ChatException e) {
-            if (HttpStatus.NOT_FOUND.equals(e.getStatus())
-                    || ChatErrorCode.CHAT_ROOM_NOT_FOUND.getStatus().equals(e.getStatus())) {
+            if (ChatErrorCode.CHAT_ROOM_NOT_FOUND.getStatus().equals(e.getStatus())) {
                 log.warn("채팅방이 없어 행사 취소 반영을 건너뜁니다. eventId={}", event.eventId());
                 return;
             }

--- a/chat-service/src/main/java/com/ojosama/chatservice/infrastructure/messaging/kafka/dto/EventStatusChangedEvent.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/infrastructure/messaging/kafka/dto/EventStatusChangedEvent.java
@@ -1,0 +1,18 @@
+package com.ojosama.chatservice.infrastructure.messaging.kafka.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.List;
+import java.util.UUID;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record EventStatusChangedEvent(
+        UUID eventId,
+        String eventName,
+        String beforeStatus,
+        String afterStatus,
+        List<UUID> deletedScheduleIds
+) {
+    public boolean isCancelled() {
+        return "CANCELLED".equalsIgnoreCase(afterStatus);
+    }
+}

--- a/chat-service/src/main/java/com/ojosama/chatservice/presentation/dto/response/MessageResponse.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/presentation/dto/response/MessageResponse.java
@@ -1,6 +1,7 @@
 package com.ojosama.chatservice.presentation.dto.response;
 
 import com.ojosama.chatservice.application.dto.result.MessageResult;
+import com.ojosama.chatservice.domain.model.MessageType;
 import com.ojosama.chatservice.domain.model.MessageStatus;
 import java.time.LocalDateTime;
 import java.util.UUID;
@@ -10,6 +11,7 @@ public record MessageResponse(
         UUID chatRoomId,
         UUID userId,
         String writerNickname,
+        MessageType messageType,
         String content,
         MessageStatus status,
         LocalDateTime createdAt
@@ -29,6 +31,7 @@ public record MessageResponse(
                 result.chatRoomId(),
                 result.userId(),
                 result.writerNickname(),
+                result.messageType(),
                 content,
                 result.status(),
                 result.createdAt()

--- a/chat-service/src/main/java/com/ojosama/chatservice/presentation/dto/response/MessageWsResponse.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/presentation/dto/response/MessageWsResponse.java
@@ -1,6 +1,7 @@
 package com.ojosama.chatservice.presentation.dto.response;
 
 import com.ojosama.chatservice.application.dto.result.MessageResult;
+import com.ojosama.chatservice.domain.model.MessageType;
 import com.ojosama.chatservice.domain.model.MessageStatus;
 import java.time.LocalDateTime;
 import java.util.UUID;
@@ -10,6 +11,7 @@ public record MessageWsResponse(
         UUID chatRoomId,
         UUID userId,
         String writerNickname,
+        MessageType messageType,
         String content,
         MessageStatus status,
         LocalDateTime createdAt
@@ -20,6 +22,7 @@ public record MessageWsResponse(
                 result.chatRoomId(),
                 result.userId(),
                 result.writerNickname(),
+                result.messageType(),
                 result.content(),
                 result.status(),
                 result.createdAt()

--- a/chat-service/src/test/resources/application.yml
+++ b/chat-service/src/test/resources/application.yml
@@ -8,6 +8,7 @@ spring:
     topic:
       event-created: event.info.created.v1
       event-changed: event.schedule.changed.v1
+      event-status-changed: event.status.changed.v1
       report-blinded: operation.report.blinded.v1
       report-unblinded: operation.report.unblinded.v1
       chat-moderation-requested: chat.moderation.requested.v1


### PR DESCRIPTION
## 🔗 Issue Number
- close #205 

## 📝 작업 내역
행사 상태 변경 이벤트에서 `CANCELLED` 상태를 수신하면, 해당 이벤트의 채팅방 종료 시간을 취소 시점 + 10분으로 조정하고, 시스템 안내 메시지를 채팅방에 자동으로 전송하도록 추가.
시스템 메시지를 쉽게 구분할 수 있도록 메시지 응답에 `messageType`(`USER` / `SYSTEM`)을 추가했습니다.

- `event.status.changed` Kafka 이벤트 소비 추가
- 행사 상태가 `CANCELLED`인 경우에만 채팅방 스케줄 조정
- 채팅방 종료 시간을 `취소 시점 + 10분`으로 변경
- 시스템 안내 메시지 자동 저장 및 STOMP 브로드캐스트
- 메시지 응답 DTO에 `messageType` 추가
- 프론트에서 시스템 메시지를 상단 고정 UI로 분리하기 쉬운 구조로 정리(상태값 추가)

## 💡 PR 특이사항
- 시스템 공지 메시지는 `writerNickname = "시스템"` 기준으로 `messageType = SYSTEM`으로 내려갑니다.
- 일반 메시지는 `messageType = USER`로 내려가는데 그래서 작성자이름이 "시스템"이라 시스템 유저를 만들어둬야합니다 
- 생각해보니 닉네임으로 구분하는건 안좋은것같아서 0..0 (모두0)인 아이디를 시스템으로 넣고 아이디비교로 변경 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 이벤트 취소 시 채팅방에 자동으로 시스템 공지 메시지 발송
  * 메시지 유형 분류 기능 추가 (사용자 메시지/시스템 메시지)
  * 이벤트 상태 변경 자동 감지 및 처리

* **리팩토링**
  * 채팅방 일정 관리 기능 강화로 취소 시나리오 지원

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/55josama/festie/pull/217)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->