### PR TITLE
[FEATURE] 행사 도메인 동시성 비관적 락 적용

### DIFF
--- a/event-service/src/main/java/com/ojosama/eventservice/config/EventServiceExceptionHandler.java
+++ b/event-service/src/main/java/com/ojosama/eventservice/config/EventServiceExceptionHandler.java
@@ -1,0 +1,22 @@
+package com.ojosama.eventservice.config;
+
+import com.ojosama.common.response.ApiResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.PessimisticLockingFailureException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class EventServiceExceptionHandler {
+
+    @ExceptionHandler(PessimisticLockingFailureException.class)
+    public ResponseEntity<ApiResponse<Void>> handlePessimisticLockingFailure(PessimisticLockingFailureException e) {
+        log.warn("락 획득 실패 (동시 요청): {}", e.getMessage());
+        return ResponseEntity
+                .status(HttpStatus.CONFLICT)
+                .body(ApiResponse.error(HttpStatus.CONFLICT.value(), "현재 다른 요청이 처리 중입니다. 잠시 후 다시 시도해주세요."));
+    }
+}

--- a/event-service/src/main/java/com/ojosama/eventservice/config/EventServiceExceptionHandler.java
+++ b/event-service/src/main/java/com/ojosama/eventservice/config/EventServiceExceptionHandler.java
@@ -2,6 +2,7 @@ package com.ojosama.eventservice.config;
 
 import com.ojosama.common.response.ApiResponse;
 import lombok.extern.slf4j.Slf4j;
