### PR TITLE
[FEATURE] front ui,ux 수정, 커뮤니티 내 글 조회, 알림 벨 조회 정리 등

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -52,6 +52,9 @@ export default function App() {
 function AdminRouteGuard() {
   const { user } = useAuthStore()
   if (!user) return <Navigate to="/login" replace />
-  if (!/ADMIN|MANAGER/.test(user.role)) return <Navigate to="/" replace />
+  const normalizedRole = String(user.role ?? '').replace(/^ROLE_/, '')
+  const canAccessAdmin =
+    normalizedRole === 'ADMIN' || normalizedRole === 'MANAGER' || normalizedRole.endsWith('_MANAGER')
+  if (!canAccessAdmin) return <Navigate to="/" replace />
   return <Admin />
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { BrowserRouter, Route, Routes } from 'react-router-dom'
+import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom'
 import Layout from './components/Layout'
 import Home from './pages/Home'
 import Events from './pages/Events'
@@ -12,6 +12,7 @@ import Admin from './pages/Admin'
 import Login from './pages/Login'
 import Register from './pages/Register'
 import MyPage from './pages/MyPage'
+import { useAuthStore } from './store/authStore'
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -36,7 +37,7 @@ export default function App() {
             <Route path="/community/new" element={<CommunityWrite />} />
             <Route path="/community/:postId/edit" element={<CommunityWrite />} />
             <Route path="/community/:postId" element={<PostDetail />} />
-            <Route path="/admin" element={<Admin />} />
+            <Route path="/admin" element={<AdminRouteGuard />} />
             <Route path="/login" element={<Login />} />
             <Route path="/register" element={<Register />} />
             <Route path="/my" element={<MyPage />} />
@@ -46,4 +47,11 @@ export default function App() {
       </BrowserRouter>
     </QueryClientProvider>
   )
+}
+
+function AdminRouteGuard() {
+  const { user } = useAuthStore()
+  if (!user) return <Navigate to="/login" replace />
+  if (!/ADMIN|MANAGER/.test(user.role)) return <Navigate to="/" replace />
+  return <Admin />
 }

--- a/frontend/src/api/community.ts
+++ b/frontend/src/api/community.ts
@@ -8,8 +8,12 @@ export const getPosts = async (params: {
   sort?: string
   page?: number
   size?: number
+  mine?: boolean
 }) => {
-  const res = await publicClient.get('/community-service/v1/posts', { params })
+  const { mine, ...query } = params
+  const res = mine
+    ? await client.get('/community-service/v1/posts', { params: query })
+    : await publicClient.get('/community-service/v1/posts', { params: query })
   return unwrapPage<Post>(res.data)
 }
 

--- a/frontend/src/components/ChatbotWidget.tsx
+++ b/frontend/src/components/ChatbotWidget.tsx
@@ -23,6 +23,7 @@ const QUICK_PROMPTS = [
 
 export default function ChatbotWidget() {
     const {user, accessToken} = useAuthStore()
+    const userStorageKey = useMemo(() => `festie-chatbot:${user?.userId ?? 'guest'}`, [user?.userId])
     const defaultMessages = useMemo<ChatMessage[]>(() => ([
         {
             id: 'welcome',
@@ -32,6 +33,7 @@ export default function ChatbotWidget() {
     ]), [])
     const [open, setOpen] = useState(false)
     const [input, setInput] = useState('')
+    const [storageKey, setStorageKey] = useState(userStorageKey)
     const {data: eventCatalog = []} = useQuery({
         queryKey: ['chatbot-event-catalog'],
         queryFn: () => getEvents({size: 200}),
@@ -41,9 +43,28 @@ export default function ChatbotWidget() {
     const bottomRef = useRef<HTMLDivElement | null>(null)
     const inputRef = useRef<HTMLTextAreaElement | null>(null)
     const hydratedRef = useRef(false)
-    const storageKey = useMemo(() => `festie-chatbot:${user?.userId ?? 'guest'}`, [user?.userId])
 
     const greetingName = useMemo(() => user?.nickname ?? '방문자', [user?.nickname])
+
+    useEffect(() => {
+        const guestKey = 'festie-chatbot:guest'
+        if (user?.userId) {
+            const nextKey = `festie-chatbot:${user.userId}`
+            if (storageKey !== nextKey) {
+                if (window.localStorage.getItem(nextKey) == null) {
+                    const guestRaw = window.localStorage.getItem(guestKey)
+                    if (guestRaw) {
+                        window.localStorage.setItem(nextKey, guestRaw)
+                    }
+                }
+                setStorageKey(nextKey)
+            }
+            return
+        }
+        if (storageKey !== guestKey) {
+            setStorageKey(guestKey)
+        }
+    }, [storageKey, user?.userId])
 
     useEffect(() => {
         hydratedRef.current = false

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -14,7 +14,7 @@ export default function Header() {
   const navigate = useNavigate()
   const { user, isLoggedIn, logout } = useAuthStore()
   const isManager = !!user && /ADMIN|MANAGER/.test(user.role)
-  const canShowMy = !!user && !isManager
+  const showMyNav = !!user && !isManager
 
   const handleLogout = async () => {
     try {
@@ -37,18 +37,12 @@ export default function Header() {
             {user ? (
               <>
                 <NotificationBell variant="mobile" />
-                {canShowMy ? (
-                  <Link
-                    to="/my"
-                    className="inline-flex items-center gap-2 rounded-full border border-[var(--line)] bg-white px-3 py-2 text-sm font-semibold text-slate-700 transition-colors hover:bg-slate-50"
-                  >
-                    {user.nickname}
-                  </Link>
-                ) : (
-                  <div className="inline-flex items-center gap-2 rounded-full border border-[var(--line)] bg-white px-3 py-2 text-sm font-semibold text-slate-700">
-                    {user.nickname}
-                  </div>
-                )}
+                <Link
+                  to="/my"
+                  className="inline-flex items-center gap-2 rounded-full border border-[var(--line)] bg-white px-3 py-2 text-sm font-semibold text-slate-700 transition-colors hover:bg-slate-50"
+                >
+                  {user.nickname}
+                </Link>
                 <button
                   onClick={handleLogout}
                   className="rounded-full bg-[var(--accent)] px-4 py-2 text-sm font-semibold text-white"
@@ -69,7 +63,7 @@ export default function Header() {
           <NavLink to="/events" className={navClass}>행사</NavLink>
           <NavLink to="/calendar" className={navClass}>캘린더</NavLink>
           <NavLink to="/community" className={navClass}>커뮤니티</NavLink>
-          {canShowMy && <NavLink to="/my/calendars" className={navClass}>MY</NavLink>}
+          {showMyNav && <NavLink to="/my/calendars" className={navClass}>MY</NavLink>}
           {isManager && <NavLink to="/admin" className={navClass}>관리</NavLink>}
         </nav>
 
@@ -83,30 +77,21 @@ export default function Header() {
             <NavLink to="/events" className={navClass}>행사</NavLink>
             <NavLink to="/calendar" className={navClass}>캘린더</NavLink>
             <NavLink to="/community" className={navClass}>커뮤니티</NavLink>
-            {canShowMy && <NavLink to="/my/calendars" className={navClass}>MY</NavLink>}
-            {isManager && <NavLink to="/admin" className={navClass}>관리</NavLink>}
+            {showMyNav && <NavLink to="/my/calendars" className={navClass}>MY</NavLink>}
+          {isManager && <NavLink to="/admin" className={navClass}>관리</NavLink>}
           </nav>
 
           <div className="flex shrink-0 items-center gap-3">
             {user ? (
-              canShowMy ? (
-                <Link
-                  to="/my"
-                  className="inline-flex items-center gap-2 rounded-full border border-[var(--line)] bg-white px-3 py-2 text-sm font-semibold text-slate-700 transition-colors hover:bg-slate-50"
-                >
-                  <span className="inline-flex h-6 w-6 items-center justify-center rounded-full bg-[var(--accent-soft)] text-[var(--accent)]">
-                    {user.nickname?.[0] ?? 'U'}
-                  </span>
-                  {user.nickname}
-                </Link>
-              ) : (
-                <div className="inline-flex items-center gap-2 rounded-full border border-[var(--line)] bg-white px-3 py-2 text-sm font-semibold text-slate-700">
-                  <span className="inline-flex h-6 w-6 items-center justify-center rounded-full bg-[var(--accent-soft)] text-[var(--accent)]">
-                    {user.nickname?.[0] ?? 'U'}
-                  </span>
-                  {user.nickname}
-                </div>
-              )
+              <Link
+                to="/my"
+                className="inline-flex items-center gap-2 rounded-full border border-[var(--line)] bg-white px-3 py-2 text-sm font-semibold text-slate-700 transition-colors hover:bg-slate-50"
+              >
+                <span className="inline-flex h-6 w-6 items-center justify-center rounded-full bg-[var(--accent-soft)] text-[var(--accent)]">
+                  {user.nickname?.[0] ?? 'U'}
+                </span>
+                {user.nickname}
+              </Link>
             ) : (
               <Link to="/login" className="rounded-full border border-[var(--line)] px-4 py-2 text-sm font-medium text-slate-700">
                 로그인

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -14,6 +14,7 @@ export default function Header() {
   const navigate = useNavigate()
   const { user, isLoggedIn, logout } = useAuthStore()
   const isManager = !!user && /ADMIN|MANAGER/.test(user.role)
+  const canShowMy = !!user && !isManager
 
   const handleLogout = async () => {
     try {
@@ -36,12 +37,18 @@ export default function Header() {
             {user ? (
               <>
                 <NotificationBell variant="mobile" />
-                <Link
-                  to="/my"
-                  className="inline-flex items-center gap-2 rounded-full border border-[var(--line)] bg-white px-3 py-2 text-sm font-semibold text-slate-700 transition-colors hover:bg-slate-50"
-                >
-                  {user.nickname}
-                </Link>
+                {canShowMy ? (
+                  <Link
+                    to="/my"
+                    className="inline-flex items-center gap-2 rounded-full border border-[var(--line)] bg-white px-3 py-2 text-sm font-semibold text-slate-700 transition-colors hover:bg-slate-50"
+                  >
+                    {user.nickname}
+                  </Link>
+                ) : (
+                  <div className="inline-flex items-center gap-2 rounded-full border border-[var(--line)] bg-white px-3 py-2 text-sm font-semibold text-slate-700">
+                    {user.nickname}
+                  </div>
+                )}
                 <button
                   onClick={handleLogout}
                   className="rounded-full bg-[var(--accent)] px-4 py-2 text-sm font-semibold text-white"
@@ -62,7 +69,7 @@ export default function Header() {
           <NavLink to="/events" className={navClass}>행사</NavLink>
           <NavLink to="/calendar" className={navClass}>캘린더</NavLink>
           <NavLink to="/community" className={navClass}>커뮤니티</NavLink>
-          <NavLink to="/my/calendars" className={navClass}>MY</NavLink>
+          {canShowMy && <NavLink to="/my/calendars" className={navClass}>MY</NavLink>}
           {isManager && <NavLink to="/admin" className={navClass}>관리</NavLink>}
         </nav>
 
@@ -76,21 +83,30 @@ export default function Header() {
             <NavLink to="/events" className={navClass}>행사</NavLink>
             <NavLink to="/calendar" className={navClass}>캘린더</NavLink>
             <NavLink to="/community" className={navClass}>커뮤니티</NavLink>
-            <NavLink to="/my/calendars" className={navClass}>MY</NavLink>
+            {canShowMy && <NavLink to="/my/calendars" className={navClass}>MY</NavLink>}
             {isManager && <NavLink to="/admin" className={navClass}>관리</NavLink>}
           </nav>
 
           <div className="flex shrink-0 items-center gap-3">
             {user ? (
-              <Link
-                to="/my"
-                className="inline-flex items-center gap-2 rounded-full border border-[var(--line)] bg-white px-3 py-2 text-sm font-semibold text-slate-700 transition-colors hover:bg-slate-50"
-              >
-                <span className="inline-flex h-6 w-6 items-center justify-center rounded-full bg-[var(--accent-soft)] text-[var(--accent)]">
-                  {user.nickname?.[0] ?? 'U'}
-                </span>
-                {user.nickname}
-              </Link>
+              canShowMy ? (
+                <Link
+                  to="/my"
+                  className="inline-flex items-center gap-2 rounded-full border border-[var(--line)] bg-white px-3 py-2 text-sm font-semibold text-slate-700 transition-colors hover:bg-slate-50"
+                >
+                  <span className="inline-flex h-6 w-6 items-center justify-center rounded-full bg-[var(--accent-soft)] text-[var(--accent)]">
+                    {user.nickname?.[0] ?? 'U'}
+                  </span>
+                  {user.nickname}
+                </Link>
+              ) : (
+                <div className="inline-flex items-center gap-2 rounded-full border border-[var(--line)] bg-white px-3 py-2 text-sm font-semibold text-slate-700">
+                  <span className="inline-flex h-6 w-6 items-center justify-center rounded-full bg-[var(--accent-soft)] text-[var(--accent)]">
+                    {user.nickname?.[0] ?? 'U'}
+                  </span>
+                  {user.nickname}
+                </div>
+              )
             ) : (
               <Link to="/login" className="rounded-full border border-[var(--line)] px-4 py-2 text-sm font-medium text-slate-700">
                 로그인

--- a/frontend/src/components/NotificationBell.tsx
+++ b/frontend/src/components/NotificationBell.tsx
@@ -226,11 +226,7 @@ export default function NotificationBell({ variant }: NotificationBellProps) {
         aria-label="알림 열기"
       >
         <BellIcon />
-        {unreadCount > 0 && (
-          <span className="absolute -right-1 -top-1 inline-flex min-w-5 items-center justify-center rounded-full bg-rose-500 px-1.5 py-0.5 text-[10px] font-semibold leading-none text-white shadow-sm">
-            {unreadCount > 99 ? '99+' : unreadCount}
-          </span>
-        )}
+        {unreadCount > 0 && <span className="absolute -right-1 -top-1 h-3 w-3 rounded-full border-2 border-white bg-rose-500 shadow-sm" />}
       </button>
 
       {open && (

--- a/frontend/src/components/NotificationBell.tsx
+++ b/frontend/src/components/NotificationBell.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
-import { Link } from 'react-router-dom'
 import { useAuthStore } from '../store/authStore'
 import type { Notification } from '../types'
 import {
@@ -13,7 +12,7 @@ type NotificationBellProps = {
   variant: 'mobile' | 'desktop'
 }
 
-const PAGE_SIZE = 10
+const PAGE_SIZE = 5
 
 function useMediaQuery(query: string) {
   const [matches, setMatches] = useState(() => window.matchMedia(query).matches)
@@ -27,17 +26,6 @@ function useMediaQuery(query: string) {
   }, [query])
 
   return matches
-}
-
-function mergeUnique(existing: Notification[], incoming: Notification[]) {
-  const map = new Map<string, Notification>()
-  existing.forEach((item) => map.set(item.id, item))
-  incoming.forEach((item) => {
-    if (!map.has(item.id)) {
-      map.set(item.id, item)
-    }
-  })
-  return Array.from(map.values())
 }
 
 function BellIcon() {
@@ -69,10 +57,10 @@ export default function NotificationBell({ variant }: NotificationBellProps) {
   const buttonRef = useRef<HTMLButtonElement | null>(null)
 
   const unreadCount = useMemo(() => notifications.filter((item) => item.readAt === null).length, [notifications])
-  const hasMore = page + 1 < totalPages
+  const hasPrev = page > 0
+  const hasNext = page + 1 < totalPages
   const isMockDev = import.meta.env.DEV && String(import.meta.env.VITE_USE_MSW ?? 'true') === 'true'
   const canUseLiveStream = shouldRender && !isMockDev
-  const isAdmin = user?.role === 'ADMIN'
 
   const syncInitialNotifications = async () => {
     if (!isLoggedIn() || !user?.userId) {
@@ -110,13 +98,12 @@ export default function NotificationBell({ variant }: NotificationBellProps) {
     setNotifications((prev) => prev.filter((item) => item.id !== notificationId))
   }
 
-  const handleLoadMore = async () => {
-    if (loadingMore || !hasMore) return
+  const handleLoadPage = async (nextPage: number) => {
+    if (loadingMore || nextPage < 0 || nextPage >= totalPages || nextPage === page) return
     setLoadingMore(true)
     try {
-      const nextPage = page + 1
       const pageResponse = await getNotifications({ page: nextPage, size: PAGE_SIZE })
-      setNotifications((prev) => mergeUnique(prev, pageResponse.content))
+      setNotifications(pageResponse.content)
       setPage(nextPage)
       setTotalPages(pageResponse.totalPages)
     } finally {
@@ -278,15 +265,6 @@ export default function NotificationBell({ variant }: NotificationBellProps) {
             <div className="flex items-center justify-between gap-2">
               <div className="text-[12px] font-semibold text-slate-500">받은 알림 {notifications.length}건</div>
               <div className="flex items-center gap-2">
-                {isAdmin && (
-                  <Link
-                    to="/admin?tab=notifications"
-                    onClick={() => setOpen(false)}
-                    className="rounded-full border border-[var(--accent-soft)] bg-[var(--accent-soft)]/50 px-3 py-1.5 text-[11px] font-semibold text-[var(--accent)] transition-colors hover:bg-[var(--accent-soft)]/70"
-                  >
-                    전체 알림 보기
-                  </Link>
-                )}
                 <button
                   type="button"
                   onClick={() => void syncInitialNotifications()}
@@ -351,16 +329,39 @@ export default function NotificationBell({ variant }: NotificationBellProps) {
               )}
             </div>
 
-            {hasMore && (
+            <div className="mt-3 flex items-center justify-center gap-2">
               <button
                 type="button"
-                onClick={() => void handleLoadMore()}
-                disabled={loadingMore}
-                className="mt-3 w-full rounded-full border border-slate-200 bg-white px-3 py-2 text-sm font-semibold text-slate-700 transition-colors hover:bg-slate-50 disabled:opacity-60"
+                onClick={() => void handleLoadPage(page - 1)}
+                disabled={!hasPrev || loadingMore}
+                className="rounded-full border border-[var(--line)] bg-white px-3 py-1.5 text-xs font-semibold text-slate-700 disabled:opacity-40"
               >
-                {loadingMore ? '불러오는 중...' : '더 보기'}
+                이전
               </button>
-            )}
+              <div className="flex items-center gap-1">
+                {Array.from({ length: Math.max(totalPages, 1) }, (_, index) => index).map((pageIndex) => (
+                  <button
+                    key={pageIndex}
+                    type="button"
+                    onClick={() => void handleLoadPage(pageIndex)}
+                    disabled={loadingMore}
+                    className={`h-8 min-w-8 rounded-full px-2 text-xs font-semibold transition-colors ${
+                      page === pageIndex ? 'bg-[var(--accent-soft)] text-[var(--accent)]' : 'bg-slate-100 text-slate-600 hover:bg-slate-200'
+                    }`}
+                  >
+                    {pageIndex + 1}
+                  </button>
+                ))}
+              </div>
+              <button
+                type="button"
+                onClick={() => void handleLoadPage(page + 1)}
+                disabled={!hasNext || loadingMore}
+                className="rounded-full border border-[var(--line)] bg-white px-3 py-1.5 text-xs font-semibold text-slate-700 disabled:opacity-40"
+              >
+                다음
+              </button>
+            </div>
           </div>
         </div>
       )}

--- a/frontend/src/pages/Admin.tsx
+++ b/frontend/src/pages/Admin.tsx
@@ -2499,6 +2499,8 @@ function validateEventDraft(draft: EventDraft): EventFormErrors {
     if (draft.hasTicketing) {
         if (!draft.ticketingOpenAt.trim()) errors.ticketingOpenAt = '티켓팅 오픈은 필수입니다.'
         if (!draft.ticketingCloseAt.trim()) errors.ticketingCloseAt = '티켓팅 종료는 필수입니다.'
+        if (!draft.ticketingLink.trim()) errors.ticketingLink = '티켓팅 링크는 필수입니다.'
+        if (!draft.img.trim()) errors.img = '대표 이미지는 필수입니다.'
     }
 
     return errors
@@ -2753,7 +2755,7 @@ function EventCreatePanel({
                             <div className="md:col-span-2">
                                 <AdminInput label="티켓팅 링크" value={draft.ticketingLink}
                                             onChange={(value) => setDraft({ticketingLink: value})}
-                                            error={mergedErrors.ticketingLink}/>
+                                            error={mergedErrors.ticketingLink} required={draft.hasTicketing}/>
                             </div>
                         </div>
                     </div>
@@ -2761,7 +2763,10 @@ function EventCreatePanel({
                 <label className="md:col-span-2 block">
                     <div
                         className="mb-1 flex items-center justify-between gap-2 text-[11px] font-semibold text-slate-500">
-                        <span>대표 이미지</span>
+                        <span className="flex items-center gap-1">
+                            <span>대표 이미지</span>
+                            {draft.hasTicketing && <span className="text-rose-500">*</span>}
+                        </span>
                         <button
                             type="button"
                             onClick={() => imageInputRef.current?.click()}

--- a/frontend/src/pages/Admin.tsx
+++ b/frontend/src/pages/Admin.tsx
@@ -18,7 +18,6 @@ import {
     updateOperationRequestStatus,
     updateReportStatus,
 } from '../api/admin'
-import { deleteNotification, getNotifications, markAllNotificationsAsRead } from '../api/notifications'
 import {createEvent, getEvent, updateEvent} from '../api/events'
 import {getAdminChatMessages, updateAdminChatMessageStatus} from '../api/chat'
 import {
@@ -43,7 +42,7 @@ const REQUEST_STATUS_FILTERS = ['ALL', 'PENDING', 'APPROVED', 'REJECTED', 'CANCE
 const OPERATION_STATUS_FILTERS = ['ALL', 'PENDING', 'IN_PROGRESS', 'RESOLVED', 'REJECTED'] as const
 const CHAT_STATUS_FILTERS = ['ALL', 'SCHEDULED', 'OPEN', 'CLOSED'] as const
 const USER_ROLE_FILTERS = ['ALL', 'USER', 'ADMIN', 'CONCERT_MANAGER', 'FESTIVAL_MANAGER', 'FANMEETING_MANAGER', 'POPUP_MANAGER', 'COMMUNITY_MANAGER'] as const
-const ADMIN_TABS = ['manage', 'reports', 'chat', 'users', 'blacklist', 'notifications'] as const
+const ADMIN_TABS = ['manage', 'reports', 'chat', 'users', 'blacklist'] as const
 const EVENT_CATEGORY_SCOPE: Record<string, string[]> = {
     ADMIN: [],
     CONCERT_MANAGER: ['\uCF58\uC11C\uD2B8'],
@@ -129,7 +128,6 @@ export default function Admin() {
     const [blacklistSubmittedSearch, setBlacklistSubmittedSearch] = useState('')
     const [blacklistPage, setBlacklistPage] = useState(0)
     const [selectedBlacklistId, setSelectedBlacklistId] = useState<string | null>(null)
-    const [adminNotificationPage, setAdminNotificationPage] = useState(0)
     const [rejectReasons, setRejectReasons] = useState<Record<string, string>>({})
     const [reportReviewForms, setReportReviewForms] = useState<Record<string, { status: string; operatorMemo: string }>>({})
     const [operationAdminMemos, setOperationAdminMemos] = useState<Record<string, string>>({})
@@ -270,14 +268,6 @@ export default function Admin() {
                 status: blacklistStatus === 'ALL' ? undefined : blacklistStatus,
             }),
         enabled: isAdmin && activeTab === 'blacklist',
-    })
-
-    const {
-        data: adminNotificationsPage = {content: [], totalElements: 0, totalPages: 0, size: 0, page: 0},
-    } = useQuery({
-        queryKey: ['admin', 'notifications', adminNotificationPage],
-        queryFn: () => getNotifications({page: adminNotificationPage, size: 10}),
-        enabled: isAdmin && activeTab === 'notifications',
     })
 
     const blacklistUserDetails = useQueries({
@@ -512,20 +502,6 @@ export default function Admin() {
         },
     })
 
-    const notificationMarkAllMutation = useMutation({
-        mutationFn: markAllNotificationsAsRead,
-        onSuccess: async () => {
-            await queryClient.invalidateQueries({queryKey: ['admin', 'notifications']})
-        },
-    })
-
-    const notificationDeleteMutation = useMutation({
-        mutationFn: deleteNotification,
-        onSuccess: async () => {
-            await queryClient.invalidateQueries({queryKey: ['admin', 'notifications']})
-        },
-    })
-
     const createEventMutation = useMutation({
         mutationFn: ({requestId, draft}: { requestId?: string; draft: EventDraft }) =>
             createEvent({
@@ -728,10 +704,9 @@ export default function Admin() {
         {value: 'chat', label: '채팅', description: '메시지·방'},
         {value: 'users', label: '사용자 조회', description: '이메일·이름·권한'},
         {value: 'blacklist', label: '블랙리스트', description: '차단·해제'},
-        {value: 'notifications', label: '알림', description: '전체 조회'},
     ]
     const visibleTabs = useMemo(
-        () => tabs.filter((tab) => (tab.value === 'users' || tab.value === 'blacklist' || tab.value === 'notifications') ? isAdmin : true),
+        () => tabs.filter((tab) => (tab.value === 'users' || tab.value === 'blacklist') ? isAdmin : true),
         [isAdmin],
     )
 
@@ -2014,101 +1989,6 @@ export default function Admin() {
                 </section>
             )}
 
-            {activeTab === 'notifications' && isAdmin && (
-                <section className="space-y-4 rounded-[24px] border border-[var(--line)] bg-white p-5 shadow-[0_12px_30px_rgba(15,23,42,0.04)]">
-                    <SectionHeader
-                        title="알림"
-                        action={
-                            <div className="flex items-center gap-2">
-                                <span className="text-xs text-slate-500">{adminNotificationsPage.totalElements}건</span>
-                                <button
-                                    type="button"
-                                    disabled={adminNotificationsPage.content.every((item) => item.readAt !== null) || notificationMarkAllMutation.isPending}
-                                    onClick={() => notificationMarkAllMutation.mutate()}
-                                    className="rounded-full border border-[var(--line)] bg-white px-3 py-1.5 text-xs font-semibold text-slate-700 disabled:opacity-40"
-                                >
-                                    모두 읽음
-                                </button>
-                            </div>
-                        }
-                    />
-                    <p className="text-sm leading-6 text-slate-600">
-                        실시간으로 들어온 알림과 DB에 저장된 알림을 함께 확인할 수 있어요.
-                    </p>
-
-                    <div className="space-y-3">
-                        {adminNotificationsPage.content.map((notification) => (
-                            <article
-                                key={notification.id}
-                                className={`rounded-[18px] border p-3 shadow-sm transition-colors ${
-                                    notification.readAt
-                                        ? 'border-slate-100 bg-white'
-                                        : 'border-[var(--accent-soft)]/60 bg-[var(--accent-soft)]/35'
-                                }`}
-                            >
-                                <div className="flex items-start justify-between gap-3">
-                                    <div className="min-w-0 flex-1">
-                                        <div className="flex items-center gap-2">
-                                            <span className="inline-flex rounded-full bg-slate-100 px-2.5 py-1 text-[10px] font-semibold text-slate-600">
-                                                {notification.readAt ? '읽음' : '새 알림'}
-                                            </span>
-                                        </div>
-                                        <div className="mt-2 text-[13px] font-semibold leading-5 text-slate-950">
-                                            {notification.title}
-                                        </div>
-                                        <div className="mt-1 text-[12px] leading-5 text-slate-600">
-                                            {notification.content}
-                                        </div>
-                                    </div>
-                                    <button
-                                        type="button"
-                                        onClick={() => notificationDeleteMutation.mutate(notification.id)}
-                                        className="rounded-full border border-slate-200 bg-white px-2.5 py-1.5 text-[11px] font-semibold text-slate-500 transition-colors hover:border-rose-200 hover:text-rose-600"
-                                        aria-label="알림 삭제"
-                                    >
-                                        삭제
-                                    </button>
-                                </div>
-                            </article>
-                        ))}
-                        {adminNotificationsPage.content.length === 0 && <EmptyState text="알림이 없습니다."/>}
-                    </div>
-
-                    <div className="flex items-center justify-center gap-2 pt-2">
-                        <button
-                            type="button"
-                            disabled={adminNotificationsPage.page === 0}
-                            onClick={() => setAdminNotificationPage((prev) => Math.max(prev - 1, 0))}
-                            className="rounded-full border border-[var(--line)] bg-white px-3 py-1.5 text-xs font-semibold text-slate-700 disabled:opacity-40"
-                        >
-                            이전
-                        </button>
-                        <div className="flex items-center gap-1">
-                            {Array.from({length: Math.max(adminNotificationsPage.totalPages || 0, 1)}, (_, index) => index).map((pageIndex) => (
-                                <button
-                                    key={pageIndex}
-                                    type="button"
-                                    onClick={() => setAdminNotificationPage(pageIndex)}
-                                    className={`h-8 min-w-8 rounded-full px-2 text-xs font-semibold transition-colors ${
-                                        adminNotificationsPage.page === pageIndex ? 'bg-[var(--accent-soft)] text-[var(--accent)]' : 'bg-slate-100 text-slate-600 hover:bg-slate-200'
-                                    }`}
-                                >
-                                    {pageIndex + 1}
-                                </button>
-                            ))}
-                        </div>
-                        <button
-                            type="button"
-                            disabled={adminNotificationsPage.page + 1 >= Math.max(adminNotificationsPage.totalPages || 0, 1)}
-                            onClick={() => setAdminNotificationPage((prev) => prev + 1)}
-                            className="rounded-full border border-[var(--line)] bg-white px-3 py-1.5 text-xs font-semibold text-slate-700 disabled:opacity-40"
-                        >
-                            다음
-                        </button>
-                    </div>
-                </section>
-            )}
-
             {selectedUserId && (
                 <div
                     className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/50 px-4 py-8"
@@ -3183,7 +3063,7 @@ function normalizeRole(role?: string | null) {
 }
 
 function normalizeAdminTab(value: string | null): AdminTab {
-    if (value === 'manage' || value === 'reports' || value === 'chat' || value === 'users' || value === 'blacklist' || value === 'notifications') return value
+    if (value === 'manage' || value === 'reports' || value === 'chat' || value === 'users' || value === 'blacklist') return value
     return 'manage'
 }
 

--- a/frontend/src/pages/Community.tsx
+++ b/frontend/src/pages/Community.tsx
@@ -13,6 +13,7 @@ import type { EventRequestItem, OperationRequestItem } from '../types/admin'
 type FeedTab = 'posts' | 'requests'
 type RequestKind = 'event' | 'operation'
 type RequestStatusFilter = 'all' | 'PENDING' | 'APPROVED' | 'IN_PROGRESS' | 'RESOLVED' | 'REJECTED'
+type PostScope = 'all' | 'mine'
 
 type RequestFeedItem = {
     id: string
@@ -34,12 +35,13 @@ type RequestFeedItem = {
 
 export default function Community() {
     const { user } = useAuthStore()
-    const [searchParams] = useSearchParams()
+    const [searchParams, setSearchParams] = useSearchParams()
     const queryClient = useQueryClient()
     const [feedTab, setFeedTab] = useState<FeedTab>(() => searchParams.get('tab') === 'requests' ? 'requests' : 'posts')
     const [requestKind, setRequestKind] = useState<RequestKind>(() => searchParams.get('requestKind') === 'operation' ? 'operation' : 'event')
     const [categoryId, setCategoryId] = useState<string | undefined>()
     const [sort, setSort] = useState<'latest' | 'popular'>('latest')
+    const [postScope, setPostScope] = useState<PostScope>(() => searchParams.get('scope') === 'mine' ? 'mine' : 'all')
     const [requestStatusFilter, setRequestStatusFilter] = useState<RequestStatusFilter>('all')
     const [requestRejectReasons, setRequestRejectReasons] = useState<Record<string, string>>({})
     const [operationRejectReasons, setOperationRejectReasons] = useState<Record<string, string>>({})
@@ -51,8 +53,10 @@ export default function Community() {
     useEffect(() => {
         const nextFeedTab = searchParams.get('tab') === 'requests' ? 'requests' : 'posts'
         const nextRequestKind = searchParams.get('requestKind') === 'operation' ? 'operation' : 'event'
+        const nextPostScope = searchParams.get('scope') === 'mine' ? 'mine' : 'all'
         setFeedTab(nextFeedTab)
         setRequestKind(nextRequestKind)
+        setPostScope(nextPostScope)
     }, [searchParams])
 
     const {data: categories = []} = useQuery({
@@ -61,8 +65,13 @@ export default function Community() {
     })
 
     const {data: rawPosts = []} = useQuery({
-        queryKey: ['posts', categoryId, sort],
-        queryFn: () => getPosts({categoryId, sort: sort === 'popular' ? 'likeCount,desc' : 'createdAt,desc', size: 100}),
+        queryKey: ['posts', categoryId, sort, postScope],
+        queryFn: () => getPosts({
+            categoryId,
+            sort: sort === 'popular' ? 'likeCount,desc' : 'createdAt,desc',
+            size: 100,
+            mine: postScope === 'mine',
+        }),
         enabled: feedTab === 'posts',
     })
 
@@ -274,6 +283,26 @@ export default function Community() {
                     <div className="flex flex-wrap items-center gap-1.5">
                         {feedTab === 'posts' && (
                             <>
+                                <span className="text-[10px] font-semibold text-slate-500">조회</span>
+                                <FilterChip active={postScope === 'all'} tone="violet" onClick={() => {
+                                    setPostScope('all')
+                                    const next = new URLSearchParams(searchParams)
+                                    next.delete('scope')
+                                    setSearchParams(next, { replace: true })
+                                }}>
+                                    전체
+                                </FilterChip>
+                                {!!user && (
+                                    <FilterChip active={postScope === 'mine'} tone="violet" onClick={() => {
+                                        setPostScope('mine')
+                                        const next = new URLSearchParams(searchParams)
+                                        next.set('scope', 'mine')
+                                        next.set('tab', 'posts')
+                                        setSearchParams(next, { replace: true })
+                                    }}>
+                                        내 글
+                                    </FilterChip>
+                                )}
                                 <span className="text-[10px] font-semibold text-slate-500">정렬</span>
                                 <FilterChip active={sort === 'latest'} tone="sky" onClick={() => setSort('latest')}>
                                     최신글

--- a/frontend/src/pages/Community.tsx
+++ b/frontend/src/pages/Community.tsx
@@ -53,11 +53,11 @@ export default function Community() {
     useEffect(() => {
         const nextFeedTab = searchParams.get('tab') === 'requests' ? 'requests' : 'posts'
         const nextRequestKind = searchParams.get('requestKind') === 'operation' ? 'operation' : 'event'
-        const nextPostScope = searchParams.get('scope') === 'mine' ? 'mine' : 'all'
+        const nextPostScope = user && searchParams.get('scope') === 'mine' ? 'mine' : 'all'
         setFeedTab(nextFeedTab)
         setRequestKind(nextRequestKind)
         setPostScope(nextPostScope)
-    }, [searchParams])
+    }, [searchParams, user])
 
     const {data: categories = []} = useQuery({
         queryKey: ['categories'],
@@ -65,14 +65,14 @@ export default function Community() {
     })
 
     const {data: rawPosts = []} = useQuery({
-        queryKey: ['posts', categoryId, sort, postScope],
+        queryKey: ['posts', categoryId, sort, postScope, user?.userId ?? null],
         queryFn: () => getPosts({
             categoryId,
             sort: sort === 'popular' ? 'likeCount,desc' : 'createdAt,desc',
             size: 100,
-            mine: postScope === 'mine',
+            mine: postScope === 'mine' && !!user,
         }),
-        enabled: feedTab === 'posts',
+        enabled: feedTab === 'posts' && (postScope !== 'mine' || !!user),
     })
 
     const {data: eventRequests = []} = useQuery<EventRequestItem[]>({
@@ -216,6 +216,14 @@ export default function Community() {
     useEffect(() => {
         setRequestStatusFilter('all')
     }, [requestKind])
+
+    useEffect(() => {
+        if (postScope !== 'mine' || user) return
+        setPostScope('all')
+        const next = new URLSearchParams(searchParams)
+        next.delete('scope')
+        setSearchParams(next, { replace: true })
+    }, [postScope, searchParams, setSearchParams, user])
 
     return (
         <div className="space-y-5 px-5 py-5 md:px-8 md:py-7">

--- a/frontend/src/pages/EventDetail.tsx
+++ b/frontend/src/pages/EventDetail.tsx
@@ -548,6 +548,18 @@ export default function EventDetail() {
                     onChange={(e) => setMessage(e.target.value)}
                     placeholder="메시지를 입력하세요"
                     disabled={chatConnectionStatus !== 'connected'}
+                    onKeyDown={(e) => {
+                      if (e.key !== 'Enter') return
+                      e.preventDefault()
+                      sendChatOverSocket({
+                        chatRoomId,
+                        content: message,
+                        client: stompClientRef.current,
+                        isConnected: chatConnectionStatusRef.current === 'connected' || stompClientRef.current?.connected === true,
+                        onSent: () => setMessage(''),
+                        onInvalid: () => window.alert('채팅방에 먼저 들어가 주세요.'),
+                      })
+                    }}
                     className={`min-w-0 flex-1 rounded-full border bg-white px-3 py-2.5 text-sm outline-none disabled:cursor-not-allowed disabled:bg-slate-100 disabled:text-slate-400 ${chatTheme.inputClass}`}
                   />
                   <button

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -15,7 +15,7 @@ export default function Home() {
   const { data: categories = [] } = useQuery({ queryKey: ['categories', 'home'], queryFn: getCategories })
   const { data: popularRooms = [] } = useQuery({ queryKey: ['popular-chat-rooms', 'home'], queryFn: () => getPopularChatRooms(3) })
 
-  const featuredPosts = useMemo(() => pickTodayPopularPosts(posts as Post[]), [posts])
+  const featuredPosts = useMemo(() => pickRecentPopularPosts(posts as Post[], 24), [posts])
   const upcomingEvents = useMemo(() => getCurrentEventWindow(allEvents as Event[]), [allEvents])
   const upcomingTicketing = useMemo(() => getCurrentTicketingWindow(ticketingEvents as Event[]), [ticketingEvents])
   const categoryNameById = useMemo(() => {
@@ -99,18 +99,25 @@ export default function Home() {
       </section>
 
       <section className="rounded-[24px] border border-[var(--line)] bg-white p-4 shadow-[0_12px_30px_rgba(15,23,42,0.04)] md:p-5">
-        <SectionHeading
-          title="오늘 인기글"
-          action={<Link to="/community" className="hidden text-sm font-medium text-[var(--accent)] md:inline">전체보기</Link>}
-        />
+        <div className="flex items-end justify-between gap-3">
+          <div>
+            <h2 className="text-[18px] font-black tracking-tight text-slate-950">인기글</h2>
+            <p className="mt-1 text-xs text-slate-500">24시간 내 인기글만 보여줘요.</p>
+          </div>
+          <Link to="/community" className="hidden text-sm font-medium text-[var(--accent)] md:inline">전체보기</Link>
+        </div>
         <div className="mt-4 grid gap-3">
-          {featuredPosts.map((post) => (
+          {featuredPosts.length ? featuredPosts.map((post) => (
             <PostRow
               key={post.id}
               post={post}
               categoryLabel={categoryNameById.get(post.categoryId) ?? post.categoryName}
             />
-          ))}
+          )) : (
+            <div className="rounded-[20px] border border-dashed border-[var(--line)] bg-slate-50 px-4 py-8 text-center text-sm text-slate-500">
+              아직 24시간 내 인기글이 없어요.
+            </div>
+          )}
         </div>
       </section>
     </div>
@@ -127,14 +134,12 @@ function sortUpcomingTicketing(events: Event[]) {
     .sort((a, b) => String(a.ticketingOpenAt ?? '').localeCompare(String(b.ticketingOpenAt ?? '')))
 }
 
-function pickTodayPopularPosts(posts: Post[]) {
-  const today = new Date().toLocaleDateString('ko-KR')
-  const todayPosts = posts
-    .filter((post) => new Date(post.createdAt).toLocaleDateString('ko-KR') === today)
+function pickRecentPopularPosts(posts: Post[], hours = 24) {
+  const cutoff = Date.now() - hours * 60 * 60 * 1000
+  return posts
+    .filter((post) => new Date(post.createdAt).getTime() >= cutoff)
     .sort((a, b) => (b.likeCount + b.commentCount) - (a.likeCount + a.commentCount))
-
-  const ranked = todayPosts.length ? todayPosts : [...posts].sort((a, b) => (b.likeCount + b.commentCount) - (a.likeCount + a.commentCount))
-  return ranked.slice(0, 4)
+    .slice(0, 4)
 }
 
 function countdownLabel(dateValue?: string | null, mode: 'event' | 'ticketing' = 'event') {
@@ -150,7 +155,7 @@ function startOfToday() {
 }
 
 function getCurrentEventWindow(events: Event[]) {
-  return sortUpcomingEvents(events.filter((event) => isOngoingEvent(event) || isWithinDays(event.startAt, 7)))
+  return sortUpcomingEvents(events.filter((event) => isWithinDays(event.startAt, 7)))
 }
 
 function getCurrentTicketingWindow(events: Event[]) {
@@ -160,13 +165,6 @@ function getCurrentTicketingWindow(events: Event[]) {
       return isWithinDays(event.ticketingOpenAt, 7) || (isTicketingOpen(event) && isWithinDays(event.startAt, 7))
     })
   )
-}
-
-function isOngoingEvent(event: Event) {
-  const now = new Date()
-  const start = new Date(event.startAt)
-  const end = new Date(event.endAt)
-  return start <= now && now <= end
 }
 
 function isTicketingOpen(event: Event) {

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -8,8 +8,8 @@ import { useAuthStore } from '../store/authStore'
 export default function Login() {
   const navigate = useNavigate()
   const { setAccessToken, setRefreshToken, setUser, syncUserFromAccessToken } = useAuthStore()
-  const [email, setEmail] = useState('test@festie.kr')
-  const [password, setPassword] = useState('password')
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
   const [error, setError] = useState('')
   const [loading, setLoading] = useState(false)
 
@@ -53,8 +53,8 @@ export default function Login() {
             <p className="mt-2 text-sm text-slate-500">서비스를 계속 사용하려면 계정으로 들어오세요.</p>
           </div>
 
-          <Input label="이메일" value={email} onChange={setEmail} type="email" />
-          <Input label="비밀번호" value={password} onChange={setPassword} type="password" />
+          <Input label="이메일" value={email} onChange={setEmail} type="email" placeholder="example@festie.kr" />
+          <Input label="비밀번호" value={password} onChange={setPassword} type="password" placeholder="비밀번호를 입력하세요" />
 
           {error && <div className="rounded-2xl bg-rose-50 px-4 py-3 text-sm text-rose-700">{error}</div>}
 
@@ -79,11 +79,13 @@ function Input({
   value,
   onChange,
   type,
+  placeholder,
 }: {
   label: string
   value: string
   onChange: (value: string) => void
   type: string
+  placeholder?: string
 }) {
   return (
     <label className="block">
@@ -92,6 +94,7 @@ function Input({
         type={type}
         value={value}
         onChange={(e) => onChange(e.target.value)}
+        placeholder={placeholder}
         className="w-full rounded-full border border-[var(--line)] bg-slate-50 px-4 py-3 text-sm outline-none focus:border-[var(--accent)]"
       />
     </label>

--- a/frontend/src/pages/MyPage.tsx
+++ b/frontend/src/pages/MyPage.tsx
@@ -111,7 +111,14 @@ export default function MyPage() {
         </section>
 
         <div className="grid gap-4 md:grid-cols-2">
-          <InfoCard title="내가 쓴 글 / 댓글" description="지금은 영역만 남겨두고, 목록 API가 생기면 바로 붙이기 좋습니다." />
+          <InfoCard title="내가 쓴 글" description="커뮤니티에서 내가 쓴 글만 바로 볼 수 있어요.">
+            <Link
+              to="/community?tab=posts&scope=mine"
+              className="mt-4 inline-flex rounded-full border border-[var(--line)] bg-[var(--accent-soft)] px-4 py-2 text-sm font-semibold text-[var(--accent)]"
+            >
+              쓴 글 보기
+            </Link>
+          </InfoCard>
           <InfoCard
             title="내가 저장한 일정"
             description="내 일정 캘린더로 바로 연결해서 추가한 행사만 따로 볼 수 있어요."

--- a/frontend/src/store/authStore.ts
+++ b/frontend/src/store/authStore.ts
@@ -2,6 +2,8 @@ import { create } from 'zustand'
 import { buildUserFromToken } from '../lib/jwt'
 import type { User } from '../types'
 
+const AUTH_STORAGE_KEY = 'festie-auth'
+
 interface AuthState {
   accessToken: string | null
   refreshToken: string | null
@@ -14,23 +16,81 @@ interface AuthState {
   isLoggedIn: () => boolean
 }
 
+type StoredAuthState = Pick<AuthState, 'accessToken' | 'refreshToken' | 'user'>
+
+function loadStoredAuthState(): StoredAuthState | null {
+  if (typeof window === 'undefined') return null
+  try {
+    const raw = window.sessionStorage.getItem(AUTH_STORAGE_KEY)
+    if (!raw) return null
+    const parsed = JSON.parse(raw) as StoredAuthState
+    return {
+      accessToken: parsed.accessToken ?? null,
+      refreshToken: parsed.refreshToken ?? null,
+      user: parsed.user ?? null,
+    }
+  } catch {
+    return null
+  }
+}
+
+function saveStoredAuthState(state: StoredAuthState) {
+  if (typeof window === 'undefined') return
+  if (!state.accessToken && !state.refreshToken && !state.user) {
+    window.sessionStorage.removeItem(AUTH_STORAGE_KEY)
+    return
+  }
+  window.sessionStorage.setItem(AUTH_STORAGE_KEY, JSON.stringify(state))
+}
+
+const storedAuthState = loadStoredAuthState()
+
 export const useAuthStore = create<AuthState>()(
   (set, get) => ({
-    accessToken: null,
-    refreshToken: null,
-    user: null,
-    setAccessToken: (token) => set({ accessToken: token }),
-    setRefreshToken: (token) => set({ refreshToken: token }),
-    setUser: (user) => set({ user }),
+    accessToken: storedAuthState?.accessToken ?? null,
+    refreshToken: storedAuthState?.refreshToken ?? null,
+    user: storedAuthState?.user ?? null,
+    setAccessToken: (token) => {
+      set({ accessToken: token })
+      saveStoredAuthState({
+        accessToken: token,
+        refreshToken: get().refreshToken,
+        user: get().user,
+      })
+    },
+    setRefreshToken: (token) => {
+      set({ refreshToken: token })
+      saveStoredAuthState({
+        accessToken: get().accessToken,
+        refreshToken: token,
+        user: get().user,
+      })
+    },
+    setUser: (user) => {
+      set({ user })
+      saveStoredAuthState({
+        accessToken: get().accessToken,
+        refreshToken: get().refreshToken,
+        user,
+      })
+    },
     syncUserFromAccessToken: () => {
       const state = get()
       if (state.user || !state.accessToken) return
       const fallbackUser = buildUserFromToken(state.accessToken)
       if (fallbackUser) {
         set({ user: fallbackUser })
+        saveStoredAuthState({
+          accessToken: state.accessToken,
+          refreshToken: state.refreshToken,
+          user: fallbackUser,
+        })
       }
     },
-    logout: () => set({ accessToken: null, refreshToken: null, user: null }),
+    logout: () => {
+      set({ accessToken: null, refreshToken: null, user: null })
+      saveStoredAuthState({ accessToken: null, refreshToken: null, user: null })
+    },
     isLoggedIn: () => !!get().accessToken,
   })
 )

--- a/frontend/src/store/authStore.ts
+++ b/frontend/src/store/authStore.ts
@@ -1,5 +1,4 @@
 import { create } from 'zustand'
-import { persist } from 'zustand/middleware'
 import { buildUserFromToken } from '../lib/jwt'
 import type { User } from '../types'
 
@@ -16,25 +15,22 @@ interface AuthState {
 }
 
 export const useAuthStore = create<AuthState>()(
-  persist(
-    (set, get) => ({
-      accessToken: null,
-      refreshToken: null,
-      user: null,
-      setAccessToken: (token) => set({ accessToken: token }),
-      setRefreshToken: (token) => set({ refreshToken: token }),
-      setUser: (user) => set({ user }),
-      syncUserFromAccessToken: () => {
-        const state = get()
-        if (state.user || !state.accessToken) return
-        const fallbackUser = buildUserFromToken(state.accessToken)
-        if (fallbackUser) {
-          set({ user: fallbackUser })
-        }
-      },
-      logout: () => set({ accessToken: null, refreshToken: null, user: null }),
-      isLoggedIn: () => !!get().accessToken,
-    }),
-    { name: 'festie-auth', partialize: (s) => ({ accessToken: s.accessToken, refreshToken: s.refreshToken, user: s.user }) }
-  )
+  (set, get) => ({
+    accessToken: null,
+    refreshToken: null,
+    user: null,
+    setAccessToken: (token) => set({ accessToken: token }),
+    setRefreshToken: (token) => set({ refreshToken: token }),
+    setUser: (user) => set({ user }),
+    syncUserFromAccessToken: () => {
+      const state = get()
+      if (state.user || !state.accessToken) return
+      const fallbackUser = buildUserFromToken(state.accessToken)
+      if (fallbackUser) {
+        set({ user: fallbackUser })
+      }
+    },
+    logout: () => set({ accessToken: null, refreshToken: null, user: null }),
+    isLoggedIn: () => !!get().accessToken,
+  })
 )

--- a/frontend/src/store/authStore.ts
+++ b/frontend/src/store/authStore.ts
@@ -36,11 +36,15 @@ function loadStoredAuthState(): StoredAuthState | null {
 
 function saveStoredAuthState(state: StoredAuthState) {
   if (typeof window === 'undefined') return
-  if (!state.accessToken && !state.refreshToken && !state.user) {
-    window.sessionStorage.removeItem(AUTH_STORAGE_KEY)
-    return
+  try {
+    if (!state.accessToken && !state.refreshToken && !state.user) {
+      window.sessionStorage.removeItem(AUTH_STORAGE_KEY)
+      return
+    }
+    window.sessionStorage.setItem(AUTH_STORAGE_KEY, JSON.stringify(state))
+  } catch {
+    // 세션 저장 실패가 로그인/토큰 갱신 흐름을 막지 않도록 흡수한다.
   }
-  window.sessionStorage.setItem(AUTH_STORAGE_KEY, JSON.stringify(state))
 }
 
 const storedAuthState = loadStoredAuthState()


### PR DESCRIPTION
## 🔗 Issue Number
- close #282 

## 📝 작업 내역
- 커뮤니티에서 `내 글` 조회를 추가하고, `/my`에서 바로 이동할 수 있게 연결
- - MY 탭은 헤더에서만 관리자/매니저 기준으로 숨기고, `/my` 경로는 직접 접근 가능하게 유지
- 프론트 전반의 자잘한 UI를 정리하고 사용성 개선
- 알림은 별도 조회 페이지 대신 종모양 패널에서 확인하도록 정리
- 알림 목록은 5개 단위 페이지네이션 + 개별 삭제 지원
- 관리자 탭의 알림 페이지는 제거
- 로그인 새로고침 유지가 되도록 auth 상태를 sessionStorage로 복구
- 관리자 페이지 직접 진입 보호를 유지
- 챗봇/인기글/캘린더/요청 카드 등 주요 화면 문구와 노출 범위 정리

https://www.notion.so/teamsparta/3612dc3ef51480b88accfc81a94da597?source=copy_link#3632dc3ef51480b6b16bd594cd52569c

## Details
### Community
- 게시글 목록에 `조회: 전체 / 내 글` 필터 추가
- `내 글` 선택 시 `X-User-Id`가 붙은 백엔드 조회를 사용하도록 연결
- `/my` 페이지에서 `쓴 글 보기` 버튼으로 `커뮤니티 > 내 글`로 바로 이동 가능

### My Page
- `/my`는 관리자도 직접 접근 가능
- 헤더의 `MY` 탭만 관리자/매니저에게 숨김
- 마이페이지에는 `내가 쓴 글` 카드와 이동 버튼 유지

### Notifications
- `관리 > 알림` 탭 제거
- 알림 조회는 종모양 벨 패널에서만 제공
- 각 알림에 삭제 버튼 유지
- 페이지당 5개 단위로 조회/페이지 이동 가능
- 패널 크기는 유지하고 내부 스크롤만 사용

### Auth
- 로그인 후 새로고침해도 유지되도록 `authStore`를 sessionStorage에 연결
- 로그아웃 시 저장값 삭제
- 자동로그인 체크박스는 추가하지 않음

### Access Control
- `/admin` 직접 진입은 권한 없는 사용자 차단
- 로그인하지 않은 사용자는 `/login`
- 관리자/매니저는 `MY` 탭은 안 보이지만 `/my` 직접 접근은 가능

### UI / UX
- 로그인 화면 기본값 제거, placeholder 안내로 변경
- 인기글은 `24시간 내 인기글` 기준으로 노출
- 다가오는 행사는 startAt 기준 D-7만 노출
- 이벤트 상세 채팅 입력은 Enter 전송 지원
- 챗봇은 유지하되, 기존 흐름을 크게 건드리지 않음



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 게시글 조회에 "내 글" 범위 필터 추가
  * 채팅 입력창에서 Enter로 메시지 전송 지원

* **개선 사항**
  * 알림 목록을 페이지 네비게이션으로 전환 및 배지 UI 간소화
  * 헤더 네비게이션을 사용자 역할에 따라 더 정교하게 표시
  * 관리자 경로 접근을 권한 기반으로 보호
  * 홈 인기글 기준을 최근 24시간 기준으로 업데이트
  * 채팅 위젯의 로컬 저장 키를 로그인 상태에 따라 안전하게 이전/동기화
  * 로그인 폼에 입력 안내문구 추가
  * 마이페이지에서 내 글 바로보기 링크 추가

* **제거됨**
  * 관리자 페이지의 알림 탭 및 관련 기능 제거

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/55josama/festie/pull/286?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->