### PR TITLE
[FEATURE] 300명 동시 로그인 요청 시 user-service 응답 지연 문제 개선

### DIFF
--- a/user-service/src/main/resources/application-local.yml
+++ b/user-service/src/main/resources/application-local.yml
@@ -9,6 +9,12 @@ spring:
     username: ${SPRING_DATASOURCE_USERNAME:${DB_USER:${USER_DB_USERNAME:festie}}}
     password: ${SPRING_DATASOURCE_PASSWORD:${DB_PASSWORD:${USER_DB_PASSWORD:1234}}}
     driver-class-name: org.postgresql.Driver
+    hikari:
+      maximum-pool-size: 30
+      minimum-idle: 10
+      connection-timeout: 30000
+      idle-timeout: 600000
+      max-lifetime: 1800000
 
   jpa:
     hibernate:
@@ -43,3 +49,16 @@ internal:
 kafka:
   topic:
     user-blacklist-status: ${KAFKA_TOPIC_USER_BLACKLIST_STATUS:operation.blacklist.updated.v1}
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,metrics,prometheus
+  endpoint:
+    health:
+      show-details: always
+  prometheus:
+    metrics:
+      export:
+        enabled: true


### PR DESCRIPTION
## 🔗 Issue Number
- close #235 

## 📝 작업 내역

- user-service의 HikariCP 커넥션풀 설정을 추가
  - maximum-pool-size: 30
  - minimum-idle: 10
  - connection-timeout: 30000
  - idle-timeout: 600000
  - max-lifetime: 1800000
- user-service의 Prometheus 메트릭 수집을 위해 actuator/prometheus 노출 설정을 추가
- Prometheus에서 user-service 메트릭 수집 상태를 확인
  - 변경 전 `up{job="user-service"}` 값이 0으로 수집 실패
  - actuator 설정 추가 후 `up{job="user-service"}` 값이 1로 정상 수집 확인
- HikariCP 커넥션풀 최대값 변경을 확인
  - 변경 전: `hikaricp_connections_max = 10`
  - 변경 후: `hikaricp_connections_max = 30`
- 로그인 300명 부하테스트를 진행하여 설정 적용 후 응답 상태를 확인
  - Error %: 0.00%
  - Average: 1628ms
  - Max: 5720ms
  - active 최대값: 29
  - pending 최대값: 13

## 💡 PR 특이사항