### PR TITLE
[TEST] community-service 부하 테스트

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,17 @@ CLAUDE.md
 **/src/main/generated/
 **/src/test/generated/
 **/build/generated/
+
+### Load Test (k6 / JMeter) outputs ###
+loadtest/results/
+loadtest/**/summary.json
+loadtest/**/*.html
+loadtest/**/*.jtl
+loadtest/seed/seed_data.json
+loadtest/.venv/
+loadtest/**/__pycache__/
+summary.json
+**/summary.json
+# k6 결과 텍스트 (tee 로 저장한 파일)
+*_result.txt
+*_result_*.txt

--- a/loadtest/k6/community-loadtest.js
+++ b/loadtest/k6/community-loadtest.js
@@ -1,0 +1,318 @@
+import http from 'k6/http';
+import { check, sleep, group } from 'k6';
+import { Rate, Trend, Counter } from 'k6/metrics';
+import { SharedArray } from 'k6/data';
+import { randomIntBetween, randomString, uuidv4 } from 'https://jslib.k6.io/k6-utils/1.2.0/index.js';
+
+// ─── 시드 데이터 로드 (init 단계, 1회) ────────────────────────
+//   seed_community.py 가 만든 JSON 을 읽어서 user_ids / category_ids 풀로 활용.
+//   파일 없으면 단일 랜덤 UUID fallback (smoke 용).
+const SEED_FILE = __ENV.SEED_FILE || '../seed/seed_data.json';
+let seedData = null;
+try {
+    seedData = JSON.parse(open(SEED_FILE));
+    console.log(`[init] 시드 로드 완료 → users=${seedData.user_ids.length}, categories=${seedData.category_ids.length}, posts=${seedData.post_count}`);
+} catch (e) {
+    console.warn(`[init] 시드 파일(${SEED_FILE}) 없음 — fallback 모드 (사용자/카테고리 단일값).`);
+}
+
+// SharedArray: VU 간 메모리 공유 (대용량일 때 메모리 절약)
+const userIdPool = new SharedArray('user_ids', () => seedData?.user_ids || []);
+const categoryIdPool = new SharedArray('category_ids', () => seedData?.category_ids || []);
+
+function pickRandom(arr) {
+    return arr[Math.floor(Math.random() * arr.length)];
+}
+
+// ─── 환경 변수 / 엔드포인트 설정 ───────────────────────────────
+const BASE_URL = __ENV.BASE_URL || 'http://localhost:9001';      // community-service
+const AUTH_URL = __ENV.AUTH_URL || 'http://localhost:8081';      // user-service (JWT 발급)
+const SCENARIO = __ENV.SCENARIO || 'load';
+const POST_RATIO = Number(__ENV.POST_RATIO ?? 0.1);              // POST /v1/posts 트리거 확률 (smoke 디버깅 시 1.0 로)
+const LIKE_RATIO = Number(__ENV.LIKE_RATIO ?? 0.3);              // POST /v1/posts/{id}/likes 트리거 확률
+const DETAIL_RATIO = Number(__ENV.DETAIL_RATIO ?? 0.5);          // GET /v1/posts/{id} 트리거 확률 (N+1 의심 케이스)
+
+// ─── 사용자 정의 메트릭 (Grafana 에서 따로 그래프 그릴 수 있음) ──
+const errorRate         = new Rate('custom_errors');
+const postCreated       = new Counter('post_created_total');
+const postLiked         = new Counter('post_liked_total');
+const postListLatency   = new Trend('post_list_latency_ms', true);
+const postDetailLatency = new Trend('post_detail_latency_ms', true);
+
+// ─── 시나리오 프리셋 ─────────────────────────────────────────
+//  smoke  : 기능 검증 (1명, 30초)
+//  load   : 일반 부하 (50명까지 ramp-up)
+//  stress : 한계 탐색 (200명까지)
+//  spike  : 순간 폭주 (10 → 300 → 10)
+const scenarios = {
+    smoke: {
+        executor: 'constant-vus',
+        vus: 1,
+        duration: '30s',
+    },
+    load: {
+        executor: 'ramping-vus',
+        startVUs: 0,
+        stages: [
+            { duration: '30s', target: 20 },   // ramp-up
+            { duration: '1m',  target: 50 },   // 유지
+            { duration: '30s', target: 0  },   // ramp-down
+        ],
+        gracefulRampDown: '10s',
+    },
+    stress: {
+        executor: 'ramping-vus',
+        startVUs: 0,
+        stages: [
+            { duration: '30s', target: 50  },
+            { duration: '1m',  target: 100 },
+            { duration: '1m',  target: 200 },
+            { duration: '30s', target: 0   },
+        ],
+    },
+    spike: {
+        executor: 'ramping-arrival-rate',
+        startRate: 10,
+        timeUnit: '1s',
+        preAllocatedVUs: 50,
+        maxVUs: 500,
+        stages: [
+            { duration: '30s', target: 10  },
+            { duration: '10s', target: 300 },  // 스파이크!
+            { duration: '1m',  target: 300 },
+            { duration: '10s', target: 10  },
+        ],
+    },
+};
+
+export const options = {
+    scenarios: { [SCENARIO]: scenarios[SCENARIO] },
+
+    // ── Pass/Fail 기준 (Threshold) — 미달 시 exit code != 0 → CI 실패 처리 가능
+    thresholds: {
+        http_req_failed:    ['rate<0.01'],                  // 에러율 1% 미만
+        http_req_duration:  ['p(95)<500', 'p(99)<1000'],    // p95 < 500ms, p99 < 1s
+        custom_errors:      ['rate<0.05'],
+        post_list_latency_ms: ['p(95)<300'],
+    },
+
+    // ── tag 로 메트릭 분류 (Grafana 에서 service 별 보기 좋음)
+    tags: { service: 'community-service', testType: SCENARIO },
+};
+
+// ─── 셋업: 한 번만 실행. 토큰 발급 + 카테고리 ID 확보 ────────────
+export function setup() {
+    // setup 안의 요청들은 부하 측정 메트릭에서 빼고 싶음.
+    // → expectedStatuses 로 4xx 도 "예상된 응답" 으로 마킹하면 http_req_failed 에 안 잡힘.
+    const setupRespOk = http.expectedStatuses({ min: 200, max: 499 });
+
+    // 1) user-service 에서 JWT 받아오기 (테스트용 계정 — 없으면 토큰 없이 진행)
+    const loginRes = http.post(
+        `${AUTH_URL}/v1/auth/login`,
+        JSON.stringify({
+            email: __ENV.TEST_USER_EMAIL || 'loadtest@test.com',
+            password: __ENV.TEST_USER_PASSWORD || 'Test1234!',
+        }),
+        {
+            headers: { 'Content-Type': 'application/json' },
+            tags: { name: 'setup_login' },
+            responseCallback: setupRespOk,   // ← 4xx 도 setup 단계에선 실패로 안 침
+        },
+    );
+
+    let token = null;
+    if (loginRes.status === 200) {
+        try {
+            token = loginRes.json('data.accessToken') || loginRes.json('accessToken');
+        } catch (e) { /* 응답 스키마 다르면 null 그대로 */ }
+    } else {
+        console.warn(`[setup] 로그인 실패 (${loginRes.status}). 토큰 없이 진행. community 가 permitAll 이면 OK.`);
+    }
+
+    // 2) 카테고리 / 사용자 풀 결정 (seed 우선, 없으면 fallback)
+    let useSeedPool = userIdPool.length > 0 && categoryIdPool.length > 0;
+    let fallbackCategoryId = __ENV.CATEGORY_ID || null;
+    let fallbackUserId = __ENV.TEST_USER_ID || null;
+
+    if (useSeedPool) {
+        console.log(`[setup] 시드 풀 사용: users=${userIdPool.length}, categories=${categoryIdPool.length}`);
+    } else {
+        // seed 없음 → fallback
+        if (!fallbackCategoryId) {
+            const catRes = http.get(`${BASE_URL}/v1/community-categories`, {
+                headers: { 'Content-Type': 'application/json' },
+                tags: { name: 'setup_categories' },
+                responseCallback: setupRespOk,
+            });
+            console.log(`[setup] GET /v1/community-categories → status=${catRes.status}, body=${(catRes.body || '').toString().slice(0, 200)}`);
+            if (catRes.status === 200) {
+                try {
+                    const body = catRes.json();
+                    let list = [];
+                    if (Array.isArray(body)) list = body;
+                    else if (Array.isArray(body?.data)) list = body.data;
+                    else if (Array.isArray(body?.data?.content)) list = body.data.content;
+                    else if (Array.isArray(body?.content)) list = body.content;
+                    if (list.length > 0) fallbackCategoryId = list[0].id || list[0].categoryId;
+                } catch (e) { /* parsing 실패 */ }
+            }
+            if (!fallbackCategoryId) {
+                console.warn('[setup] 카테고리 ID 확보 실패 → POST /v1/posts 시나리오는 스킵됩니다.');
+            }
+        }
+        if (!fallbackUserId) {
+            fallbackUserId = uuidv4();
+            console.warn(`[setup] TEST_USER_ID env 없음 → 랜덤 UUID(${fallbackUserId}) 사용.`);
+        }
+    }
+
+    return { token, useSeedPool, fallbackCategoryId, fallbackUserId };
+}
+
+// ─── 메인 시나리오 ───────────────────────────────────────────
+export default function (data) {
+    // 매 iteration 마다 사용자/카테고리 풀에서 랜덤 픽 (현실적인 분포)
+    const userId = data.useSeedPool ? pickRandom(userIdPool) : data.fallbackUserId;
+    const categoryId = data.useSeedPool ? pickRandom(categoryIdPool) : data.fallbackCategoryId;
+
+    const headers = {
+        'Content-Type': 'application/json',
+        // 게이트웨이가 JWT 검증 후 전달하는 X-User-Id 헤더를 직접 세팅 (POST 엔드포인트 필수)
+        'X-User-Id': userId,
+        ...(data.token ? { Authorization: `Bearer ${data.token}` } : {}),
+    };
+
+    // 목록 응답에서 글 ID 한 개 추출 → 다음 시나리오에서 활용
+    let pickedPostId = null;
+
+    // ──── 1) 게시글 목록 조회 (가장 트래픽 많은 케이스)
+    group('GET /v1/posts (목록)', () => {
+        // 페이지를 다양하게 (0~9) — 깊은 페이지 latency 도 보기 위함
+        const page = randomIntBetween(0, 9);
+        const res = http.get(`${BASE_URL}/v1/posts?page=${page}&size=20`, {
+            headers,
+            tags: { name: 'list_posts' },
+        });
+        postListLatency.add(res.timings.duration);
+        const ok = check(res, {
+            '목록 200 OK': (r) => r.status === 200,
+            '응답시간 < 500ms': (r) => r.timings.duration < 500,
+        });
+        errorRate.add(!ok);
+
+        // 응답에서 글 ID 추출
+        if (res.status === 200) {
+            try {
+                const body = res.json();
+                const list = body?.data?.content || body?.content || (Array.isArray(body?.data) ? body.data : []);
+                if (list.length > 0) {
+                    const item = list[randomIntBetween(0, list.length - 1)];
+                    pickedPostId = item.id || item.postId;
+                }
+            } catch (e) { /* skip */ }
+        }
+    });
+
+    sleep(randomIntBetween(1, 3));   // 실제 유저 행동 사이의 think time
+
+    // ──── 2) 게시글 상세조회 (N+1 의심 케이스 — DETAIL_RATIO 확률)
+    if (pickedPostId && Math.random() < DETAIL_RATIO) {
+        group('GET /v1/posts/{id} (상세)', () => {
+            const res = http.get(`${BASE_URL}/v1/posts/${pickedPostId}`, {
+                headers,
+                tags: { name: 'detail_post' },
+            });
+            postDetailLatency.add(res.timings.duration);
+            check(res, { '상세 200 OK': (r) => r.status === 200 });
+        });
+    }
+
+    sleep(1);
+
+    // ──── 3) 카테고리 조회
+    group('GET /v1/community-categories', () => {
+        const res = http.get(`${BASE_URL}/v1/community-categories`, {
+            headers,
+            tags: { name: 'list_categories' },
+        });
+        check(res, { '카테고리 200': (r) => r.status === 200 });
+    });
+
+    sleep(1);
+
+    // ──── 4) 좋아요 (동시성 의심 케이스 — LIKE_RATIO 확률)
+    if (pickedPostId && Math.random() < LIKE_RATIO) {
+        group('POST /v1/posts/{id}/likes (좋아요)', () => {
+            const res = http.post(`${BASE_URL}/v1/posts/${pickedPostId}/likes`, null, {
+                headers,
+                tags: { name: 'like_post' },
+                // 좋아요 중복(409)은 비즈니스적으로 정상 응답이라 http_req_failed 메트릭에서 제외
+                responseCallback: http.expectedStatuses({ min: 200, max: 201 }, 409),
+            });
+            const ok = check(res, {
+                '좋아요 정상응답': (r) => r.status === 200 || r.status === 201 || r.status === 409,
+            });
+            if (ok && (res.status === 200 || res.status === 201)) postLiked.add(1);
+            if (!ok) errorRate.add(1);
+        });
+    }
+
+    sleep(randomIntBetween(1, 2));
+
+    // ──── 5) 게시글 작성 (POST_RATIO 확률로, categoryId 가 확보된 경우만)
+    if (categoryId && Math.random() < POST_RATIO) {
+        group('POST /v1/posts (작성)', () => {
+            const payload = JSON.stringify({
+                categoryId: categoryId,
+                title: `loadtest-${randomString(8)}`,
+                content: `automated load test content ${randomString(40)}`,
+            });
+            const res = http.post(`${BASE_URL}/v1/posts`, payload, {
+                headers,
+                tags: { name: 'create_post' },
+            });
+            const created = check(res, {
+                '작성 200/201': (r) => r.status === 200 || r.status === 201,
+            });
+            if (created) postCreated.add(1);
+            else {
+                errorRate.add(1);
+                console.warn(`[create_post] 실패 status=${res.status}, body=${(res.body || '').toString().slice(0, 200)}`);
+            }
+        });
+    }
+
+    // ──── 6) 헬스 (모니터링 통과 확인용 — 부하 자체엔 비중 ↓)
+    if (Math.random() < 0.02) {
+        http.get(`${BASE_URL}/actuator/health`, { tags: { name: 'health' } });
+    }
+}
+
+// ─── 종료 시 콘솔 요약 출력 ──────────────────────────────────
+export function handleSummary(data) {
+    const m = data.metrics;
+    const fmt = (n) => (n ? n.toFixed(2) : 'n/a');
+
+    const summary = `
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  community-service 부하 테스트 결과 [${SCENARIO}]
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  총 요청 수         : ${m.http_reqs?.values.count ?? 0}
+  실패율             : ${fmt((m.http_req_failed?.values.rate ?? 0) * 100)}%
+  평균 응답시간      : ${fmt(m.http_req_duration?.values.avg)} ms
+  p95 응답시간       : ${fmt(m.http_req_duration?.values['p(95)'])} ms
+  p99 응답시간       : ${fmt(m.http_req_duration?.values['p(99)'])} ms
+  최대 RPS           : ${fmt(m.http_reqs?.values.rate)}  req/s
+  ─────────────────────────────────────────────
+  목록 p95           : ${fmt(m.post_list_latency_ms?.values['p(95)'])} ms
+  상세 p95           : ${fmt(m.post_detail_latency_ms?.values['p(95)'])} ms
+  생성된 글 수       : ${m.post_created_total?.values.count ?? 0}
+  눌러진 좋아요 수   : ${m.post_liked_total?.values.count ?? 0}
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+`;
+    console.log(summary);
+    return {
+        'stdout': summary,
+        'summary.json': JSON.stringify(data, null, 2),
+    };
+}

