### PR TITLE
[FIX] 행사 카테고리 삭제 시 행사 존재 여부 검증 추가

### DIFF
--- a/event-service/src/main/java/com/ojosama/eventservice/event/application/service/EventCategoryCommandService.java
+++ b/event-service/src/main/java/com/ojosama/eventservice/event/application/service/EventCategoryCommandService.java
@@ -7,6 +7,7 @@ import com.ojosama.eventservice.event.domain.exception.EventErrorCode;
 import com.ojosama.eventservice.event.domain.exception.EventException;
 import com.ojosama.eventservice.event.domain.model.EventCategory;
 import com.ojosama.eventservice.event.domain.repository.EventCategoryRepository;
+import com.ojosama.eventservice.event.domain.repository.EventRepository;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -19,6 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class EventCategoryCommandService {
 
     private final EventCategoryRepository eventCategoryRepository;
+    private final EventRepository eventRepository;
 
     public EventCategoryResult createCategory(CreateEventCategoryCommand command) {
         String normalizedName = EventCategory.normalizeName(command.name());
@@ -48,6 +50,9 @@ public class EventCategoryCommandService {
     public void deleteCategory(UUID userId, UUID categoryId) {
         EventCategory category = eventCategoryRepository.findById(categoryId)
                 .orElseThrow(() -> new EventException(EventErrorCode.EVENT_CATEGORY_NOT_FOUND));
+        if (eventRepository.existsActiveEventsByCategoryId(categoryId)) {
+            throw new EventException(EventErrorCode.EVENT_CATEGORY_HAS_ACTIVE_EVENTS);
+        }
         category.deleted(userId);
     }
 }

--- a/event-service/src/main/java/com/ojosama/eventservice/event/domain/exception/EventErrorCode.java
+++ b/event-service/src/main/java/com/ojosama/eventservice/event/domain/exception/EventErrorCode.java
@@ -21,6 +21,7 @@ public enum EventErrorCode implements ErrorCode {
     EVENT_CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 카테고리를 찾을 수 없습니다."),
     EVENT_CATEGORY_INVALID(HttpStatus.BAD_REQUEST, "행사 카테고리가 유효하지 않습니다."),
     EVENT_CATEGORY_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 존재하는 카테고리 이름입니다."),
+    EVENT_CATEGORY_HAS_ACTIVE_EVENTS(HttpStatus.CONFLICT, "진행 중이거나 예정된 행사가 있어 카테고리를 삭제할 수 없습니다."),
 
     // EventSchedule 관련 에러
     EVENT_SCHEDULE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 행사 일정을 찾을 수 없습니다."),

--- a/event-service/src/main/java/com/ojosama/eventservice/event/domain/repository/EventRepository.java
+++ b/event-service/src/main/java/com/ojosama/eventservice/event/domain/repository/EventRepository.java
@@ -17,4 +17,5 @@ public interface EventRepository {
     List<Event> findAllByIds(List<UUID> ids);
     Page<Event> findAll(EventFilter filter, Pageable pageable);
     void delete(Event event);
+    boolean existsActiveEventsByCategoryId(UUID categoryId);
 }

--- a/event-service/src/main/java/com/ojosama/eventservice/event/infrastructure/persistence/EventRepositoryImpl.java
+++ b/event-service/src/main/java/com/ojosama/eventservice/event/infrastructure/persistence/EventRepositoryImpl.java
@@ -1,6 +1,7 @@
 package com.ojosama.eventservice.event.infrastructure.persistence;
 
 import com.ojosama.eventservice.event.domain.model.Event;
+import com.ojosama.eventservice.event.domain.model.EventStatus;
 import com.ojosama.eventservice.event.domain.model.QEvent;
 import com.ojosama.eventservice.event.domain.repository.EventFilter;
 import com.ojosama.eventservice.event.domain.repository.EventRepository;
@@ -105,6 +106,18 @@ public class EventRepositoryImpl implements EventRepository {
     @Override
     public void delete(Event event) {
         jpaEventRepository.save(event);
+    }
+
+    @Override
+    public boolean existsActiveEventsByCategoryId(UUID categoryId) {
+        QEvent event = QEvent.event;
+        return queryFactory
+            .selectOne()
+            .from(event)
+            .where(event.category.id.eq(categoryId)
+                .and(event.status.in(EventStatus.SCHEDULED, EventStatus.IN_PROGRESS))
+                .and(event.deletedAt.isNull()))
+            .fetchFirst() != null;
     }
 
     private BooleanBuilder buildWhere(QEvent event, EventFilter filter) {


### PR DESCRIPTION
## 🔗 Issue Number
- close #261

## 📝 작업 내역

- 예정된 행사와, 진행중인 행사가 있을 시 삭제 불가


## 💡 PR 특이사항

- 현재는 행사 카테고리 삭제가 가능하면 안되는 상황이지만 추후 확장성을 위해 검증만 추가합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 진행 중이거나 예정된 행사가 있는 이벤트 카테고리 삭제 시도를 방지합니다. 활성 행사가 존재하는 경우 삭제 요청 시 충돌 오류가 반환됩니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/55josama/festie/pull/262)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->