+import jakarta.persistence.LockTimeoutException;
 import org.springframework.dao.PessimisticLockingFailureException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -12,8 +13,8 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RestControllerAdvice
 public class EventServiceExceptionHandler {
 
-    @ExceptionHandler(PessimisticLockingFailureException.class)
-    public ResponseEntity<ApiResponse<Void>> handlePessimisticLockingFailure(PessimisticLockingFailureException e) {
+    @ExceptionHandler({PessimisticLockingFailureException.class, LockTimeoutException.class})
+    public ResponseEntity<ApiResponse<Void>> handlePessimisticLockingFailure(Exception e) {
         log.warn("락 획득 실패 (동시 요청): {}", e.getMessage());
         return ResponseEntity
                 .status(HttpStatus.CONFLICT)

--- a/event-service/src/main/java/com/ojosama/eventservice/event/application/service/EventCommandService.java
+++ b/event-service/src/main/java/com/ojosama/eventservice/event/application/service/EventCommandService.java
@@ -145,7 +145,7 @@ public class EventCommandService {
     }
 
     public void deleteEvent(UUID userId, UUID eventId) {
-        Event event = eventRepository.findById(eventId)
+        Event event = eventRepository.findByIdForUpdate(eventId)
                 .orElseThrow(() -> new EventException(EventErrorCode.EVENT_NOT_FOUND));
 
         event.deleted(userId);
@@ -154,7 +154,7 @@ public class EventCommandService {
     }
 
     public EventResult cancelEvent(UUID eventId, UUID userId) {
-        Event event = eventRepository.findById(eventId)
+        Event event = eventRepository.findByIdForUpdate(eventId)
                 .orElseThrow(() -> new EventException(EventErrorCode.EVENT_NOT_FOUND));
 
         String beforeStatus = event.getStatus().name();

--- a/event-service/src/main/java/com/ojosama/eventservice/event/application/service/EventCommandService.java
+++ b/event-service/src/main/java/com/ojosama/eventservice/event/application/service/EventCommandService.java
@@ -154,13 +154,13 @@ public class EventCommandService {
     }
 
     public EventResult cancelEvent(UUID eventId, UUID userId) {
-        Event event = eventRepository.findByIdForUpdate(eventId)
+        Event event = eventRepository.findByIdForUpdateWithSchedules(eventId)
                 .orElseThrow(() -> new EventException(EventErrorCode.EVENT_NOT_FOUND));
 
         String beforeStatus = event.getStatus().name();
         event.markCancelled();
 
-        scheduleActionRepository.findPendingByEventId(eventId).forEach(EventScheduleAction::markCancelled);
+        scheduleActionRepository.findPendingByEventIdForUpdate(eventId).forEach(EventScheduleAction::markCancelled);
 
         List<UUID> deletedScheduleIds = event.getSchedules().stream()
                 .filter(schedule -> !schedule.getScheduleTime().isScheduleEnded())

--- a/event-service/src/main/java/com/ojosama/eventservice/event/domain/model/EventScheduleAction.java
+++ b/event-service/src/main/java/com/ojosama/eventservice/event/domain/model/EventScheduleAction.java
@@ -63,11 +63,17 @@ public class EventScheduleAction {
     private String errorMessage;
 
     public void markExecuted(LocalDateTime executedAt) {
+        if (this.status != ScheduleActionStatus.PENDING) {
+            return;
+        }
         this.status = ScheduleActionStatus.EXECUTED;
         this.executedAt = executedAt;
     }
 
     public void markFailed(String errorMessage) {
+        if (this.status != ScheduleActionStatus.PENDING) {
+            return;
+        }
         this.status = ScheduleActionStatus.FAILED;
 
         if (errorMessage == null) {

--- a/event-service/src/main/java/com/ojosama/eventservice/event/domain/repository/EventRepository.java
+++ b/event-service/src/main/java/com/ojosama/eventservice/event/domain/repository/EventRepository.java
@@ -12,6 +12,7 @@ public interface EventRepository {
     Optional<Event> findById(UUID id);
 
     Optional<Event> findByIdForUpdate(UUID id);
+    Optional<Event> findByIdForUpdateWithSchedules(UUID id);
     List<Event> findAllActive();
     List<Event> findAllByIds(List<UUID> ids);
     Page<Event> findAll(EventFilter filter, Pageable pageable);

--- a/event-service/src/main/java/com/ojosama/eventservice/event/domain/repository/EventRepository.java
+++ b/event-service/src/main/java/com/ojosama/eventservice/event/domain/repository/EventRepository.java
@@ -10,6 +10,8 @@ import org.springframework.data.domain.Pageable;
 public interface EventRepository {
     Event save(Event event);
     Optional<Event> findById(UUID id);
+
+    Optional<Event> findByIdForUpdate(UUID id);
     List<Event> findAllActive();
     List<Event> findAllByIds(List<UUID> ids);
     Page<Event> findAll(EventFilter filter, Pageable pageable);

--- a/event-service/src/main/java/com/ojosama/eventservice/event/domain/repository/EventScheduleActionRepository.java
+++ b/event-service/src/main/java/com/ojosama/eventservice/event/domain/repository/EventScheduleActionRepository.java
@@ -10,4 +10,5 @@ public interface EventScheduleActionRepository {
     EventScheduleAction save(EventScheduleAction action);
     List<EventScheduleAction> findPendingByScheduledAtBefore(LocalDateTime now, Pageable pageable);
     List<EventScheduleAction> findPendingByEventId(UUID eventId);
+    List<EventScheduleAction> findPendingByEventIdForUpdate(UUID eventId);
 }

--- a/event-service/src/main/java/com/ojosama/eventservice/event/infrastructure/persistence/EventRepositoryImpl.java
+++ b/event-service/src/main/java/com/ojosama/eventservice/event/infrastructure/persistence/EventRepositoryImpl.java
@@ -35,6 +35,11 @@ public class EventRepositoryImpl implements EventRepository {
     }
 
     @Override
+    public Optional<Event> findByIdForUpdateWithSchedules(UUID id) {
+        return jpaEventRepository.findByIdAndDeletedAtIsNullForUpdateWithSchedules(id);
+    }
+
+    @Override
     public Optional<Event> findById(UUID id) {
         QEvent event = QEvent.event;
         Event result = queryFactory

--- a/event-service/src/main/java/com/ojosama/eventservice/event/infrastructure/persistence/EventRepositoryImpl.java
+++ b/event-service/src/main/java/com/ojosama/eventservice/event/infrastructure/persistence/EventRepositoryImpl.java
@@ -30,6 +30,11 @@ public class EventRepositoryImpl implements EventRepository {
     }
 
     @Override
+    public Optional<Event> findByIdForUpdate(UUID id) {
+        return jpaEventRepository.findByIdAndDeletedAtIsNullForUpdate(id);
+    }
+
+    @Override
     public Optional<Event> findById(UUID id) {
         QEvent event = QEvent.event;
         Event result = queryFactory

--- a/event-service/src/main/java/com/ojosama/eventservice/event/infrastructure/persistence/EventScheduleActionExecutor.java
+++ b/event-service/src/main/java/com/ojosama/eventservice/event/infrastructure/persistence/EventScheduleActionExecutor.java
@@ -27,7 +27,7 @@ public class EventScheduleActionExecutor {
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void processOne(EventScheduleAction action) {
         try {
-            Event event = eventRepository.findById(action.getEventId())
+            Event event = eventRepository.findByIdForUpdate(action.getEventId())
                 .orElseThrow(() -> new EventException(EventErrorCode.EVENT_NOT_FOUND));
 
             executeAction(event, action);

--- a/event-service/src/main/java/com/ojosama/eventservice/event/infrastructure/persistence/EventScheduleActionRepositoryImpl.java
+++ b/event-service/src/main/java/com/ojosama/eventservice/event/infrastructure/persistence/EventScheduleActionRepositoryImpl.java
@@ -30,4 +30,9 @@ public class EventScheduleActionRepositoryImpl implements EventScheduleActionRep
     public List<EventScheduleAction> findPendingByEventId(UUID eventId) {
         return jpaRepo.findByEventIdAndStatus(eventId, ScheduleActionStatus.PENDING);
     }
+
+    @Override
+    public List<EventScheduleAction> findPendingByEventIdForUpdate(UUID eventId) {
+        return jpaRepo.findByEventIdAndStatusForUpdate(eventId, ScheduleActionStatus.PENDING);
+    }
 }

--- a/event-service/src/main/java/com/ojosama/eventservice/event/infrastructure/persistence/JpaEventRepository.java
+++ b/event-service/src/main/java/com/ojosama/eventservice/event/infrastructure/persistence/JpaEventRepository.java
@@ -1,11 +1,16 @@
 package com.ojosama.eventservice.event.infrastructure.persistence;
 
 import com.ojosama.eventservice.event.domain.model.Event;
+import jakarta.persistence.LockModeType;
+import jakarta.persistence.QueryHint;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.QueryHints;
 
 public interface JpaEventRepository extends JpaRepository<Event, UUID> {
 
@@ -14,4 +19,9 @@ public interface JpaEventRepository extends JpaRepository<Event, UUID> {
     List<Event> findAllByDeletedAtIsNull();
 
     List<Event> findAllByIdInAndDeletedAtIsNull(Collection<UUID> ids);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @QueryHints(@QueryHint(name = "jakarta.persistence.lock.timeout", value = "3000"))
+    @Query("SELECT e FROM Event e WHERE e.id = :id AND e.deletedAt IS NULL")
+    Optional<Event> findByIdAndDeletedAtIsNullForUpdate(UUID id);
 }

--- a/event-service/src/main/java/com/ojosama/eventservice/event/infrastructure/persistence/JpaEventRepository.java
+++ b/event-service/src/main/java/com/ojosama/eventservice/event/infrastructure/persistence/JpaEventRepository.java
@@ -24,4 +24,9 @@ public interface JpaEventRepository extends JpaRepository<Event, UUID> {
     @QueryHints(@QueryHint(name = "jakarta.persistence.lock.timeout", value = "3000"))
     @Query("SELECT e FROM Event e WHERE e.id = :id AND e.deletedAt IS NULL")
     Optional<Event> findByIdAndDeletedAtIsNullForUpdate(UUID id);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @QueryHints(@QueryHint(name = "jakarta.persistence.lock.timeout", value = "3000"))
+    @Query("SELECT e FROM Event e LEFT JOIN FETCH e.schedules WHERE e.id = :id AND e.deletedAt IS NULL")
+    Optional<Event> findByIdAndDeletedAtIsNullForUpdateWithSchedules(UUID id);
 }

--- a/event-service/src/main/java/com/ojosama/eventservice/event/infrastructure/persistence/JpaEventScheduleActionRepository.java
+++ b/event-service/src/main/java/com/ojosama/eventservice/event/infrastructure/persistence/JpaEventScheduleActionRepository.java
@@ -2,15 +2,20 @@ package com.ojosama.eventservice.event.infrastructure.persistence;
 
 import com.ojosama.eventservice.event.domain.model.EventScheduleAction;
 import com.ojosama.eventservice.event.domain.model.ScheduleActionStatus;
+import jakarta.persistence.LockModeType;
+import jakarta.persistence.QueryHint;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.QueryHints;
 import org.springframework.data.repository.query.Param;
 
 public interface JpaEventScheduleActionRepository extends JpaRepository<EventScheduleAction, UUID> {
+
     @Query("SELECT a FROM EventScheduleAction a " +
            "WHERE a.status = :status AND a.scheduledAt <= :now " +
            "ORDER BY a.scheduledAt ASC, a.id ASC")
@@ -20,4 +25,11 @@ public interface JpaEventScheduleActionRepository extends JpaRepository<EventSch
             Pageable pageable);
 
     List<EventScheduleAction> findByEventIdAndStatus(UUID eventId, ScheduleActionStatus status);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @QueryHints(@QueryHint(name = "jakarta.persistence.lock.timeout", value = "3000"))
+    @Query("SELECT a FROM EventScheduleAction a WHERE a.eventId = :eventId AND a.status = :status")
+    List<EventScheduleAction> findByEventIdAndStatusForUpdate(
+            @Param("eventId") UUID eventId,
+            @Param("status") ScheduleActionStatus status);
 }

--- a/event-service/src/main/java/com/ojosama/eventservice/eventrequest/application/service/EventRequestCommandService.java
+++ b/event-service/src/main/java/com/ojosama/eventservice/eventrequest/application/service/EventRequestCommandService.java
@@ -46,19 +46,19 @@ public class EventRequestCommandService {
     }
 
     public void cancelEventRequest(UUID userId, UUID requestId) {
-        EventRequest request = eventRequestRepository.findById(requestId)
+        EventRequest request = eventRequestRepository.findByIdForUpdate(requestId)
                 .orElseThrow(() -> new EventRequestException(EventRequestErrorCode.EVENT_REQUEST_NOT_FOUND));
         request.cancel(userId);
     }
 
     public void adminCancelEventRequest(UUID adminId, UUID requestId) {
-        EventRequest request = eventRequestRepository.findById(requestId)
+        EventRequest request = eventRequestRepository.findByIdForUpdate(requestId)
                 .orElseThrow(() -> new EventRequestException(EventRequestErrorCode.EVENT_REQUEST_NOT_FOUND));
         request.adminCancel(adminId);
     }
 
     public EventRequestResult approveEventRequest(UUID requestId) {
-        EventRequest request = eventRequestRepository.findById(requestId)
+        EventRequest request = eventRequestRepository.findByIdForUpdate(requestId)
                 .orElseThrow(() -> new EventRequestException(EventRequestErrorCode.EVENT_REQUEST_NOT_FOUND));
         request.approve();
         EventRequestResult result = EventRequestResult.from(request);
@@ -68,7 +68,7 @@ public class EventRequestCommandService {
     }
 
     public EventRequestResult rejectEventRequest(UUID requestId, String rejectReason) {
-        EventRequest request = eventRequestRepository.findById(requestId)
+        EventRequest request = eventRequestRepository.findByIdForUpdate(requestId)
                 .orElseThrow(() -> new EventRequestException(EventRequestErrorCode.EVENT_REQUEST_NOT_FOUND));
         request.reject(rejectReason);
         EventRequestResult result = EventRequestResult.from(request);

--- a/event-service/src/main/java/com/ojosama/eventservice/eventrequest/domain/repository/EventRequestRepository.java
+++ b/event-service/src/main/java/com/ojosama/eventservice/eventrequest/domain/repository/EventRequestRepository.java
@@ -11,5 +11,7 @@ public interface EventRequestRepository {
 
     Optional<EventRequest> findById(UUID id);
 
+    Optional<EventRequest> findByIdForUpdate(UUID id);
+
     Page<EventRequest> findAll(EventRequestFilter filter, Pageable pageable);
 }

--- a/event-service/src/main/java/com/ojosama/eventservice/eventrequest/infrastructure/persistence/EventRequestRepositoryImpl.java
+++ b/event-service/src/main/java/com/ojosama/eventservice/eventrequest/infrastructure/persistence/EventRequestRepositoryImpl.java
@@ -36,6 +36,11 @@ public class EventRequestRepositoryImpl implements EventRequestRepository {
     }
 
     @Override
+    public Optional<EventRequest> findByIdForUpdate(UUID id) {
+        return jpaEventRequestRepository.findByIdAndDeletedAtIsNullForUpdate(id);
+    }
+
+    @Override
     public Page<EventRequest> findAll(EventRequestFilter filter, Pageable pageable) {
         QEventRequest er = QEventRequest.eventRequest;
         BooleanBuilder where = buildWhere(er, filter);

--- a/event-service/src/main/java/com/ojosama/eventservice/eventrequest/infrastructure/persistence/JpaEventRequestRepository.java
+++ b/event-service/src/main/java/com/ojosama/eventservice/eventrequest/infrastructure/persistence/JpaEventRequestRepository.java
@@ -1,11 +1,21 @@
 package com.ojosama.eventservice.eventrequest.infrastructure.persistence;
 
 import com.ojosama.eventservice.eventrequest.domain.model.EventRequest;
+import jakarta.persistence.LockModeType;
+import jakarta.persistence.QueryHint;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.QueryHints;
 
 public interface JpaEventRequestRepository extends JpaRepository<EventRequest, UUID> {
 
     Optional<EventRequest> findByIdAndDeletedAtIsNull(UUID id);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @QueryHints(@QueryHint(name = "jakarta.persistence.lock.timeout", value = "3000"))
+    @Query("SELECT r FROM EventRequest r WHERE r.id = :id AND r.deletedAt IS NULL")
+    Optional<EventRequest> findByIdAndDeletedAtIsNullForUpdate(UUID id);
 }


### PR DESCRIPTION
## 🔗 Issue Number
- close #225 
## 📝 작업 내역

 **EventRequest 동시성 처리**
  - `JpaEventRequestRepository`에 `@Lock(PESSIMISTIC_WRITE)` 기반 `findByIdAndDeletedAtIsNullForUpdate()` 추가
  - `EventRequestRepository` 인터페이스에 `findByIdForUpdate()` 추가
  - `EventRequestCommandService`의 `approveEventRequest()`, `rejectEventRequest()`, `cancelEventRequest()` 모두 `findByIdForUpdate()` 사용으로 변경
  - 동시 요청 시 두 번째 요청은 첫 번째 커밋 후 최신 상태를 읽어 `EVENT_REQUEST_ALREADY_PROCESSED(409)` 반환

  **Event 상태 변경 동시성 처리**
  - `JpaEventRepository`에 `@Lock(PESSIMISTIC_WRITE)` 기반 `findByIdAndDeletedAtIsNullForUpdate()` 추가
  - `EventRepository` 인터페이스에 `findByIdForUpdate()` 추가
  - `EventCommandService`의 `cancelEvent()`, `deleteEvent()` → `findByIdForUpdate()` 사용으로 변경
  - `EventScheduleActionExecutor.processOne()` → `findByIdForUpdate()` 사용으로 변경
  - 스케줄러 자동 전환과 관리자 수동 취소가 동시에 실행되어도 row 락으로 직렬화

  **EventScheduleAction 상태 덮어쓰기 버그 수정**
  - `markFailed()`에 PENDING 상태 체크 추가
  - `cancelEvent()`가 action을 CANCELLED 처리 후 `processOne()`의 catch 블록에서 `markFailed()`가 호출되어 FAILED로 덮어쓰는 버그 수정
  - 이미 CANCELLED 상태인 action은 `markFailed()` 무시

----
### 코드래빗 피드백 반영
 1. 락 타임아웃 예외 처리 — EventServiceExceptionHandler 신규 추가, PessimisticLockingFailureException + LockTimeoutException → 409 반환 (기존 PR 설명에 없음)                                                                    
  2. cancelEvent N+1 개선 — findByIdForUpdateWithSchedules (PESSIMISTIC_WRITE + LEFT JOIN FETCH schedules 한 번에)                                                                                                                 
  3. EventScheduleAction 락 추가 — findPendingByEventIdForUpdate (cancelEvent와 processOne 동시 실행 시 ScheduleAction race condition 방지)
  4. markFailed() / markExecuted() PENDING 체크 — 이미 CANCELLED/EXECUTED 상태인 action을 덮어쓰지 않도록

## 💡 PR 특이사항

 - **낙관락 미적용 이유**: approve/reject/cancel은 충돌 후 재시도가 의미 없음. 낙관락(`@Version`)은 예외가 커밋 시점에 발생해 비즈니스 예외(`EVENT_REQUEST_ALREADY_PROCESSED`)로 변환하기 불편하고 스키마 변경(`version` 컬럼)도  
  필요함. 비관락이 더 자연스러운 케이스
  - **lock timeout 3초**: `jakarta.persistence.lock.timeout=3000` 설정. 트랜잭션1(먼저 처리 중인 요청)이 락을 3초 이상
  잡고 있어야 발생하는데, approve/reject 처리가 수십ms 수준이라
  실제로는 발생하지 않음. 만약 발생하면 500 반환
  - **EventScheduleAction 상태 전환 규칙은 도메인 모델 책임으로 유지**: enum(`ScheduleActionStatus`)이 아닌 `EventScheduleAction`에서 처리 — 비즈니스 맥락과 부가 로직(로깅, 예외 등)이 도메인에 함께 있어야 하기 때문
  - **Event 락으로 EventScheduleAction 충돌도 간접 해소**: `cancelEvent()`와 `processOne()`이 같은 Event row 락을 두고 경쟁하므로 두 작업이 동시에 같은 action에 접근하는 상황 자체가 직렬화됨


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 여러 동시 요청 처리 중 이벤트 및 이벤트 요청 데이터 일관성이 개선되었습니다.
  * 이벤트 상태 변경(취소, 삭제) 및 스케줄 작업 처리 안정성이 강화되었습니다.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/55josama/festie/pull/226)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->