### PR TITLE
[FIX] 신고 2회 시 블라인드 처리되는 문제 해결

### DIFF
--- a/operation-service/src/main/java/com/ojosama/report/application/service/ReportService.java
+++ b/operation-service/src/main/java/com/ojosama/report/application/service/ReportService.java
@@ -59,9 +59,11 @@ public class ReportService {
         try {
             validateDuplicateReport(command.reporterId(), command.targetId());
 
+            long reportCountBefore = reportRepository.countByTargetId(command.targetId());
+
             Report savedReport = saveReportSafely(command.toEntity(reporterType));
 
-            checkAndProcessAutomaticBlind(command, savedReport);
+            checkAndProcessAutomaticBlind(command, savedReport, reportCountBefore);
 
             return ReportInfoResult.from(savedReport);
 
@@ -186,9 +188,7 @@ public class ReportService {
 
     // ============= 블라인드 처리 관련 메서드 =============
 
-    private void checkAndProcessAutomaticBlind(CreateReportCommand command, Report report) {
-        long reportCountBefore = reportRepository.countByTargetId(command.targetId());
-
+    private void checkAndProcessAutomaticBlind(CreateReportCommand command, Report report, long reportCountBefore) {
         long reportCountAfter = reportCountBefore + 1;
 
         if (reportCountAfter >= 3 && reportCountBefore < 3) {


### PR DESCRIPTION
## 🔗 Issue Number
- close #287 

## 📝 작업 내역

- saveReportSafely() 호출 후 countByTargetId() 실행해서, 이미 저장된 신고를 포함해서 카운트 됨.
- 그 결과 reportCountAfter = reportCountBefore + 1로 인해 실제로는 +2가 됨
- 신고 저장 전에 현재 개수를 조회하도록 변경

## 💡 PR 특이사항

- 이제 잘 될겁니다!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 신고 누적 카운트 처리 로직을 개선하여 자동 블라인드 처리의 정확성 및 안정성을 강화했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/55josama/festie/pull/288?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->