--- a/loadtest/seed/seed_community.py
+++ b/loadtest/seed/seed_community.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+"""
+festie 부하 테스트용 시드 데이터 생성기
+
+사용법:
+    pip install requests
+    python loadtest/seed/seed_community.py                          # 기본: 사용자 50, 글 1000
+    python loadtest/seed/seed_community.py --users 100 --posts 5000 # 대량
+    python loadtest/seed/seed_community.py --skip-users             # user-service 없을 때
+
+생성:
+    - user-service: 사용자 N명
+    - community-service: 카테고리 3개 + 게시글 K개 (랜덤 사용자/카테고리 분포)
+
+결과:
+    loadtest/seed/seed_data.json 에 user_ids / category_ids 저장
+    → k6 스크립트가 이 파일을 읽어서 부하 분산
+"""
+
+import argparse
+import json
+import random
+import sys
+import time
+import uuid
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+
+try:
+    import requests
+except ImportError:
+    print(
+        "requests 모듈이 없습니다. 다음 중 한 가지 방법으로 설치하세요:\n"
+        "  1) pip3 install requests\n"
+        "  2) pip3 install requests --break-system-packages   (PEP 668 보호 정책 거부 시)\n"
+        "  3) 가상환경 사용:\n"
+        "     python3 -m venv loadtest/.venv && source loadtest/.venv/bin/activate && pip install requests",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+# ─── 기본 설정 (환경변수로 override 가능) ────────────────────
+USER_BASE_URL = "http://localhost:8081"
+COMMUNITY_BASE_URL = "http://localhost:9001"
+SEED_OUTPUT = Path(__file__).parent / "seed_data.json"
+
+# ─── 더미 데이터 풀 ──────────────────────────────────────
+KOREAN_FIRST = ["민준", "서연", "도윤", "지우", "예준", "서윤", "주원", "하은", "지호", "수아", "건우", "지유", "현우", "다은", "우진"]
+KOREAN_LAST  = ["김", "이", "박", "최", "정", "강", "조", "윤", "장", "임", "한", "오", "신", "권", "황"]
+CATEGORIES   = ["잡담", "후기", "정보공유"]
+POST_TITLES  = [
+    "오늘 다녀온 페스티벌 후기",
+    "처음 가본 사람도 즐길 수 있을까요?",
+    "주차 정보 공유합니다",
+    "다음 페스티벌 같이 가실 분",
+    "굿즈 정보 모음",
+    "라인업 분석",
+    "음향 너무 좋았어요",
+    "교통편 추천드림",
+]
+POST_CONTENTS_TEMPLATE = (
+    "이 글은 부하 테스트 시드로 자동 생성된 글입니다.\n"
+    "현실적인 데이터 분포를 만들기 위해 다양한 사용자/카테고리에서 작성됩니다.\n"
+    "(seed run_id={run_id}, post_idx={idx})\n"
+    "본문 본문 본문 본문 본문 본문 본문 본문 본문 본문\n"
+)
+
+
+def random_name() -> str:
+    return random.choice(KOREAN_LAST) + random.choice(KOREAN_FIRST)
+
+
+def random_phone() -> str:
+    return f"010{random.randint(10000000, 99999999)}"
+
+
+# ─── API 호출 헬퍼 ───────────────────────────────────────
+def create_user(idx: int, run_id: str) -> str | None:
+    """user-service 에 회원가입. 성공 시 userId(UUID) 반환."""
+    email = f"loadtest+{run_id}+{idx}@test.com"
+    payload = {
+        "email": email,
+        "password": "Test1234!",
+        "nickname": f"부하테스트{idx:04d}",
+        "name": random_name(),
+        "phoneNumber": random_phone(),
+    }
+    try:
+        r = requests.post(f"{USER_BASE_URL}/v1/users", json=payload, timeout=10)
+        if r.status_code in (200, 201):
+            body = r.json()
+            data = body.get("data", body)
+            return data.get("userId") or data.get("id")
+        if idx < 3:  # 처음 몇 개만 로그
+            print(f"  [user {idx}] {r.status_code}: {r.text[:120]}", file=sys.stderr)
+        return None
+    except Exception as e:
+        if idx < 3:
+            print(f"  [user {idx}] exception: {e}", file=sys.stderr)
+        return None
+
+
+def create_category(name: str) -> str | None:
+    """community-service 에 카테고리 생성."""
+    try:
+        r = requests.post(
+            f"{COMMUNITY_BASE_URL}/v1/community-categories",
+            json={"name": name},
+            timeout=10,
+        )
+        if r.status_code in (200, 201):
+            body = r.json()
+            data = body.get("data", body)
+            return data.get("id") or data.get("categoryId")
+        print(f"  [category {name}] {r.status_code}: {r.text[:120]}", file=sys.stderr)
+        return None
+    except Exception as e:
+        print(f"  [category {name}] exception: {e}", file=sys.stderr)
+        return None
+
+
+def create_post(user_id: str, category_id: str, idx: int, run_id: str) -> bool:
+    """community-service 에 글 생성."""
+    payload = {
+        "categoryId": category_id,
+        "title": f"{random.choice(POST_TITLES)} #{idx}",
+        "content": POST_CONTENTS_TEMPLATE.format(run_id=run_id, idx=idx),
+    }
+    try:
+        r = requests.post(
+            f"{COMMUNITY_BASE_URL}/v1/posts",
+            json=payload,
+            headers={"X-User-Id": user_id, "Content-Type": "application/json"},
+            timeout=10,
+        )
+        if r.status_code in (200, 201):
+            return True
+        if idx < 3:
+            print(f"  [post {idx}] {r.status_code}: {r.text[:120]}", file=sys.stderr)
+        return False
+    except Exception as e:
+        if idx < 3:
+            print(f"  [post {idx}] exception: {e}", file=sys.stderr)
+        return False
+
+
+# ─── 메인 ────────────────────────────────────────────────
+def main() -> None:
+    parser = argparse.ArgumentParser(description="festie 부하 테스트 시드 데이터 생성")
+    parser.add_argument("--users",   type=int, default=50,   help="생성할 사용자 수")
+    parser.add_argument("--posts",   type=int, default=1000, help="생성할 글 수")
+    parser.add_argument("--workers", type=int, default=10,   help="동시 워커 수")
+    parser.add_argument("--skip-users", action="store_true",
+                        help="user-service 호출 안 함 (랜덤 UUID 로 대체, 검증 우회되면 사용)")
+    args = parser.parse_args()
+
+    run_id = str(int(time.time()))
+
+    print("━" * 50)
+    print(f" festie 부하 테스트 시드 (run_id={run_id})")
+    print(f" 사용자: {args.users}명, 카테고리: {len(CATEGORIES)}개, 글: {args.posts}개")
+    print(f" 동시 워커: {args.workers}")
+    if args.skip_users:
+        print(" ⚠️  --skip-users : 사용자 API 호출 건너뜀 (랜덤 UUID 사용)")
+    print("━" * 50)
+
+    # 1. 사용자
+    print(f"\n[1/3] 사용자 {args.users}명 생성...")
+    t0 = time.time()
+    user_ids: list[str] = []
+    if args.skip_users:
+        user_ids = [str(uuid.uuid4()) for _ in range(args.users)]
+        print(f"  → 랜덤 UUID {len(user_ids)}개 생성")
+    else:
+        with ThreadPoolExecutor(max_workers=args.workers) as ex:
+            futures = [ex.submit(create_user, i, run_id) for i in range(args.users)]
+            for f in as_completed(futures):
+                uid = f.result()
+                if uid:
+                    user_ids.append(uid)
+        print(f"  → 성공: {len(user_ids)}/{args.users} ({time.time()-t0:.1f}s)")
+
+    if not user_ids:
+        print("\n✗ 사용자 0명. user-service 가 떠 있는지 확인하거나 --skip-users 옵션 사용.",
+              file=sys.stderr)
+        sys.exit(1)
+
+    # 2. 카테고리
+    print(f"\n[2/3] 카테고리 {len(CATEGORIES)}개 생성...")
+    t0 = time.time()
+    category_ids: list[str] = []
+    for name in CATEGORIES:
+        cid = create_category(f"{name}-{run_id}")
+        if cid:
+            category_ids.append(cid)
+    print(f"  → 성공: {len(category_ids)}/{len(CATEGORIES)} ({time.time()-t0:.1f}s)")
+
+    if not category_ids:
+        print("\n✗ 카테고리 0개. community-service 가 떠 있는지 확인.", file=sys.stderr)
+        sys.exit(1)
+
+    # 3. 글
+    print(f"\n[3/3] 글 {args.posts}개 생성...")
+    t0 = time.time()
+    success = 0
+    fail = 0
+    with ThreadPoolExecutor(max_workers=args.workers) as ex:
+        futures = [
+            ex.submit(
+                create_post,
+                random.choice(user_ids),
+                random.choice(category_ids),
+                i,
+                run_id,
+            )
+            for i in range(args.posts)
+        ]
+        done = 0
+        for f in as_completed(futures):
+            done += 1
+            if f.result():
+                success += 1
+            else:
+                fail += 1
+            if done % 100 == 0:
+                print(f"  → 진행: {done}/{args.posts} (성공 {success}, 실패 {fail})")
+    print(f"  → 성공: {success}/{args.posts} ({time.time()-t0:.1f}s)")
+
+    # 4. 결과 저장
+    SEED_OUTPUT.parent.mkdir(parents=True, exist_ok=True)
+    SEED_OUTPUT.write_text(
+        json.dumps(
+            {
+                "run_id": run_id,
+                "created_at": int(time.time()),
+                "user_count": len(user_ids),
+                "category_count": len(category_ids),
+                "post_count": success,
+                "user_ids": user_ids,
+                "category_ids": category_ids,
+            },
+            indent=2,
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+
+    print(f"\n✓ 완료! → {SEED_OUTPUT}")
+    print("\n다음 단계 — k6 부하 테스트 실행:")
+    print(f"  k6 run --env SCENARIO=load \\")
+    print(f"         --env SEED_FILE={SEED_OUTPUT.relative_to(Path.cwd()) if SEED_OUTPUT.is_relative_to(Path.cwd()) else SEED_OUTPUT} \\")
+    print(f"         loadtest/k6/community-loadtest.js")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 🔗 Issue Number
- close #222 

## 📝 작업 내역

-dev1
- k6 시나리오 4종 (smoke/load/stress/spike)
- Python 시드 데이터 생성기

## 부하 테스트 결과

- stress 200 VU 기준, 데이터 5배 증가 시 응답시간 3-4배 비례 증가됨을 발견

**초기 측정 확인**
```
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  community-service 부하 테스트 결과 [load]
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  총 요청 수         : 1336
  실패율             : 0.67%
  평균 응답시간      : 11.12 ms
  p95 응답시간       : 28.37 ms
  p99 응답시간       : n/a ms
  최대 RPS           : 10.98  req/s
  ─────────────────────────────────────────────
  목록 p95           : 28.01 ms
  상세 p95           : 33.17 ms
  생성된 글 수       : 61
  눌러진 좋아요 수   : 22
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━  source=console
```
---
**1. 비교 측정 환경:**
- 시드: 사용자 50명, 카테고리 3개, 게시글 1,000개
- 시나리오: 목록조회 / 상세조회 / 카테고리 / 좋아요 / 글작성
- k6 run --env SCENARIO=stress \
       --env SEED_FILE=/Users/t2025-m0034/Documents/sparta/iimsa/festie/loadtest/seed/seed_data.json \
       loadtest/k6/community-loadtest.js 

```
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  community-service 부하 테스트 결과 [stress]
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  총 요청 수         : 7557
  실패율             : n/a%
  평균 응답시간      : 5.15 ms
  p95 응답시간       : 12.80 ms
  p99 응답시간       : n/a ms
  최대 RPS           : 40.87  req/s
  ─────────────────────────────────────────────
  목록 p95           : 11.86 ms
  상세 p95           : 12.98 ms
  생성된 글 수       : 330
  눌러진 좋아요 수   : 185
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

running (3m04.9s), 000/200 VUs, 3220 complete and 0 interrupted iterations
stress ✓ [======================================] 000/200 VUs  3m0s
```
**시스템 영향 (Grafana, community-service):**
- Heap Used: 5.0% (95% 여유)
- CPU: System max 6.4%, Process max 0.8%
- DB 커넥션 풀: Pool 10, Active 평균 0, Pending **0건**
- DB Acquire Time: 172~176 μs / Usage Time: 1.85~1.87 ms
- GC Pause: 평균 81μs, max 1.70ms (Old Gen 안정 = 메모리 누수 없음)
- Thread: 부하 시 37 → 39 (안정)

200 VU 수준에서 community-service 한계 없음. 

---

**2. 비교 측정 환경:**
- 사용자 500명 + 글 5000개
- 상세 p95 | (33.17ms) | 55.81ms | 🚨 약 1.7배 ↑

```
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  community-service 부하 테스트 결과 [stress]
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  총 요청 수         : 7031
  실패율             : n/a%
  평균 응답시간      : 16.00 ms
  p95 응답시간       : 41.27 ms
  p99 응답시간       : n/a ms
  최대 RPS           : 38.10  req/s
  ─────────────────────────────────────────────
  목록 p95           : 40.98 ms
  상세 p95           : 57.36 ms
  생성된 글 수       : 297
  눌러진 좋아요 수   : 91
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

running (3m04.5s), 000/200 VUs, 3208 complete and 0 interrupted iterations
stress ✓ [ 100% ] 000/200 VUs  3m0s
``` 
- Connection Usage Time 1.85ms → 3.4ms
<img width="2598" height="1956" alt="image" src="https://github.com/user-attachments/assets/b6bf8f02-cc3b-44db-bca1-aa159aeba6a0" />

---

가능 원인 (확인 필요..)
1. N+1 쿼리 — PostRepository fetch join 미적용
2. viewCount UPDATE 매 조회 발생 (코드 주석에 Redis 부채 명시)
3. Outbox 백그라운드 폴링이 부하 시간대에도 DB 점유

후속 작업
- [ ] N+1 쿼리 검증
- [ ] 상세조회 fetch join 또는 DTO Projection 검증
- [ ] viewCount Redis INCR 마이그레이션
- [ ] Outbox 폴링 주기 / 부하 시 영향 검토

---
+++
N+1 쿼리는 발생하지 않는 것으로 확인. (Outbox 영향으로 sql 나타났던 것)
viewCount Redis INCR 마이그레이션, 목록조회 성능 개선으로 방향성 잡음. (이슈 243)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Tests**
  * 커뮤니티 서비스 로드 테스트 스크립트 추가
  * 다양한 테스트 시나리오(스모크, 로드, 스트레스, 스파이크) 지원

* **Chores**
  * 빌드 결과물 및 테스트 출력 파일 제외 설정 업데이트
  * 로드 테스트 데이터 생성 도구 추가

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/55josama/festie/pull/232)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->