### PR TITLE
[FEATURE/TEST] community 성능 개선 및 테스트

### DIFF
--- a/community-service/build.gradle
+++ b/community-service/build.gradle
@@ -19,6 +19,11 @@ dependencies {
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.16'
     implementation 'org.springframework.boot:spring-boot-starter-security'
 
+    // Redis (viewCount Write-Behind 캐시용)
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    // Lettuce connection pool 활성화 필수 (application.yml 의 lettuce.pool 설정이 이 의존성 없으면 무시됨)
+    implementation 'org.apache.commons:commons-pool2'
+
     implementation project(':common')
 }
 

--- a/community-service/src/main/java/com/ojosama/category/presentation/controller/CategoryController.java
+++ b/community-service/src/main/java/com/ojosama/category/presentation/controller/CategoryController.java
@@ -9,6 +9,8 @@ import com.ojosama.category.presentation.dto.request.CreateCategoryRequest;
 import com.ojosama.category.presentation.dto.request.UpdateCategoryRequest;
 import com.ojosama.category.presentation.dto.response.CategoryResponse;
 import com.ojosama.common.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -28,6 +30,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "커뮤니티 카테고리", description = "커뮤니티 카테고리 관리 API (관리자 전용)")
 @RestController
 @RequestMapping("/v1/community-categories")
 @RequiredArgsConstructor
@@ -35,6 +38,7 @@ public class CategoryController {
 
     private final CategoryService categoryService;
 
+    @Operation(summary = "카테고리 생성", description = "새 커뮤니티 카테고리를 생성합니다. 관리자만 가능합니다.")
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     @PreAuthorize("hasRole('ADMIN')")
@@ -45,6 +49,7 @@ public class CategoryController {
         return ApiResponse.created(CategoryResponse.from(result));
     }
 
+    @Operation(summary = "카테고리 수정", description = "카테고리 이름을 수정합니다. 관리자만 가능합니다.")
     @PatchMapping("/{categoryId}")
     @PreAuthorize("hasRole('ADMIN')")
     public ApiResponse<CategoryResponse> update(
@@ -55,6 +60,7 @@ public class CategoryController {
         return ApiResponse.success(CategoryResponse.from(result));
     }
 
+    @Operation(summary = "카테고리 삭제", description = "카테고리를 삭제합니다. 관리자만 가능합니다.")
     @DeleteMapping("/{categoryId}")
     @PreAuthorize("hasRole('ADMIN')")
     public ApiResponse<Void> delete(
@@ -64,13 +70,14 @@ public class CategoryController {
         return ApiResponse.deleted();
     }
 
-    // GET 은 SecurityConfig 에서 permitAll
+    @Operation(summary = "카테고리 상세 조회", description = "카테고리 상세 정보를 조회합니다. 비로그인도 가능합니다.")
     @GetMapping("/{categoryId}")
     public ApiResponse<CategoryResponse> getDetail(@PathVariable UUID categoryId) {
         CategoryResult result = categoryService.getDetail(categoryId);
         return ApiResponse.success(CategoryResponse.from(result));
     }
 
+    @Operation(summary = "카테고리 목록 조회", description = "전체 커뮤니티 카테고리 목록을 조회합니다. 비로그인도 가능합니다.")
     @GetMapping
     public ApiResponse<Page<CategoryResponse>> list(
             @PageableDefault(size = 20, sort = "createdAt") Pageable pageable) {

--- a/community-service/src/main/java/com/ojosama/category/presentation/controller/CategoryController.java
+++ b/community-service/src/main/java/com/ojosama/category/presentation/controller/CategoryController.java
@@ -16,13 +16,14 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
@@ -32,13 +33,11 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class CategoryController {
 
-    private static final String USER_ID_HEADER = "X-User-Id";
-
     private final CategoryService categoryService;
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    //@PreAuthorize("hasRole('ADMIN')")
+    @PreAuthorize("hasRole('ADMIN')")
     public ApiResponse<CategoryResponse> create(
             @Valid @RequestBody CreateCategoryRequest req) {
         CategoryResult result = categoryService.create(
@@ -47,7 +46,7 @@ public class CategoryController {
     }
 
     @PatchMapping("/{categoryId}")
-    //@PreAuthorize("hasRole('ADMIN')")
+    @PreAuthorize("hasRole('ADMIN')")
     public ApiResponse<CategoryResponse> update(
             @PathVariable UUID categoryId,
             @Valid @RequestBody UpdateCategoryRequest req) {
@@ -57,27 +56,25 @@ public class CategoryController {
     }
 
     @DeleteMapping("/{categoryId}")
-    //@PreAuthorize("hasRole('ADMIN')")
+    @PreAuthorize("hasRole('ADMIN')")
     public ApiResponse<Void> delete(
             @PathVariable UUID categoryId,
-            @RequestHeader(USER_ID_HEADER) UUID userId) {
+            @AuthenticationPrincipal UUID userId) {
         categoryService.delete(new DeleteCategoryCommand(categoryId, userId));
         return ApiResponse.deleted();
     }
 
+    // GET 은 SecurityConfig 에서 permitAll
     @GetMapping("/{categoryId}")
-    //@PreAuthorize("hasRole('ADMIN')")
     public ApiResponse<CategoryResponse> getDetail(@PathVariable UUID categoryId) {
         CategoryResult result = categoryService.getDetail(categoryId);
         return ApiResponse.success(CategoryResponse.from(result));
     }
 
     @GetMapping
-    //@PreAuthorize("hasRole('ADMIN')")
     public ApiResponse<Page<CategoryResponse>> list(
             @PageableDefault(size = 20, sort = "createdAt") Pageable pageable) {
         Page<CategoryResult> page = categoryService.list(pageable);
         return ApiResponse.success(page.map(CategoryResponse::from));
     }
-
 }

--- a/community-service/src/main/java/com/ojosama/comment/presentation/controller/CommentController.java
+++ b/community-service/src/main/java/com/ojosama/comment/presentation/controller/CommentController.java
@@ -11,6 +11,8 @@ import com.ojosama.comment.presentation.dto.request.CreateCommentRequest;
 import com.ojosama.comment.presentation.dto.request.UpdateCommentRequest;
 import com.ojosama.comment.presentation.dto.response.CommentResponse;
 import com.ojosama.common.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -30,6 +32,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "댓글", description = "댓글 CRUD 및 좋아요 API")
 @RestController
 @RequiredArgsConstructor
 public class CommentController {
@@ -37,6 +40,7 @@ public class CommentController {
     private final CommentService commentService;
     private final CommentLikeService commentLikeService;
 
+    @Operation(summary = "댓글 작성", description = "게시글에 댓글을 작성합니다. parentId 를 전달하면 대댓글로 등록됩니다.")
     @PostMapping("/v1/posts/{postId}/comments")
     @ResponseStatus(HttpStatus.CREATED)
     @PreAuthorize("hasAnyRole('USER', 'ADMIN')")
@@ -49,6 +53,7 @@ public class CommentController {
         return ApiResponse.created(CommentResponse.from(result));
     }
 
+    @Operation(summary = "댓글 수정", description = "본인이 작성한 댓글 내용을 수정합니다.")
     @PatchMapping("/v1/comments/{commentId}")
     @PreAuthorize("hasAnyRole('USER', 'ADMIN')")
     public ApiResponse<CommentResponse> update(
@@ -60,6 +65,7 @@ public class CommentController {
         return ApiResponse.success(CommentResponse.from(result));
     }
 
+    @Operation(summary = "댓글 삭제", description = "본인이 작성한 댓글을 삭제합니다. 관리자는 모든 댓글 삭제 가능합니다.")
     @DeleteMapping("/v1/comments/{commentId}")
     @PreAuthorize("hasAnyRole('USER', 'ADMIN')")
     public ApiResponse<Void> delete(
@@ -72,7 +78,7 @@ public class CommentController {
         return ApiResponse.deleted();
     }
 
-    // GET 은 SecurityConfig 에서 permitAll
+    @Operation(summary = "댓글 목록 조회", description = "게시글에 달린 댓글 목록을 조회합니다. 비로그인도 가능합니다.")
     @GetMapping("/v1/posts/{postId}/comments")
     public ApiResponse<Page<CommentResponse>> list(
             @PathVariable UUID postId,
@@ -82,6 +88,7 @@ public class CommentController {
         return ApiResponse.success(page.map(CommentResponse::from));
     }
 
+    @Operation(summary = "댓글 좋아요", description = "댓글에 좋아요를 누릅니다. 중복 좋아요는 불가합니다.")
     @PostMapping("/v1/comments/{commentId}/likes")
     @PreAuthorize("hasAnyRole('USER', 'ADMIN')")
     public ApiResponse<Integer> like(
@@ -91,6 +98,7 @@ public class CommentController {
         return ApiResponse.success(likeCount);
     }
 
+    @Operation(summary = "댓글 좋아요 취소", description = "댓글 좋아요를 취소합니다.")
     @DeleteMapping("/v1/comments/{commentId}/likes")
     @PreAuthorize("hasAnyRole('USER', 'ADMIN')")
     public ApiResponse<Integer> unlike(

--- a/community-service/src/main/java/com/ojosama/comment/presentation/controller/CommentController.java
+++ b/community-service/src/main/java/com/ojosama/comment/presentation/controller/CommentController.java
@@ -18,57 +18,61 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
 public class CommentController {
+
     private final CommentService commentService;
     private final CommentLikeService commentLikeService;
 
-    private static final String USER_ID_HEADER = "X-User-Id";
-    private static final String USER_ROLE_HEADER = "X-User-Role";
-
     @PostMapping("/v1/posts/{postId}/comments")
     @ResponseStatus(HttpStatus.CREATED)
+    @PreAuthorize("hasAnyRole('USER', 'ADMIN')")
     public ApiResponse<CommentResponse> create(
             @PathVariable UUID postId,
             @Valid @RequestBody CreateCommentRequest req,
-            @RequestHeader(USER_ID_HEADER) UUID userId) {
+            @AuthenticationPrincipal UUID userId) {
         CommentResult result = commentService.create(new CreateCommentCommand(
-                postId, userId, req.parentId(), req.content())); //인증인가 구현되면 수정
+                postId, userId, req.parentId(), req.content()));
         return ApiResponse.created(CommentResponse.from(result));
     }
 
     @PatchMapping("/v1/comments/{commentId}")
+    @PreAuthorize("hasAnyRole('USER', 'ADMIN')")
     public ApiResponse<CommentResponse> update(
             @PathVariable UUID commentId,
             @Valid @RequestBody UpdateCommentRequest req,
-            @RequestHeader(USER_ID_HEADER) UUID userId) {
+            @AuthenticationPrincipal UUID userId) {
         CommentResult result = commentService.update(new UpdateCommentCommand(
                 commentId, userId, req.content()));
         return ApiResponse.success(CommentResponse.from(result));
     }
 
     @DeleteMapping("/v1/comments/{commentId}")
+    @PreAuthorize("hasAnyRole('USER', 'ADMIN')")
     public ApiResponse<Void> delete(
             @PathVariable UUID commentId,
-            @RequestHeader(USER_ID_HEADER) UUID userId,
-            @RequestHeader(USER_ROLE_HEADER) String role) {
-        boolean isAdmin = "ADMIN".equals(role);
-        commentService.delete(new DeleteCommentCommand(
-                commentId, userId, isAdmin));
+            @AuthenticationPrincipal UUID userId,
+            Authentication authentication) {
+        boolean isAdmin = authentication.getAuthorities().stream()
+                .anyMatch(a -> a.getAuthority().equals("ROLE_ADMIN"));
+        commentService.delete(new DeleteCommentCommand(commentId, userId, isAdmin));
         return ApiResponse.deleted();
     }
 
+    // GET 은 SecurityConfig 에서 permitAll
     @GetMapping("/v1/posts/{postId}/comments")
     public ApiResponse<Page<CommentResponse>> list(
             @PathVariable UUID postId,
@@ -78,19 +82,20 @@ public class CommentController {
         return ApiResponse.success(page.map(CommentResponse::from));
     }
 
-    //애그리거트
     @PostMapping("/v1/comments/{commentId}/likes")
+    @PreAuthorize("hasAnyRole('USER', 'ADMIN')")
     public ApiResponse<Integer> like(
             @PathVariable UUID commentId,
-            @RequestHeader(USER_ID_HEADER) UUID userId) {
-        int likeCount = commentLikeService.like(commentId,userId);
+            @AuthenticationPrincipal UUID userId) {
+        int likeCount = commentLikeService.like(commentId, userId);
         return ApiResponse.success(likeCount);
     }
 
     @DeleteMapping("/v1/comments/{commentId}/likes")
+    @PreAuthorize("hasAnyRole('USER', 'ADMIN')")
     public ApiResponse<Integer> unlike(
             @PathVariable UUID commentId,
-            @RequestHeader(USER_ID_HEADER) UUID userId) {
+            @AuthenticationPrincipal UUID userId) {
         int likeCount = commentLikeService.unlike(commentId, userId);
         return ApiResponse.success(likeCount);
     }

--- a/community-service/src/main/java/com/ojosama/community/infrastructure/config/SecurityConfig.java
+++ b/community-service/src/main/java/com/ojosama/community/infrastructure/config/SecurityConfig.java
@@ -1,18 +1,48 @@
 package com.ojosama.community.infrastructure.config;
 
+import com.ojosama.community.infrastructure.config.filter.HeaderAuthenticationFilter;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity          // @PreAuthorize 활성화
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final HeaderAuthenticationFilter headerAuthenticationFilter;
+
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-        http.csrf(csrf -> csrf.disable())
-                .authorizeHttpRequests(auth -> auth.anyRequest().permitAll());
+        http
+                .csrf(csrf -> csrf.disable())
+                .authorizeHttpRequests(auth -> auth
+                        // Swagger / Actuator
+                        .requestMatchers(
+                                "/swagger-ui/**",
+                                "/v3/api-docs/**",
+                                "/swagger-ui.html",
+                                "/swagger-resources/**",
+                                "/webjars/**",
+                                "/actuator/**"
+                        ).permitAll()
+                        // 게시글·댓글·카테고리 조회는 비로그인도 허용
+                        .requestMatchers(HttpMethod.GET,
+                                "/v1/posts/**",
+                                "/v1/community-categories/**"
+                        ).permitAll()
+                        // 나머지 모든 요청은 인증 필요
+                        .anyRequest().authenticated()
+                )
+                .addFilterBefore(headerAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+
         return http.build();
     }
 }

--- a/community-service/src/main/java/com/ojosama/community/infrastructure/config/filter/HeaderAuthenticationFilter.java
+++ b/community-service/src/main/java/com/ojosama/community/infrastructure/config/filter/HeaderAuthenticationFilter.java
@@ -1,0 +1,66 @@
+package com.ojosama.community.infrastructure.config.filter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.List;
+import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+/**
+ * Gateway 가 내려주는 X-User-Id / X-User-Role 헤더를 읽어 SecurityContext 에 등록.
+ * JWT 검증은 Gateway 에서 완료됐으므로 여기서는 헤더 신뢰 후 인증 객체만 생성한다.
+ */
+@Slf4j
+@Component
+public class HeaderAuthenticationFilter extends OncePerRequestFilter {
+
+    private static final String USER_ID_HEADER = "X-User-Id";
+    private static final String USER_ROLE_HEADER = "X-User-Role";
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+
+        String userId = request.getHeader(USER_ID_HEADER);
+        String role   = request.getHeader(USER_ROLE_HEADER);
+
+        if (userId != null && !userId.isBlank() && role != null && !role.isBlank()) {
+            try {
+                UUID userIdUuid = UUID.fromString(userId.trim());
+
+                // "ROLE_" 접두사 중복 방지
+                String normalizedRole = role.trim().toUpperCase();
+                if (normalizedRole.startsWith("ROLE_")) {
+                    normalizedRole = normalizedRole.substring(5);
+                }
+
+                UsernamePasswordAuthenticationToken authentication =
+                        new UsernamePasswordAuthenticationToken(
+                                userIdUuid,
+                                null,
+                                List.of(new SimpleGrantedAuthority("ROLE_" + normalizedRole))
+                        );
+
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            } catch (IllegalArgumentException e) {
+                log.warn("[HeaderAuthFilter] 잘못된 X-User-Id 형식: {}", userId);
+                SecurityContextHolder.clearContext();
+                response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Invalid authentication headers");
+                return;
+            }
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/community-service/src/main/java/com/ojosama/post/application/service/PostService.java
+++ b/community-service/src/main/java/com/ojosama/post/application/service/PostService.java
@@ -17,6 +17,8 @@ import com.ojosama.post.domain.exception.PostException;
 import com.ojosama.post.domain.model.Post;
 import com.ojosama.post.domain.model.PostStatus;
 import com.ojosama.post.domain.repository.PostRepository;
+import com.ojosama.post.infrastructure.cache.PostViewCountExecutor;
+import com.ojosama.post.infrastructure.cache.ViewCountCacheService;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -32,6 +34,8 @@ public class PostService {
 
     private final PostRepository postRepository;
     private final OutboxEventPublisher outbox;
+    private final ViewCountCacheService viewCountCache;
+    private final PostViewCountExecutor postViewCountExecutor;
 
     @Value("${spring.kafka.topic.community-moderation-requested}")
     private String moderationRequestedTopic;
@@ -101,18 +105,24 @@ public class PostService {
         );
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public PostResult getDetail(UUID postId) {
         Post post = loadAlive(postId);
-        // BLINDED 게시글도 200으로 응답한다 (PostResponse에서 마스킹 처리).
-        // 단, 조회수는 증가시키지 않음 — 차단된 게시글에 어뷰징성 조회수 발생 방지.
+        // BLINDED 게시글도 200으로 응답한다 (PostResponse 에서 마스킹 처리).
+        // 블라인드 상태에서는 조회수를 올리지 않음.
         if (post.isBlinded()) {
             return PostResult.from(post);
         }
-        int affected = postRepository.incrementViewCount(postId);
-        if (affected == 0) {
-            throw new PostException(PostErrorCode.POST_NOT_FOUND);
+
+        // Write-Behind: Redis INCR 만 하고 DB flush 는 스케줄러가 일괄 처리.
+        // Redis 장애 시 fallback 으로 DB 직접 UPDATE.
+        // class-level readOnly 트랜잭션 안에서 UPDATE 하면 JPA 예외가 발생할 수 있어
+        // REQUIRES_NEW 로 분리된 executor 에 위임한다.
+        boolean cached = viewCountCache.increment(postId);
+        if (!cached) {
+            postViewCountExecutor.incrementViewCountFallback(postId);
         }
+
         return adjustViewCountForResponse(post, 1);
     }
 

--- a/community-service/src/main/java/com/ojosama/post/application/service/PostService.java
+++ b/community-service/src/main/java/com/ojosama/post/application/service/PostService.java
@@ -17,7 +17,6 @@ import com.ojosama.post.domain.exception.PostException;
 import com.ojosama.post.domain.model.Post;
 import com.ojosama.post.domain.model.PostStatus;
 import com.ojosama.post.domain.repository.PostRepository;
-import com.ojosama.post.infrastructure.cache.PostViewCountExecutor;
 import com.ojosama.post.infrastructure.cache.ViewCountCacheService;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -35,7 +34,6 @@ public class PostService {
     private final PostRepository postRepository;
     private final OutboxEventPublisher outbox;
     private final ViewCountCacheService viewCountCache;
-    private final PostViewCountExecutor postViewCountExecutor;
 
     @Value("${spring.kafka.topic.community-moderation-requested}")
     private String moderationRequestedTopic;
@@ -115,13 +113,13 @@ public class PostService {
         }
 
         // Write-Behind: Redis INCR 만 하고 DB flush 는 스케줄러가 일괄 처리.
-        // Redis 장애 시 fallback 으로 DB 직접 UPDATE.
-        // class-level readOnly 트랜잭션 안에서 UPDATE 하면 JPA 예외가 발생할 수 있어
-        // REQUIRES_NEW 로 분리된 executor 에 위임한다.
-        boolean cached = viewCountCache.increment(postId);
-        if (!cached) {
-            postViewCountExecutor.incrementViewCountFallback(postId);
-        }
+        // fallback(DB 직접 UPDATE)을 제거한 이유:
+        //   executePipelined() 예외는 INCR 명령이 서버에서 실행된 후 응답 수신에 실패한
+        //   경우(timeout 등)를 구분할 수 없다. 이 상태에서 fallback 을 실행하면
+        //   Redis 캐시 + DB 에 각각 +1 되어 동일 조회에 +2가 적용되는 이중 카운트가 발생한다.
+        //   조회수는 eventually consistent 가 허용되는 데이터이므로 Redis 장애 시
+        //   해당 요청의 카운트를 놓치더라도 서비스 정합성에 영향이 없다고 판단하여 일시적 허용으로.
+        viewCountCache.increment(postId);
 
         return adjustViewCountForResponse(post, 1);
     }

--- a/community-service/src/main/java/com/ojosama/post/domain/model/Post.java
+++ b/community-service/src/main/java/com/ojosama/post/domain/model/Post.java
@@ -23,9 +23,12 @@ import lombok.NoArgsConstructor;
 @Table(
         name = "p_post",
         indexes = {
-                @Index(name = "idx_post_user", columnList = "user_id"),
-                @Index(name = "idx_post_category", columnList = "category_id"),
-                @Index(name = "idx_post_status_created", columnList = "status, created_at")
+                // 전체 목록: WHERE deleted_at IS NULL AND status <> ? ORDER BY created_at
+                @Index(name = "idx_post_deleted_created",          columnList = "deleted_at, created_at"),
+                // 유저별 목록: WHERE user_id = ? AND deleted_at IS NULL ORDER BY created_at
+                @Index(name = "idx_post_user_deleted_created",     columnList = "user_id, deleted_at, created_at"),
+                // 카테고리별 목록: WHERE category_id = ? AND deleted_at IS NULL ORDER BY created_at
+                @Index(name = "idx_post_category_deleted_created", columnList = "category_id, deleted_at, created_at")
         }
 )
 @Getter

--- a/community-service/src/main/java/com/ojosama/post/domain/repository/PostRepository.java
+++ b/community-service/src/main/java/com/ojosama/post/domain/repository/PostRepository.java
@@ -13,18 +13,22 @@ import org.springframework.data.repository.query.Param;
 
 public interface PostRepository extends JpaRepository<Post, UUID> {
 
-    //조회수 증가. MVP는 매 조회마다 호출
-    //추후 Redis INCR + 주기 flush로 마이그레이션 예정
+    //조회수 증가. MVP는 매 조회마다 호출 (Redis 캐시 fallback 용으로 유지)
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("UPDATE Post p SET p.viewCount = p.viewCount + 1 WHERE p.id = :id")
     int incrementViewCount(@Param("id") UUID id);
 
+    /**
+     * 조회수를 N 만큼 한 번에 증가 (Redis flush 용).
+     * 동일 row 에 100번 조회됐다면 UPDATE 1번으로 처리 → row lock 점유 시간 폭감.
+     */
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("UPDATE Post p SET p.viewCount = p.viewCount + :delta WHERE p.id = :id")
+    int incrementViewCountBy(@Param("id") UUID id, @Param("delta") long delta);
+
     /** 특정 유저가 쓴 게시글 (소프트 삭제/BLOCKED 제외). */
     Page<Post> findByUserIdAndDeletedAtIsNullAndStatusNot(
             UUID userId, PostStatus excludedStatus, Pageable pageable);
-//    @Query("SELECT p FROM Post p WHERE p.userId = :userId " +
-//            "AND p.deletedAt IS NULL AND p.status != 'BLOCKED'")
-//    Page<Post> findActivePostsByUserId(UUID userId, Pageable pageable);
 
     /** 카테고리별 게시글 (소프트 삭제/BLOCKED 제외). */
     Page<Post> findByCategoryIdAndDeletedAtIsNullAndStatusNot(
@@ -34,19 +38,14 @@ public interface PostRepository extends JpaRepository<Post, UUID> {
     Page<Post> findByDeletedAtIsNullAndStatusNot(
             PostStatus excludedStatus, Pageable pageable);
 
-    /**
-     * 좋아요 수 증가. PostLike INSERT 성공 시 함께 호출.
-     * 동시 요청에도 DB가 원자적으로 처리하므로 충돌하지 않는다.
-     */
+//    좋아요 수 증가. PostLike INSERT 성공 시 함께 호출.
+//    동시 요청에도 DB가 원자적으로 처리하므로 충돌하지 않는다.
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("UPDATE Post p SET p.likeCount = p.likeCount + 1 WHERE p.id = :id")
     int incrementLikeCount(@Param("id") UUID id);
 
-    /**
-     * 좋아요 수 감소. WHERE 조건에 {@code likeCount > 0}을 포함하여 음수 방지.
-     *
-     * @return 영향받은 행 수. 0이면 likeCount가 이미 0이거나 게시글이 없는 상태.
-     */
+//    좋아요 수 감소. WHERE 조건에 {@code likeCount > 0}을 포함하여 음수 방지.
+//     @return 영향받은 행 수. 0이면 likeCount가 이미 0이거나 게시글이 없는 상태.
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("UPDATE Post p SET p.likeCount = p.likeCount - 1 WHERE p.id = :id AND p.likeCount > 0")
     int decrementLikeCount(@Param("id") UUID id);

--- a/community-service/src/main/java/com/ojosama/post/domain/repository/PostRepository.java
+++ b/community-service/src/main/java/com/ojosama/post/domain/repository/PostRepository.java
@@ -18,23 +18,17 @@ public interface PostRepository extends JpaRepository<Post, UUID> {
     @Query("UPDATE Post p SET p.viewCount = p.viewCount + 1 WHERE p.id = :id")
     int incrementViewCount(@Param("id") UUID id);
 
-    /**
-     * 조회수를 N 만큼 한 번에 증가 (Redis flush 용).
-     * 동일 row 에 100번 조회됐다면 UPDATE 1번으로 처리 → row lock 점유 시간 폭감.
-     */
+//    조회수를 N 만큼 한 번에 증가 (Redis flush 용). 동일 row 에 100번 조회됐다면 UPDATE 1번으로 처리 → row lock 점유 시간 폭감.
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("UPDATE Post p SET p.viewCount = p.viewCount + :delta WHERE p.id = :id")
     int incrementViewCountBy(@Param("id") UUID id, @Param("delta") long delta);
 
-    /** 특정 유저가 쓴 게시글 (소프트 삭제/BLOCKED 제외). */
     Page<Post> findByUserIdAndDeletedAtIsNullAndStatusNot(
             UUID userId, PostStatus excludedStatus, Pageable pageable);
 
-    /** 카테고리별 게시글 (소프트 삭제/BLOCKED 제외). */
     Page<Post> findByCategoryIdAndDeletedAtIsNullAndStatusNot(
             UUID categoryId, PostStatus excludedStatus, Pageable pageable);
 
-    /** 전체 목록 (소프트 삭제/BLOCKED 제외). */
     Page<Post> findByDeletedAtIsNullAndStatusNot(
             PostStatus excludedStatus, Pageable pageable);
 

--- a/community-service/src/main/java/com/ojosama/post/infrastructure/cache/PostViewCountExecutor.java
+++ b/community-service/src/main/java/com/ojosama/post/infrastructure/cache/PostViewCountExecutor.java
@@ -1,0 +1,49 @@
+package com.ojosama.post.infrastructure.cache;
+
+import com.ojosama.post.domain.exception.PostErrorCode;
+import com.ojosama.post.domain.exception.PostException;
+import com.ojosama.post.domain.repository.PostRepository;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 조회수 DB 쓰기를 REQUIRES_NEW 트랜잭션으로 분리.
+ *
+ * Spring AOP self-invocation 문제로 인해 Scheduler/Service 내부 메서드로 분리해도
+ * REQUIRES_NEW 가 적용되지 않아 별도 빈으로 추출했다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PostViewCountExecutor {
+
+    private final PostRepository postRepository;
+
+    /**
+     * @return true: UPDATE 성공 / false: affected=0 (글 삭제 등, 재시도 불필요)
+     * @throws Exception DB 장애 — 호출부에서 dirty 유지 후 다음 주기 재시도
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public boolean flushOne(UUID postId, long delta) {
+        int affected = postRepository.incrementViewCountBy(postId, delta);
+        if (affected == 0) {
+            log.warn("[ViewCountExecutor] UPDATE affected=0 postId={}, delta={}", postId, delta);
+            return false;
+        }
+        return true;
+    }
+
+    // PostService 는 class-level readOnly 트랜잭션이라 직접 UPDATE 불가.
+    // REQUIRES_NEW 로 별도 쓰기 트랜잭션을 열어 fallback 처리.
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void incrementViewCountFallback(UUID postId) {
+        int affected = postRepository.incrementViewCount(postId);
+        if (affected == 0) {
+            throw new PostException(PostErrorCode.POST_NOT_FOUND);
+        }
+    }
+}

--- a/community-service/src/main/java/com/ojosama/post/infrastructure/cache/PostViewCountExecutor.java
+++ b/community-service/src/main/java/com/ojosama/post/infrastructure/cache/PostViewCountExecutor.java
@@ -1,7 +1,5 @@
 package com.ojosama.post.infrastructure.cache;
 
-import com.ojosama.post.domain.exception.PostErrorCode;
-import com.ojosama.post.domain.exception.PostException;
 import com.ojosama.post.domain.repository.PostRepository;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -37,13 +35,4 @@ public class PostViewCountExecutor {
         return true;
     }
 
-    // PostService 는 class-level readOnly 트랜잭션이라 직접 UPDATE 불가.
-    // REQUIRES_NEW 로 별도 쓰기 트랜잭션을 열어 fallback 처리.
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void incrementViewCountFallback(UUID postId) {
-        int affected = postRepository.incrementViewCount(postId);
-        if (affected == 0) {
-            throw new PostException(PostErrorCode.POST_NOT_FOUND);
-        }
-    }
 }

--- a/community-service/src/main/java/com/ojosama/post/infrastructure/cache/ViewCountCacheService.java
+++ b/community-service/src/main/java/com/ojosama/post/infrastructure/cache/ViewCountCacheService.java
@@ -90,17 +90,13 @@ public class ViewCountCacheService {
         try {
             String value = redis.opsForValue().get(viewKey(postId));
             return value != null ? Long.parseLong(value) : 0L;
-public long peek(UUID postId) {
-    try {
-        String value = redis.opsForValue().get(viewKey(postId));
-        return value != null ? Long.parseLong(value) : 0L;
-    } catch (NumberFormatException e) {
-        log.warn("[ViewCountCache] Redis 값 파싱 실패 postId={}", postId);
-        return 0L;
-    } catch (Exception e) {
-        throw new IllegalStateException("peek failed for postId=" + postId, e);
-    }
-}
+        } catch (NumberFormatException e) {
+            log.warn("[ViewCountCache] Redis 값 파싱 실패 postId={}", postId);
+            return 0L;
+        } catch (Exception e) {
+            log.error("[ViewCountCache] peek 실패 postId={}: {}", postId, e.getMessage());
+            return 0L;
+        }
     }
 
     /**

--- a/community-service/src/main/java/com/ojosama/post/infrastructure/cache/ViewCountCacheService.java
+++ b/community-service/src/main/java/com/ojosama/post/infrastructure/cache/ViewCountCacheService.java
@@ -54,13 +54,17 @@ public class ViewCountCacheService {
         try {
             String value = redis.opsForValue().get(viewKey(postId));
             return value != null ? Long.parseLong(value) : 0L;
-        } catch (NumberFormatException e) {
-            log.warn("[ViewCountCache] Redis 값 파싱 실패 postId={}", postId);
-            return 0L;
-        } catch (Exception e) {
-            log.error("[ViewCountCache] peek 실패 postId={}: {}", postId, e.getMessage());
-            return 0L;
-        }
+public long peek(UUID postId) {
+    try {
+        String value = redis.opsForValue().get(viewKey(postId));
+        return value != null ? Long.parseLong(value) : 0L;
+    } catch (NumberFormatException e) {
+        log.warn("[ViewCountCache] Redis 값 파싱 실패 postId={}", postId);
+        return 0L;
+    } catch (Exception e) {
+        throw new IllegalStateException("peek failed for postId=" + postId, e);
+    }
+}
     }
 
     // DB UPDATE 성공 후 flush 한 만큼만 DECRBY.

--- a/community-service/src/main/java/com/ojosama/post/infrastructure/cache/ViewCountCacheService.java
+++ b/community-service/src/main/java/com/ojosama/post/infrastructure/cache/ViewCountCacheService.java
@@ -1,5 +1,6 @@
 package com.ojosama.post.infrastructure.cache;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
@@ -17,11 +18,19 @@ import org.springframework.stereotype.Component;
 public class ViewCountCacheService {
 
     private static final String VIEW_KEY_PREFIX = "post:views:";
-    private static final String DIRTY_SET_KEY   = "post:views:dirty";
+    private static final String DIRTY_SET_KEY = "post:views:dirty";
 
+    /**
+     * DECRBY + 조건부 SADD 를 원자적으로 실행하는 Lua 스크립트.
+     *
+     * SPOP 으로 dirty set 에서 이미 제거된 상태이므로 SREM 은 불필요.
+     * DECRBY 후 remaining > 0 이면 flush 중 새 INCR 가 들어온 것 → dirty set 에 재등록.
+     *
+     * KEYS[1] = viewKey(postId), KEYS[2] = DIRTY_SET_KEY
+     * ARGV[1] = flushed, ARGV[2] = postId string
+     */
     private static final RedisScript<Long> RESET_BY_LUA = RedisScript.of(
         "local remaining = redis.call('DECRBY', KEYS[1], ARGV[1])\n" +
-        "redis.call('SREM', KEYS[2], ARGV[2])\n" +
         "if tonumber(remaining) > 0 then\n" +
         "    redis.call('SADD', KEYS[2], ARGV[2])\n" +
         "end\n" +
@@ -50,14 +59,29 @@ public class ViewCountCacheService {
         }
     }
 
-    // 스케줄러가 flush 대상 ID 목록을 가져갈 때 사용
-    public Set<String> getDirtyPostIds() {
+    /**
+     * dirty set 에서 최대 count 개를 원자적으로 SPOP.
+     *
+     * SMEMBERS(읽기만) 대신 SPOP(꺼내기)를 사용하므로 멀티 인스턴스 환경에서
+     * 동일 postId 를 두 인스턴스가 중복 처리하는 문제를 방지한다.
+     */
+    public Set<String> spopDirtyPostIds(int count) {
         try {
-            Set<String> ids = redis.opsForSet().members(DIRTY_SET_KEY);
-            return ids != null ? ids : Set.of();
+            // Spring Data Redis 3.x 에서 pop(key, count) 는 List<V> 반환
+            List<String> popped = redis.opsForSet().pop(DIRTY_SET_KEY, count);
+            return popped != null ? new HashSet<>(popped) : Set.of();
         } catch (Exception e) {
-            log.error("[ViewCountCache] dirty set 조회 실패: {}", e.getMessage());
+            log.error("[ViewCountCache] dirty set SPOP 실패: {}", e.getMessage());
             return Set.of();
+        }
+    }
+
+    // DB 장애 등으로 flush 실패 시 다음 주기에 재시도할 수 있도록 dirty set 에 재등록
+    public void requeue(UUID postId) {
+        try {
+            redis.opsForSet().add(DIRTY_SET_KEY, postId.toString());
+        } catch (Exception e) {
+            log.warn("[ViewCountCache] requeue 실패 postId={}", postId);
         }
     }
 
@@ -77,8 +101,8 @@ public class ViewCountCacheService {
 
     /**
      * DB UPDATE 성공 후 flush 한 만큼만 차감 — Lua 스크립트로 원자 처리.
-     * peek~resetBy 사이에 들어온 INCR 는 그대로 남아 다음 주기에 반영됨.
-     * ex) peek=5 → DB +5 → 그 사이 INCR 2번 → resetBy(5) → Redis 잔여=2
+     * SPOP 으로 이미 dirty set 에서 제거된 상태이므로 SREM 은 없음.
+     * remaining > 0 이면 flush 중 새 INCR 가 들어온 것 → 자동으로 dirty 재등록.
      */
     public void resetBy(UUID postId, long flushed) {
         if (flushed <= 0) return;
@@ -93,22 +117,12 @@ public class ViewCountCacheService {
         }
     }
 
-    // 글 삭제 등으로 재시도가 불필요한 경우 카운터 키와 dirty 항목 모두 제거
+    // 글 삭제 등으로 재시도가 불필요한 경우 카운터 키 제거 (dirty set 은 SPOP 으로 이미 제거됨)
     public void discard(UUID postId) {
         try {
             redis.delete(viewKey(postId));
-            redis.opsForSet().remove(DIRTY_SET_KEY, postId.toString());
         } catch (Exception e) {
             log.warn("[ViewCountCache] discard 실패 postId={}", postId);
-        }
-    }
-
-    // dirty set 에 잘못된 UUID 형식이 들어온 경우 제거 (무한 재시도 방지)
-    public void removeInvalidEntry(String rawId) {
-        try {
-            redis.opsForSet().remove(DIRTY_SET_KEY, rawId);
-        } catch (Exception e) {
-            log.warn("[ViewCountCache] removeInvalidEntry 실패 rawId={}", rawId);
         }
     }
 

--- a/community-service/src/main/java/com/ojosama/post/infrastructure/cache/ViewCountCacheService.java
+++ b/community-service/src/main/java/com/ojosama/post/infrastructure/cache/ViewCountCacheService.java
@@ -1,0 +1,104 @@
+package com.ojosama.post.infrastructure.cache;
+
+import java.util.Set;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.connection.StringRedisConnection;
+import org.springframework.data.redis.core.RedisCallback;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ViewCountCacheService {
+
+    private static final String VIEW_KEY_PREFIX = "post:views:";
+    private static final String DIRTY_SET_KEY = "post:views:dirty";
+
+    private final StringRedisTemplate redis;
+
+    // INCR + SADD 를 pipeline 으로 묶어 RTT 1번에 처리.
+    // SessionCallback 은 제네릭 시그니처 문제로 RedisCallback + StringRedisConnection 사용.
+    public boolean increment(UUID postId) {
+        try {
+            final String key = viewKey(postId);
+            final String postIdStr = postId.toString();
+            redis.executePipelined((RedisCallback<Object>) connection -> {
+                StringRedisConnection conn = (StringRedisConnection) connection;
+                conn.incr(key);
+                conn.sAdd(DIRTY_SET_KEY, postIdStr);
+                return null;
+            });
+            return true;
+        } catch (Exception e) {
+            log.warn("[ViewCountCache] Redis INCR 실패 postId={} : {}", postId, e.getMessage());
+            return false;
+        }
+    }
+
+    // 스케줄러가 flush 대상 ID 목록을 가져갈 때 사용
+    public Set<String> getDirtyPostIds() {
+        try {
+            Set<String> ids = redis.opsForSet().members(DIRTY_SET_KEY);
+            return ids != null ? ids : Set.of();
+        } catch (Exception e) {
+            log.error("[ViewCountCache] dirty set 조회 실패: {}", e.getMessage());
+            return Set.of();
+        }
+    }
+
+    // 값만 읽고 리셋하지 않음 — DB UPDATE 성공 후 resetBy() 로 차감
+    public long peek(UUID postId) {
+        try {
+            String value = redis.opsForValue().get(viewKey(postId));
+            return value != null ? Long.parseLong(value) : 0L;
+        } catch (NumberFormatException e) {
+            log.warn("[ViewCountCache] Redis 값 파싱 실패 postId={}", postId);
+            return 0L;
+        } catch (Exception e) {
+            log.error("[ViewCountCache] peek 실패 postId={}: {}", postId, e.getMessage());
+            return 0L;
+        }
+    }
+
+    // DB UPDATE 성공 후 flush 한 만큼만 DECRBY.
+    // peek~resetBy 사이에 들어온 INCR 는 그대로 남아 다음 주기에 반영됨.
+    // ex) peek=5 → DB +5 → 그 사이 INCR 2번 → resetBy(5) → Redis 잔여=2
+    public void resetBy(UUID postId, long flushed) {
+        if (flushed <= 0) return;
+        try {
+            Long remaining = redis.opsForValue().decrement(viewKey(postId), flushed);
+            redis.opsForSet().remove(DIRTY_SET_KEY, postId.toString());
+            if (remaining != null && remaining > 0) {
+                redis.opsForSet().add(DIRTY_SET_KEY, postId.toString());
+            }
+        } catch (Exception e) {
+            log.error("[ViewCountCache] resetBy 실패 postId={}, flushed={}: {}", postId, flushed, e.getMessage());
+        }
+    }
+
+    // 글 삭제 등으로 재시도가 불필요한 경우 카운터 키와 dirty 항목 모두 제거
+    public void discard(UUID postId) {
+        try {
+            redis.delete(viewKey(postId));
+            redis.opsForSet().remove(DIRTY_SET_KEY, postId.toString());
+        } catch (Exception e) {
+            log.warn("[ViewCountCache] discard 실패 postId={}", postId);
+        }
+    }
+
+    // dirty set 에 잘못된 UUID 형식이 들어온 경우 제거 (무한 재시도 방지)
+    public void removeInvalidEntry(String rawId) {
+        try {
+            redis.opsForSet().remove(DIRTY_SET_KEY, rawId);
+        } catch (Exception e) {
+            log.warn("[ViewCountCache] removeInvalidEntry 실패 rawId={}", rawId);
+        }
+    }
+
+    private String viewKey(UUID postId) {
+        return VIEW_KEY_PREFIX + postId;
+    }
+}

--- a/community-service/src/main/java/com/ojosama/post/infrastructure/cache/ViewCountCacheService.java
+++ b/community-service/src/main/java/com/ojosama/post/infrastructure/cache/ViewCountCacheService.java
@@ -1,5 +1,6 @@
 package com.ojosama.post.infrastructure.cache;
 
+import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -7,6 +8,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.connection.StringRedisConnection;
 import org.springframework.data.redis.core.RedisCallback;
 import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.RedisScript;
 import org.springframework.stereotype.Component;
 
 @Slf4j
@@ -15,7 +17,17 @@ import org.springframework.stereotype.Component;
 public class ViewCountCacheService {
 
     private static final String VIEW_KEY_PREFIX = "post:views:";
-    private static final String DIRTY_SET_KEY = "post:views:dirty";
+    private static final String DIRTY_SET_KEY   = "post:views:dirty";
+
+    private static final RedisScript<Long> RESET_BY_LUA = RedisScript.of(
+        "local remaining = redis.call('DECRBY', KEYS[1], ARGV[1])\n" +
+        "redis.call('SREM', KEYS[2], ARGV[2])\n" +
+        "if tonumber(remaining) > 0 then\n" +
+        "    redis.call('SADD', KEYS[2], ARGV[2])\n" +
+        "end\n" +
+        "return remaining",
+        Long.class
+    );
 
     private final StringRedisTemplate redis;
 
@@ -63,17 +75,19 @@ public class ViewCountCacheService {
         }
     }
 
-    // DB UPDATE 성공 후 flush 한 만큼만 DECRBY.
-    // peek~resetBy 사이에 들어온 INCR 는 그대로 남아 다음 주기에 반영됨.
-    // ex) peek=5 → DB +5 → 그 사이 INCR 2번 → resetBy(5) → Redis 잔여=2
+    /**
+     * DB UPDATE 성공 후 flush 한 만큼만 차감 — Lua 스크립트로 원자 처리.
+     * peek~resetBy 사이에 들어온 INCR 는 그대로 남아 다음 주기에 반영됨.
+     * ex) peek=5 → DB +5 → 그 사이 INCR 2번 → resetBy(5) → Redis 잔여=2
+     */
     public void resetBy(UUID postId, long flushed) {
         if (flushed <= 0) return;
         try {
-            Long remaining = redis.opsForValue().decrement(viewKey(postId), flushed);
-            redis.opsForSet().remove(DIRTY_SET_KEY, postId.toString());
-            if (remaining != null && remaining > 0) {
-                redis.opsForSet().add(DIRTY_SET_KEY, postId.toString());
-            }
+            redis.execute(
+                RESET_BY_LUA,
+                List.of(viewKey(postId), DIRTY_SET_KEY),
+                String.valueOf(flushed), postId.toString()
+            );
         } catch (Exception e) {
             log.error("[ViewCountCache] resetBy 실패 postId={}, flushed={}: {}", postId, flushed, e.getMessage());
         }

--- a/community-service/src/main/java/com/ojosama/post/infrastructure/cache/ViewCountFlushScheduler.java
+++ b/community-service/src/main/java/com/ojosama/post/infrastructure/cache/ViewCountFlushScheduler.java
@@ -1,0 +1,87 @@
+package com.ojosama.post.infrastructure.cache;
+
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * Redis 에 쌓인 조회수를 주기적으로 DB 에 flush 하는 스케줄러.
+ *
+ * 흐름: peek(Redis 조회) → flushOne(DB UPDATE, REQUIRES_NEW) → resetBy(Redis 차감)
+ * DB UPDATE 성공 후에 Redis 를 차감하므로 중간에 장애가 나도 조회수가 유실되지 않는다.
+ * 전체 루프에 @Transactional 을 걸지 않고 flushOne 단위로 트랜잭션을 분리해,
+ * 한 글 실패가 다른 글 flush 에 영향을 주지 않는다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ViewCountFlushScheduler {
+
+    @Value("${community.view-count.batch-size:500}")
+    private int batchSize;
+
+    private final ViewCountCacheService viewCountCache;
+    private final PostViewCountExecutor postViewCountExecutor;
+
+    @Scheduled(fixedDelayString = "${community.view-count.flush-interval-ms:30000}")
+    public void flush() {
+        Set<String> dirtyIds = viewCountCache.getDirtyPostIds();
+        if (dirtyIds.isEmpty()) {
+            return;
+        }
+
+        // 한 번에 처리할 글 수를 제한해 DB 락 점유 시간을 제어
+        List<String> batch = dirtyIds.stream()
+                .limit(batchSize)
+                .toList();
+
+        int flushedCount = 0;
+        long totalDelta = 0L;
+
+        for (String idStr : batch) {
+            UUID postId;
+            try {
+                postId = UUID.fromString(idStr);
+            } catch (IllegalArgumentException e) {
+                log.warn("[ViewCountFlush] 잘못된 UUID, dirty set 에서 제거: {}", idStr);
+                viewCountCache.removeInvalidEntry(idStr);
+                continue;
+            }
+
+            try {
+                long delta = viewCountCache.peek(postId);
+                if (delta <= 0) {
+                    viewCountCache.discard(postId);
+                    continue;
+                }
+
+                boolean updated = postViewCountExecutor.flushOne(postId, delta);
+
+                if (updated) {
+                    viewCountCache.resetBy(postId, delta);
+                    flushedCount++;
+                    totalDelta += delta;
+                } else {
+                    // affected=0: 글이 삭제된 케이스
+                    viewCountCache.discard(postId);
+                }
+
+            } catch (Exception e) {
+                // DB 장애 등 — dirty 유지, 다음 주기에 재시도
+                log.error("[ViewCountFlush] flush 실패, 다음 주기 재시도 postId={}: {}", postId, e.getMessage());
+            }
+        }
+
+        if (flushedCount > 0) {
+            log.info("[ViewCountFlush] {}개 글 flush 완료 (총 조회수 +{})", flushedCount, totalDelta);
+        }
+        if (dirtyIds.size() > batchSize) {
+            log.debug("[ViewCountFlush] dirty {}개 중 {}개 처리, 나머지 다음 주기", dirtyIds.size(), batch.size());
+        }
+    }
+}

--- a/community-service/src/main/java/com/ojosama/post/infrastructure/cache/ViewCountFlushScheduler.java
+++ b/community-service/src/main/java/com/ojosama/post/infrastructure/cache/ViewCountFlushScheduler.java
@@ -1,6 +1,5 @@
 package com.ojosama.post.infrastructure.cache;
 
-import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -11,11 +10,12 @@ import org.springframework.stereotype.Component;
 
 /**
  * Redis 에 쌓인 조회수를 주기적으로 DB 에 flush 하는 스케줄러.
- *
- * 흐름: peek(Redis 조회) → flushOne(DB UPDATE, REQUIRES_NEW) → resetBy(Redis 차감)
- * DB UPDATE 성공 후에 Redis 를 차감하므로 중간에 장애가 나도 조회수가 유실되지 않는다.
- * 전체 루프에 @Transactional 을 걸지 않고 flushOne 단위로 트랜잭션을 분리해,
- * 한 글 실패가 다른 글 flush 에 영향을 주지 않는다.
+ * 흐름: spopDirtyPostIds(SPOP) → peek → flushOne(DB UPDATE) → resetBy(Redis 차감)
+ * SMEMBERS 대신 SPOP 을 사용하는 이유:
+ *   멀티 인스턴스 환경에서 SMEMBERS 는 모든 인스턴스가 동일 postId 를 읽어
+ *   동일 delta 를 DB 에 중복 flush 할 수 있다. SPOP 은 pop 이 원자적이라
+ *   인스턴스 간 같은 postId 를 중복으로 처리하지 않는다.
+ * DB 실패 시: requeue() 로 dirty set 에 재등록 → 다음 주기에 재시도
  */
 @Slf4j
 @Component
@@ -30,32 +30,29 @@ public class ViewCountFlushScheduler {
 
     @Scheduled(fixedDelayString = "${community.view-count.flush-interval-ms:30000}")
     public void flush() {
-        Set<String> dirtyIds = viewCountCache.getDirtyPostIds();
-        if (dirtyIds.isEmpty()) {
+        // SPOP: 최대 batchSize 개를 원자적으로 꺼냄 (다른 인스턴스와 중복 없음)
+        Set<String> poppedIds = viewCountCache.spopDirtyPostIds(batchSize);
+        if (poppedIds.isEmpty()) {
             return;
         }
 
-        // 한 번에 처리할 글 수를 제한해 DB 락 점유 시간을 제어
-        List<String> batch = dirtyIds.stream()
-                .limit(batchSize)
-                .toList();
-
         int flushedCount = 0;
-        long totalDelta = 0L;
+        long totalDelta  = 0L;
 
-        for (String idStr : batch) {
+        for (String idStr : poppedIds) {
             UUID postId;
             try {
                 postId = UUID.fromString(idStr);
             } catch (IllegalArgumentException e) {
-                log.warn("[ViewCountFlush] 잘못된 UUID, dirty set 에서 제거: {}", idStr);
-                viewCountCache.removeInvalidEntry(idStr);
+                // 잘못된 UUID — SPOP 으로 이미 dirty set 에서 제거됐으므로 그냥 skip
+                log.warn("[ViewCountFlush] 잘못된 UUID, skip: {}", idStr);
                 continue;
             }
 
             try {
                 long delta = viewCountCache.peek(postId);
                 if (delta <= 0) {
+                    // 이미 다른 경로에서 처리됐거나 값이 없는 경우 — Redis 키만 정리
                     viewCountCache.discard(postId);
                     continue;
                 }
@@ -63,25 +60,24 @@ public class ViewCountFlushScheduler {
                 boolean updated = postViewCountExecutor.flushOne(postId, delta);
 
                 if (updated) {
+                    // DB UPDATE 성공 → Redis 에서 flush 한 만큼 차감 (INCR 잔여분 보존)
                     viewCountCache.resetBy(postId, delta);
                     flushedCount++;
                     totalDelta += delta;
                 } else {
-                    // affected=0: 글이 삭제된 케이스
+                    // affected=0: 글이 삭제된 경우 — Redis 키 정리, 재시도 불필요
                     viewCountCache.discard(postId);
                 }
 
             } catch (Exception e) {
-                // DB 장애 등 — dirty 유지, 다음 주기에 재시도
+                // DB 장애 등 — dirty set 에 재등록해 다음 주기에 재시도
                 log.error("[ViewCountFlush] flush 실패, 다음 주기 재시도 postId={}: {}", postId, e.getMessage());
+                viewCountCache.requeue(postId);
             }
         }
 
         if (flushedCount > 0) {
             log.info("[ViewCountFlush] {}개 글 flush 완료 (총 조회수 +{})", flushedCount, totalDelta);
-        }
-        if (dirtyIds.size() > batchSize) {
-            log.debug("[ViewCountFlush] dirty {}개 중 {}개 처리, 나머지 다음 주기", dirtyIds.size(), batch.size());
         }
     }
 }

--- a/community-service/src/main/java/com/ojosama/post/infrastructure/cache/ViewCountFlushScheduler.java
+++ b/community-service/src/main/java/com/ojosama/post/infrastructure/cache/ViewCountFlushScheduler.java
@@ -22,7 +22,7 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class ViewCountFlushScheduler {
 
-    @Value("${community.view-count.batch-size:500}")
+    @Value("${community.view-count.batch-size:100}")
     private int batchSize;
 
     private final ViewCountCacheService viewCountCache;

--- a/community-service/src/main/java/com/ojosama/post/presesntation/controller/PostController.java
+++ b/community-service/src/main/java/com/ojosama/post/presesntation/controller/PostController.java
@@ -12,6 +12,8 @@ import com.ojosama.post.application.service.PostService;
 import com.ojosama.post.presesntation.dto.request.CreatePostRequest;
 import com.ojosama.post.presesntation.dto.request.UpdatePostRequest;
 import com.ojosama.post.presesntation.dto.response.PostResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -33,6 +35,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "게시글", description = "게시글 CRUD 및 좋아요 API")
 @RestController
 @RequestMapping("v1/posts")
 @RequiredArgsConstructor
@@ -41,6 +44,7 @@ public class PostController {
     private final PostService postService;
     private final PostLikeService postLikeService;
 
+    @Operation(summary = "게시글 작성", description = "새 게시글을 작성합니다. 로그인한 사용자만 가능합니다.")
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     @PreAuthorize("hasAnyRole('USER', 'ADMIN')")
@@ -52,6 +56,7 @@ public class PostController {
         return ApiResponse.created(PostResponse.from(result));
     }
 
+    @Operation(summary = "게시글 수정", description = "본인이 작성한 게시글을 수정합니다.")
     @PatchMapping("/{postId}")
     @PreAuthorize("hasAnyRole('USER', 'ADMIN')")
     public ApiResponse<PostResponse> update(
@@ -63,6 +68,7 @@ public class PostController {
         return ApiResponse.success(PostResponse.from(result));
     }
 
+    @Operation(summary = "게시글 삭제", description = "본인이 작성한 게시글을 삭제합니다. 관리자는 모든 게시글 삭제 가능합니다.")
     @DeleteMapping("/{postId}")
     @PreAuthorize("hasAnyRole('USER', 'ADMIN')")
     public ApiResponse<Void> delete(
@@ -75,13 +81,18 @@ public class PostController {
         return ApiResponse.deleted();
     }
 
-    // GET 은 SecurityConfig 에서 permitAll — 비로그인도 조회 가능
+    @Operation(summary = "게시글 상세 조회", description = "게시글 상세 정보를 조회합니다. 비로그인도 가능합니다.")
     @GetMapping("/{postId}")
     public ApiResponse<PostResponse> getDetail(@PathVariable UUID postId) {
         PostResult result = postService.getDetail(postId);
         return ApiResponse.success(PostResponse.from(result));
     }
 
+    @Operation(
+            summary = "게시글 목록 조회",
+            description = "게시글 목록을 조회합니다. 비로그인도 가능합니다. <br>" +
+                    "categoryId 지정 시 카테고리 필터링, userId 지정 시 특정 유저의 게시글만 조회합니다."
+    )
     @GetMapping
     public ApiResponse<PageResponse<PostResponse>> list(
             @RequestParam(required = false) UUID categoryId,
@@ -99,6 +110,7 @@ public class PostController {
         return ApiResponse.success(PageResponse.from(page.map(PostResponse::from)));
     }
 
+    @Operation(summary = "게시글 좋아요", description = "게시글에 좋아요를 누릅니다. 중복 좋아요는 불가합니다.")
     @PostMapping("/{postId}/likes")
     @PreAuthorize("hasAnyRole('USER', 'ADMIN')")
     public ApiResponse<Void> like(
@@ -108,6 +120,7 @@ public class PostController {
         return ApiResponse.success();
     }
 
+    @Operation(summary = "게시글 좋아요 취소", description = "게시글 좋아요를 취소합니다.")
     @DeleteMapping("/{postId}/likes")
     @PreAuthorize("hasAnyRole('USER', 'ADMIN')")
     public ApiResponse<Void> unlike(

--- a/community-service/src/main/java/com/ojosama/post/presesntation/controller/PostController.java
+++ b/community-service/src/main/java/com/ojosama/post/presesntation/controller/PostController.java
@@ -1,6 +1,7 @@
 package com.ojosama.post.presesntation.controller;
 
 import com.ojosama.common.response.ApiResponse;
+import com.ojosama.common.response.PageResponse;
 import com.ojosama.post.application.dto.command.CreatePostCommand;
 import com.ojosama.post.application.dto.command.DeletePostCommand;
 import com.ojosama.post.application.dto.command.UpdatePostCommand;
@@ -75,7 +76,7 @@ public class PostController {
     }
 
     @GetMapping
-    public ApiResponse<Page<PostResponse>> list(
+    public ApiResponse<PageResponse<PostResponse>> list(
             @RequestParam(required = false) UUID categoryId,
             @RequestHeader(value = USER_ID_HEADER, required = false) UUID userId,
             @PageableDefault(size = 20, sort = "createdAt") Pageable pageable) {
@@ -88,7 +89,7 @@ public class PostController {
             query = PostListQuery.all(pageable);
         }
         Page<PostResult> page = postService.list(query);
-        return ApiResponse.success(page.map(PostResponse::from));
+        return ApiResponse.success(PageResponse.from(page.map(PostResponse::from)));
     }
 
     @PostMapping("/{postId}/likes")

--- a/community-service/src/main/java/com/ojosama/post/presesntation/controller/PostController.java
+++ b/community-service/src/main/java/com/ojosama/post/presesntation/controller/PostController.java
@@ -7,8 +7,8 @@ import com.ojosama.post.application.dto.command.DeletePostCommand;
 import com.ojosama.post.application.dto.command.UpdatePostCommand;
 import com.ojosama.post.application.dto.result.PostResult;
 import com.ojosama.post.application.query.PostListQuery;
-import com.ojosama.post.application.service.PostService;
 import com.ojosama.post.application.service.PostLikeService;
+import com.ojosama.post.application.service.PostService;
 import com.ojosama.post.presesntation.dto.request.CreatePostRequest;
 import com.ojosama.post.presesntation.dto.request.UpdatePostRequest;
 import com.ojosama.post.presesntation.dto.response.PostResponse;
@@ -19,13 +19,15 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -35,40 +37,45 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("v1/posts")
 @RequiredArgsConstructor
 public class PostController {
+
     private final PostService postService;
     private final PostLikeService postLikeService;
 
-    private static final String USER_ID_HEADER = "X-User-Id";
-    private static final String USER_ROLE_HEADER = "X-User-Role";
-
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    public ApiResponse<PostResponse> create(@Valid @RequestBody CreatePostRequest req,
-                                            @RequestHeader(USER_ID_HEADER) UUID userId){
-        PostResult result = postService.create(new CreatePostCommand(userId, req.categoryId(), req.title(), req.content()));
+    @PreAuthorize("hasAnyRole('USER', 'ADMIN')")
+    public ApiResponse<PostResponse> create(
+            @Valid @RequestBody CreatePostRequest req,
+            @AuthenticationPrincipal UUID userId) {
+        PostResult result = postService.create(new CreatePostCommand(
+                userId, req.categoryId(), req.title(), req.content()));
         return ApiResponse.created(PostResponse.from(result));
     }
 
     @PatchMapping("/{postId}")
+    @PreAuthorize("hasAnyRole('USER', 'ADMIN')")
     public ApiResponse<PostResponse> update(
             @PathVariable UUID postId,
             @Valid @RequestBody UpdatePostRequest req,
-            @RequestHeader(USER_ID_HEADER) UUID userId) {
+            @AuthenticationPrincipal UUID userId) {
         PostResult result = postService.update(new UpdatePostCommand(
                 postId, userId, req.categoryId(), req.title(), req.content()));
         return ApiResponse.success(PostResponse.from(result));
     }
 
     @DeleteMapping("/{postId}")
+    @PreAuthorize("hasAnyRole('USER', 'ADMIN')")
     public ApiResponse<Void> delete(
             @PathVariable UUID postId,
-            @RequestHeader(USER_ID_HEADER) UUID userId,
-            @RequestHeader(USER_ROLE_HEADER) String role) {
-        boolean isAdmin = "ADMIN".equals(role);
+            @AuthenticationPrincipal UUID userId,
+            Authentication authentication) {
+        boolean isAdmin = authentication.getAuthorities().stream()
+                .anyMatch(a -> a.getAuthority().equals("ROLE_ADMIN"));
         postService.delete(new DeletePostCommand(postId, userId, isAdmin));
         return ApiResponse.deleted();
     }
 
+    // GET 은 SecurityConfig 에서 permitAll — 비로그인도 조회 가능
     @GetMapping("/{postId}")
     public ApiResponse<PostResponse> getDetail(@PathVariable UUID postId) {
         PostResult result = postService.getDetail(postId);
@@ -78,7 +85,7 @@ public class PostController {
     @GetMapping
     public ApiResponse<PageResponse<PostResponse>> list(
             @RequestParam(required = false) UUID categoryId,
-            @RequestHeader(value = USER_ID_HEADER, required = false) UUID userId,
+            @RequestParam(required = false) UUID userId,
             @PageableDefault(size = 20, sort = "createdAt") Pageable pageable) {
         PostListQuery query;
         if (categoryId != null) {
@@ -93,17 +100,19 @@ public class PostController {
     }
 
     @PostMapping("/{postId}/likes")
+    @PreAuthorize("hasAnyRole('USER', 'ADMIN')")
     public ApiResponse<Void> like(
             @PathVariable UUID postId,
-            @RequestHeader(USER_ID_HEADER) UUID userId) {
+            @AuthenticationPrincipal UUID userId) {
         postLikeService.like(postId, userId);
         return ApiResponse.success();
     }
 
     @DeleteMapping("/{postId}/likes")
+    @PreAuthorize("hasAnyRole('USER', 'ADMIN')")
     public ApiResponse<Void> unlike(
             @PathVariable UUID postId,
-            @RequestHeader(USER_ID_HEADER) UUID userId) {
+            @AuthenticationPrincipal UUID userId) {
         postLikeService.unlike(postId, userId);
         return ApiResponse.success();
     }

--- a/community-service/src/main/resources/application.yml
+++ b/community-service/src/main/resources/application.yml
@@ -10,30 +10,3 @@ spring:
       uri: ${CONFIG_SERVER_URL:http://festie-config:8888}
       username: ${CONFIG_USERNAME}
       password: ${CONFIG_PASSWORD}
-
-  jpa:
-    properties:
-      hibernate:
-        default_schema: community_schema
-
-  # Redis — viewCount Write-Behind 캐시용
-  data:
-    redis:
-      host: ${SPRING_REDIS_HOST:festie-redis}
-      port: ${SPRING_REDIS_PORT:6379}
-      timeout: 1000ms
-      lettuce:
-        pool:
-          max-active: 16
-          max-idle: 8
-          min-idle: 2
-
-# viewCount Write-Behind 설정
-community:
-  view-count:
-    flush-interval-ms: ${VIEW_COUNT_FLUSH_INTERVAL_MS:30000}  # 30초
-
-logging:
-  level:
-    com.ojosama.community.infrastructure.persistence.outbox: INFO
-    com.ojosama.post.infrastructure.cache: INFO

--- a/community-service/src/main/resources/application.yml
+++ b/community-service/src/main/resources/application.yml
@@ -16,6 +16,24 @@ spring:
       hibernate:
         default_schema: community_schema
 
+  # Redis — viewCount Write-Behind 캐시용
+  data:
+    redis:
+      host: ${SPRING_REDIS_HOST:festie-redis}
+      port: ${SPRING_REDIS_PORT:6379}
+      timeout: 1000ms
+      lettuce:
+        pool:
+          max-active: 16
+          max-idle: 8
+          min-idle: 2
+
+# viewCount Write-Behind 설정
+community:
+  view-count:
+    flush-interval-ms: ${VIEW_COUNT_FLUSH_INTERVAL_MS:30000}  # 30초
+
 logging:
   level:
     com.ojosama.community.infrastructure.persistence.outbox: INFO
+    com.ojosama.post.infrastructure.cache: INFO

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -205,7 +205,7 @@ services:
       GIT_TOKEN: ${GIT_TOKEN}
       EUREKA_SERVER_URL: http://festie-eureka:8761/eureka/
     healthcheck:
-      test: [ "CMD-SHELL", "wget --spider -q --http-user=${CONFIG_USERNAME} --http-password=${CONFIG_PASSWORD} http://localhost:8888/actuator/health || exit 1" ]
+      test: [ "CMD-SHELL", "wget --spider -q --http-user=\"$$CONFIG_USERNAME\" --http-password=\"$$CONFIG_PASSWORD\" http://localhost:8888/actuator/health || exit 1" ]
       interval: 10s
       timeout: 5s
       retries: 10

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -205,7 +205,7 @@ services:
       GIT_TOKEN: ${GIT_TOKEN}
       EUREKA_SERVER_URL: http://festie-eureka:8761/eureka/
     healthcheck:
-      test: [ "CMD-SHELL", "wget --spider -q http://localhost:8888/actuator/health || exit 1" ]
+      test: [ "CMD-SHELL", "wget --spider -q --http-user=${CONFIG_USERNAME} --http-password=${CONFIG_PASSWORD} http://localhost:8888/actuator/health || exit 1" ]
       interval: 10s
       timeout: 5s
       retries: 10
@@ -476,6 +476,11 @@ services:
       SPRING_REDIS_HOST: festie-redis
       EUREKA_SERVER_URL: http://festie-eureka:8761/eureka/
       ZIPKIN_ENDPOINT: http://festie-zipkin:9411/api/v2/spans
+      # HikariCP 커넥션 풀
+      # 200 VU 기준: 읽기/쓰기 동시 트랜잭션 고려해 50으로 설정
+      SPRING_DATASOURCE_HIKARI_MAXIMUM_POOL_SIZE: 50
+      SPRING_DATASOURCE_HIKARI_MINIMUM_IDLE: 50
+      SPRING_DATASOURCE_HIKARI_CONNECTION_TIMEOUT: 10000
 
   # ============ favorite-service ============
   favorite-service:

--- a/monitoring/grafana/provisioning/dashboards/community-service.json
+++ b/monitoring/grafana/provisioning/dashboards/community-service.json
@@ -15,7 +15,7 @@
       }
     ]
   },
-  "description": "community-service Spring Boot 모니터링",
+  "description": "community-service Spring Boot \ubaa8\ub2c8\ud130\ub9c1",
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
@@ -908,12 +908,148 @@
       "type": "timeseries"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 30
+      },
+      "id": 60,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "last"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "jvm_buffer_memory_used_bytes{job=\"community-service\", id=\"direct\"}",
+          "legendFormat": "Used",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "jvm_buffer_total_capacity_bytes{job=\"community-service\", id=\"direct\"}",
+          "legendFormat": "Capacity",
+          "refId": "B"
+        }
+      ],
+      "title": "Direct Buffers (Memory)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 30
+      },
+      "id": 61,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "last"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "jvm_buffer_count_buffers{job=\"community-service\", id=\"direct\"}",
+          "legendFormat": "Direct Buffer Count",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "expr": "jvm_buffer_count_buffers{job=\"community-service\", id=\"mapped\"}",
+          "legendFormat": "Mapped Buffer Count",
+          "refId": "B"
+        }
+      ],
+      "title": "Direct Buffers (Count)",
+      "type": "timeseries"
+    },
+    {
       "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 30
+        "y": 39
       },
       "id": 40,
       "panels": [],
@@ -946,7 +1082,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 31
+        "y": 40
       },
       "id": 41,
       "options": {
@@ -1012,7 +1148,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 39
+        "y": 48
       },
       "id": 50,
       "panels": [],
@@ -1047,7 +1183,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 40
+        "y": 49
       },
       "id": 51,
       "options": {
@@ -1146,7 +1282,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 40
+        "y": 49
       },
       "id": 53,
       "options": {

--- a/monitoring/grafana/provisioning/datasources/datasource.yml
+++ b/monitoring/grafana/provisioning/datasources/datasource.yml
@@ -4,7 +4,7 @@ datasources:
   - name: Prometheus
     type: prometheus
     access: proxy
-    url: http://localhost:9090
+    url: http://festie-prometheus:9090
     isDefault: true
     editable: true
   - name: Loki

--- a/testing/loadtest/community-loadtest.js
+++ b/testing/loadtest/community-loadtest.js
@@ -1,0 +1,421 @@
+/**
+ * Community Service 부하테스트
+ *
+ * 실행 방법:
+ *   # 시드 생성 (최초 1회) — 사용자 50명 / 카테고리 3개 / 게시글 1000개
+ *   node loadtest/seed/community-seed.js
+ *
+ *   # 시나리오별 실행
+ *   k6 run --env SCENARIO=list    loadtest/k6/community-loadtest.js  # 목록 조회 (인덱스 성능)
+ *   k6 run --env SCENARIO=detail  loadtest/k6/community-loadtest.js  # 상세 조회 (Redis 조회수)
+ *   k6 run --env SCENARIO=write   loadtest/k6/community-loadtest.js  # 글쓰기 (인증 필요)
+ *   k6 run --env SCENARIO=stress  loadtest/k6/community-loadtest.js  # 복합 스트레스 (기존 동일 조건)
+ *
+ * 환경변수:
+ *   SCENARIO      실행할 시나리오 (list|detail|write|stress), 기본 stress
+ *   SEED_FILE     시드 파일 경로, 기본 loadtest/seed/seed_data.json
+ *   COMMUNITY_URL 서비스 URL, 기본 http://localhost:9001 (Docker 포트 동일)
+ *   HOT_MODE      detail 시나리오에서 핫스팟 집중 여부 (true|false)
+ *
+ * stress 시나리오 VU 플랜 (기존 동일):
+ *   0→50 VU  (30s 램프업) → 50→100 VU (1m) → 100→200 VU (1m 정점) → 200→0 VU (30s 다운)
+ *   max VUs: 200 / total: 3m / gracefulStop: 30s → 총 3m30s
+ */
+
+import http    from 'k6/http';
+import { check, sleep } from 'k6';
+import { Counter, Trend, Rate } from 'k6/metrics';
+
+// ── 시드 데이터 ───────────────────────────────────────────────────────────────
+const SEED_FILE = __ENV.SEED_FILE || 'loadtest/seed/seed_data.json';
+const seed      = JSON.parse(open(SEED_FILE));
+
+const BASE_URL  = __ENV.COMMUNITY_URL || seed.communityUrl || 'http://localhost:9001';
+const SCENARIO  = (__ENV.SCENARIO || 'stress').toLowerCase();
+const HOT_MODE  = (__ENV.HOT_MODE || 'false').toLowerCase() === 'true';
+
+const users               = seed.users               || [];
+const communityCategories = seed.communityCategories || [];
+const posts               = seed.posts               || [];
+const hotPosts            = seed.hotPosts            || posts.slice(0, 5);
+const adminId             = seed.adminUserId;
+
+// ── 커스텀 메트릭 ─────────────────────────────────────────────────────────────
+const listDuration   = new Trend('community_list_duration',   true);
+const detailDuration = new Trend('community_detail_duration', true);
+const writeDuration  = new Trend('community_write_duration',  true);
+const commentDuration= new Trend('community_comment_duration',true);
+const likeDuration   = new Trend('community_like_duration',   true);
+
+const successCount   = new Counter('community_success');
+const failCount      = new Counter('community_fail');
+const authFailRate   = new Rate('community_auth_fail_rate');
+
+// ── 시나리오 정의 ─────────────────────────────────────────────────────────────
+const scenarioConfigs = {
+    // 목록 조회 — 인덱스 + Page/COUNT 성능 확인
+    list: {
+        executor: 'ramping-vus',
+        startVUs: 1,
+        stages: [
+            { duration: '30s', target: Number(__ENV.TARGET_VUS || 30) },
+            { duration: '1m',  target: Number(__ENV.TARGET_VUS || 30) },
+            { duration: '20s', target: 0 },
+        ],
+        gracefulRampDown: '10s',
+        exec: 'listScenario',
+    },
+    // 상세 조회 — Redis Write-Behind 조회수 부하
+    detail: {
+        executor: 'ramping-vus',
+        startVUs: 1,
+        stages: [
+            { duration: '30s', target: Number(__ENV.TARGET_VUS || 50) },
+            { duration: '2m',  target: Number(__ENV.TARGET_VUS || 50) },
+            { duration: '20s', target: 0 },
+        ],
+        gracefulRampDown: '10s',
+        exec: 'detailScenario',
+    },
+    // 글쓰기 — 인증 + DB 쓰기 부하
+    write: {
+        executor: 'ramping-vus',
+        startVUs: 1,
+        stages: [
+            { duration: '20s', target: Number(__ENV.TARGET_VUS || 10) },
+            { duration: '1m',  target: Number(__ENV.TARGET_VUS || 10) },
+            { duration: '20s', target: 0 },
+        ],
+        gracefulRampDown: '10s',
+        exec: 'writeScenario',
+    },
+    // 복합 스트레스 — 기존 동일 조건
+    // 0→50 VU (30s) → 50→100 VU (1m) → 100→200 VU (1m 정점) → 200→0 VU (30s)
+    // 총 3m, gracefulStop 30s → k6 표시: 3m30s max duration
+    stress: {
+        executor: 'ramping-vus',
+        startVUs: 1,
+        stages: [
+            { duration: '30s', target: 50  },   // 램프업
+            { duration: '1m',  target: 100 },   // 증가
+            { duration: '1m',  target: 200 },   // 정점
+            { duration: '30s', target: 0   },   // 램프다운
+        ],
+        gracefulRampDown: '30s',
+        exec: 'stressScenario',
+    },
+};
+
+export const options = {
+    scenarios: {
+        [SCENARIO]: scenarioConfigs[SCENARIO] || scenarioConfigs.stress,
+    },
+    // p(99) 를 포함한 Trend 통계 수집 — 없으면 handleSummary 에서 n/a 로 뜸
+    summaryTrendStats: ['avg', 'min', 'med', 'max', 'p(90)', 'p(95)', 'p(99)', 'count'],
+    thresholds: {
+        http_req_failed:            ['rate<0.01'],
+        community_list_duration:    ['p(95)<500'],
+        community_detail_duration:  ['p(95)<200'],
+        community_write_duration:   ['p(95)<1000'],
+        community_auth_fail_rate:   ['rate<0.001'],
+    },
+};
+
+// ── 헬퍼 ─────────────────────────────────────────────────────────────────────
+function safeJson(res) {
+    try { return JSON.parse(res.body || ''); } catch { return null; }
+}
+
+function unwrap(res) {
+    const parsed = safeJson(res);
+    return parsed?.data ?? parsed ?? null;
+}
+
+/** X-User-Id / X-User-Role 헤더 반환 (Gateway 없이 서비스 직접 호출) */
+function authHeader(userId, role = 'USER') {
+    return {
+        'X-User-Id':   userId,
+        'X-User-Role': role,
+        'Content-Type': 'application/json',
+    };
+}
+
+function jsonHeader() {
+    return { 'Content-Type': 'application/json' };
+}
+
+function pickRandom(arr) {
+    if (!arr.length) throw new Error('빈 배열에서 선택 불가');
+    return arr[Math.floor(Math.random() * arr.length)];
+}
+
+function pickUser() { return pickRandom(users); }
+
+function pickPost() {
+    // HOT_MODE: 핫스팟 게시글에 80% 집중 (Redis 한 키에 부하 집중 시나리오)
+    if (HOT_MODE && hotPosts.length && Math.random() < 0.8) {
+        return pickRandom(hotPosts);
+    }
+    return pickRandom(posts);
+}
+
+function thinkTime() { sleep(Math.random() * 0.3 + 0.1); }
+
+// ── 시나리오 함수 ─────────────────────────────────────────────────────────────
+
+/**
+ * 목록 조회 시나리오
+ * - 전체 목록 / 카테고리 필터 / 유저 글 목록 혼합
+ * - 인덱스 성능 + COUNT(*) 비용 측정
+ */
+export function listScenario() {
+    const roll = Math.random();
+    let url;
+
+    if (roll < 0.5) {
+        // 50%: 전체 목록
+        url = `${BASE_URL}/v1/posts?page=0&size=20&sort=createdAt,desc`;
+    } else if (roll < 0.8 && communityCategories.length) {
+        // 30%: 카테고리별 필터
+        const cat = pickRandom(communityCategories);
+        url = `${BASE_URL}/v1/posts?categoryId=${cat.id}&page=0&size=20&sort=createdAt,desc`;
+    } else if (users.length) {
+        // 20%: 특정 유저의 글 목록
+        const user = pickUser();
+        url = `${BASE_URL}/v1/posts?userId=${user.userId}&page=0&size=20&sort=createdAt,desc`;
+    } else {
+        url = `${BASE_URL}/v1/posts?page=0&size=20`;
+    }
+
+    const start = Date.now();
+    const res   = http.get(url, { tags: { api: 'post_list' } });
+    listDuration.add(Date.now() - start);
+
+    const ok = check(res, {
+        'list status 200':      r => r.status === 200,
+        'list has content':     r => Array.isArray(unwrap(r)?.content),
+        'list has totalPages':  r => unwrap(r)?.totalPages !== undefined,
+    });
+    ok ? successCount.add(1) : failCount.add(1);
+
+    thinkTime();
+}
+
+/**
+ * 상세 조회 시나리오
+ * - Redis INCR 부하 측정
+ * - HOT_MODE=true 시 동일 게시글에 집중 → Redis 단일 키 경합 테스트
+ */
+export function detailScenario() {
+    if (!posts.length) return;
+
+    const post = pickPost();
+    const start = Date.now();
+    const res   = http.get(
+        `${BASE_URL}/v1/posts/${post.postId}`,
+        { tags: { api: 'post_detail' } }
+    );
+    detailDuration.add(Date.now() - start);
+
+    const ok = check(res, {
+        'detail status 200':    r => r.status === 200,
+        'detail has postId':    r => unwrap(r)?.id !== undefined,
+        'detail has viewCount': r => typeof unwrap(r)?.viewCount === 'number',
+    });
+    ok ? successCount.add(1) : failCount.add(1);
+
+    thinkTime();
+}
+
+/**
+ * 글쓰기 시나리오
+ * - 게시글 작성 + 댓글 + 좋아요 순서대로 실행
+ * - 인증 헤더 포함 (HeaderAuthenticationFilter 검증)
+ */
+export function writeScenario() {
+    if (!users.length || !communityCategories.length) return;
+
+    const user     = pickUser();
+    const category = pickRandom(communityCategories);
+    const headers  = authHeader(user.userId, 'USER');
+
+    // 1. 게시글 작성
+    const writeStart = Date.now();
+    const writeRes = http.post(
+        `${BASE_URL}/v1/posts`,
+        JSON.stringify({
+            categoryId: category.id,
+            title:      `k6 테스트 게시글 ${Date.now()}`,
+            content:    '부하테스트 중 작성된 게시글입니다.',
+        }),
+        { headers, tags: { api: 'post_write' } }
+    );
+    writeDuration.add(Date.now() - writeStart);
+
+    const writeOk = check(writeRes, {
+        'write status 201':    r => r.status === 201,
+        'write has postId':    r => unwrap(r)?.id !== undefined,
+        'write not 401/403':   r => r.status !== 401 && r.status !== 403,
+    });
+    authFailRate.add(writeRes.status === 401 || writeRes.status === 403 ? 1 : 0);
+    if (!writeOk) { failCount.add(1); return; }
+    successCount.add(1);
+
+    const newPostId = unwrap(writeRes)?.id;
+    if (!newPostId) return;
+
+    thinkTime();
+
+    // 2. 댓글 작성
+    const commentStart = Date.now();
+    const commentRes = http.post(
+        `${BASE_URL}/v1/posts/${newPostId}/comments`,
+        JSON.stringify({ content: 'k6 테스트 댓글입니다.' }),
+        { headers, tags: { api: 'comment_write' } }
+    );
+    commentDuration.add(Date.now() - commentStart);
+
+    check(commentRes, {
+        'comment status 201': r => r.status === 201,
+        'comment not 401':    r => r.status !== 401,
+    }) ? successCount.add(1) : failCount.add(1);
+
+    thinkTime();
+
+    // 3. 좋아요 — VU 번호 + iteration 으로 분산하여 중복 최소화
+    // posts.find() 는 항상 같은 첫 번째 글을 반환 → 중복 좋아요 폭발
+    const otherPosts = posts.filter(p => p.userId !== user.userId);
+    if (otherPosts.length) {
+        // VU 별로 다른 오프셋 사용 → 동일 글 좋아요 중복 방지
+        const likeTarget = otherPosts[(__VU * 7 + __ITER) % otherPosts.length];
+        const likeStart = Date.now();
+        const likeRes = http.post(
+            `${BASE_URL}/v1/posts/${likeTarget.postId}/likes`,
+            null,
+            { headers, tags: { api: 'post_like' } }
+        );
+        likeDuration.add(Date.now() - likeStart);
+
+        // 409 = 이미 좋아요 (정상 비즈니스 케이스) — 실패로 집계하지 않음
+        check(likeRes, {
+            'like not 401/500': r => r.status !== 401 && r.status !== 500,
+        }) ? successCount.add(1) : failCount.add(1);
+    }
+
+    thinkTime();
+}
+
+/**
+ * 복합 스트레스 시나리오
+ * - 실제 커뮤니티 트래픽 패턴 시뮬레이션
+ * - 읽기 70% / 상세 조회 20% / 쓰기 10%
+ */
+export function stressScenario() {
+    const roll = Math.random();
+
+    if (roll < 0.45) {
+        // 45%: 목록 조회
+        listScenario();
+    } else if (roll < 0.70) {
+        // 25%: 상세 조회 (Redis 조회수 증가)
+        detailScenario();
+    } else if (roll < 0.85) {
+        // 15%: 목록 → 상세 → 댓글 목록 (실제 사용자 흐름)
+        listScenario();
+        if (posts.length) {
+            const post = pickPost();
+            const res  = http.get(
+                `${BASE_URL}/v1/posts/${post.postId}`,
+                { tags: { api: 'post_detail_flow' } }
+            );
+            check(res, { 'flow detail 200': r => r.status === 200 })
+                ? successCount.add(1) : failCount.add(1);
+
+            thinkTime();
+
+            const commentRes = http.get(
+                `${BASE_URL}/v1/posts/${post.postId}/comments?page=0&size=20`,
+                { tags: { api: 'comment_list_flow' } }
+            );
+            check(commentRes, { 'flow comments 200': r => r.status === 200 })
+                ? successCount.add(1) : failCount.add(1);
+        }
+    } else {
+        // 15%: 인증 필요한 쓰기 작업
+        writeScenario();
+    }
+}
+
+// ── 커스텀 요약 리포트 ────────────────────────────────────────────────────────
+export function handleSummary(data) {
+    const m = data.metrics;
+
+    function val(metric, stat) {
+        return m[metric]?.values?.[stat] ?? null;
+    }
+    function ms(v) {
+        return v === null ? 'n/a' : v.toFixed(2) + ' ms';
+    }
+    function pct(v) {
+        return v === null ? 'n/a' : (v * 100).toFixed(2) + '%';
+    }
+    function num(v) {
+        return v === null ? 'n/a' : Math.round(v).toString();
+    }
+
+    const totalReqs  = val('http_reqs',          'count');
+    const failRate   = val('http_req_failed',     'rate');
+    const avgDur     = val('http_req_duration',   'avg');
+    const p95Dur     = val('http_req_duration',   'p(95)');
+    const p99Dur     = val('http_req_duration',   'p(99)');
+    const maxRps     = val('http_reqs',           'rate');
+
+    const listP95    = val('community_list_duration',   'p(95)');
+    const detailP95  = val('community_detail_duration', 'p(95)');
+    // Counter 메트릭은 values.count 가 아니라 values.value 에 있음
+    // Trend 의 count 는 summaryTrendStats 에 'count' 추가해야 포함됨
+    const writeCount = val('community_write_duration',  'count');
+    const likeCount  = val('community_like_duration',   'count');
+    // 성공/실패 Counter
+    const successTotal = val('community_success', 'count') ?? m['community_success']?.values?.value ?? null;
+    const failTotal    = val('community_fail',    'count') ?? m['community_fail']?.values?.value    ?? null;
+
+    const W  = 56; // 박스 너비
+    const HR = '─'.repeat(W);
+    const title = ` community-service 부하 테스트 결과 [${SCENARIO}] `;
+    const pad   = Math.max(0, W - title.length);
+    const lp    = Math.floor(pad / 2);
+    const rp    = pad - lp;
+
+    function row(label, value) {
+        const dots = '.'.repeat(Math.max(1, W - label.length - value.length - 2));
+        return `  ${label} ${dots} ${value}`;
+    }
+
+    const lines = [
+        '',
+        '━'.repeat(lp) + title + '━'.repeat(rp),
+        row('총 요청 수',       num(totalReqs)   + ' 건'),
+        row('실패율',           pct(failRate)),
+        row('평균 응답시간',    ms(avgDur)),
+        row('p95 응답시간',     ms(p95Dur)),
+        row('p99 응답시간',     ms(p99Dur)),
+        row('평균 RPS',         maxRps === null ? 'n/a' : maxRps.toFixed(2) + ' req/s'),
+        HR,
+        row('목록 조회 p95',    ms(listP95)),
+        row('상세 조회 p95',    ms(detailP95)),
+        row('글쓰기 p95',       ms(val('community_write_duration', 'p(95)'))),
+        row('글쓰기 요청 수',   num(writeCount)  + ' 건'),
+        row('좋아요 요청 수',   num(likeCount)   + ' 건'),
+        row('성공 체크 수',     num(successTotal) + ' 건'),
+        '━'.repeat(W),
+        '',
+    ];
+
+    console.log(lines.join('\n'));
+
+    // 기본 k6 JSON 요약도 파일로 저장 (선택)
+    return {
+        stdout: '\n',   // 기본 출력은 비움 (위 console.log 로 대체)
+    };
+}

--- a/testing/loadtest/community-seed.js
+++ b/testing/loadtest/community-seed.js
@@ -1,0 +1,229 @@
+/**
+ * community-service 부하테스트용 시드 데이터 생성기
+ *
+ * 실행 방법:
+ *   node loadtest/seed/community-seed.js
+ *
+ * 환경변수 (선택):
+ *   COMMUNITY_URL    기본값 http://localhost:9001
+ *   POST_COUNT       생성할 게시글 수, 기본 1000
+ *   USER_COUNT       사용할 사용자 수 (상위 N명), 기본 50
+ *   CATEGORY_COUNT   생성할 카테고리 수, 기본 3
+ *   BASE_SEED_FILE   기존 사용자 ID 가 담긴 파일, 기본 testing/data/loadtest-ids.json
+ *
+ * 결과: loadtest/seed/seed_data.json 에 저장
+ */
+
+const fs   = require('fs');
+const path = require('path');
+const http = require('http');
+const https = require('https');
+
+// ── 설정 ─────────────────────────────────────────────────────────────────────
+const COMMUNITY_URL    = process.env.COMMUNITY_URL  || 'http://localhost:9001';
+const POST_COUNT       = parseInt(process.env.POST_COUNT      || '1000', 10);
+const USER_COUNT       = parseInt(process.env.USER_COUNT      || '50',   10);
+const CATEGORY_COUNT   = parseInt(process.env.CATEGORY_COUNT  || '3',    10);
+const BASE_SEED_FILE   = process.env.BASE_SEED_FILE ||
+    path.resolve(__dirname, '../../testing/data/loadtest-ids.json');
+const OUT_FILE         = path.resolve(__dirname, 'seed_data.json');
+
+// ── 유틸 ─────────────────────────────────────────────────────────────────────
+function request(method, url, body, headers = {}) {
+    return new Promise((resolve, reject) => {
+        const parsed = new URL(url);
+        const lib    = parsed.protocol === 'https:' ? https : http;
+        const data   = body ? JSON.stringify(body) : null;
+
+        const options = {
+            hostname: parsed.hostname,
+            port:     parsed.port || (parsed.protocol === 'https:' ? 443 : 80),
+            path:     parsed.pathname + parsed.search,
+            method,
+            headers: {
+                'Content-Type': 'application/json',
+                ...(data ? { 'Content-Length': Buffer.byteLength(data) } : {}),
+                ...headers,
+            },
+        };
+
+        const req = lib.request(options, (res) => {
+            let raw = '';
+            res.on('data', chunk => raw += chunk);
+            res.on('end', () => {
+                try {
+                    resolve({ status: res.statusCode, body: JSON.parse(raw) });
+                } catch {
+                    resolve({ status: res.statusCode, body: raw });
+                }
+            });
+        });
+
+        req.on('error', reject);
+        if (data) req.write(data);
+        req.end();
+    });
+}
+
+/** X-User-Id / X-User-Role 헤더 — Gateway 없이 서비스 직접 호출 시 사용 */
+function authHeaders(userId, role = 'USER') {
+    return { 'X-User-Id': userId, 'X-User-Role': role };
+}
+
+function sleep(ms) {
+    return new Promise(r => setTimeout(r, ms));
+}
+
+function pick(arr) {
+    return arr[Math.floor(Math.random() * arr.length)];
+}
+
+// ── 메인 ─────────────────────────────────────────────────────────────────────
+async function main() {
+    console.log('=== Community 시드 데이터 생성 시작 ===');
+    console.log(`  서버:       ${COMMUNITY_URL}`);
+    console.log(`  사용자 수:  ${USER_COUNT}명`);
+    console.log(`  카테고리:   ${CATEGORY_COUNT}개`);
+    console.log(`  게시글 수:  ${POST_COUNT}개`);
+
+    // 1. 기존 사용자 목록 로드
+    if (!fs.existsSync(BASE_SEED_FILE)) {
+        console.error(`[ERROR] 베이스 시드 파일 없음: ${BASE_SEED_FILE}`);
+        console.error('       testing/data/loadtest-ids.json 을 먼저 생성하세요.');
+        process.exit(1);
+    }
+    const base     = JSON.parse(fs.readFileSync(BASE_SEED_FILE, 'utf-8'));
+    const adminId  = base.adminUserId || '00000000-0000-0000-0000-000000000001';
+
+    // USER_COUNT 만큼만 사용 (상위 N명)
+    const allUsers = base.users || [];
+    if (!allUsers.length) {
+        console.error('[ERROR] 사용자 데이터가 없습니다.');
+        process.exit(1);
+    }
+    const users = allUsers.slice(0, USER_COUNT);
+    console.log(`  사용자 ${users.length}명 선택 (전체 ${allUsers.length}명 중)`);
+
+    // 2. 커뮤니티 카테고리 생성 (ADMIN) — CATEGORY_COUNT 개만 생성
+    const allCategoryNames = ['자유게시판', '질문게시판', '후기게시판', '정보공유', '이벤트'];
+    const categoryNames    = allCategoryNames.slice(0, CATEGORY_COUNT);
+    const communityCategories = [];
+
+    console.log('\n[1/3] 커뮤니티 카테고리 생성...');
+    for (const name of categoryNames) {
+        try {
+            const res = await request(
+                'POST',
+                `${COMMUNITY_URL}/v1/community-categories`,
+                { name },
+                authHeaders(adminId, 'ADMIN')
+            );
+            if (res.status === 201 && res.body?.data?.id) {
+                communityCategories.push({ name, id: res.body.data.id });
+                console.log(`  ✓ ${name} → ${res.body.data.id}`);
+            } else if (res.status === 409) {
+                console.log(`  - ${name} 이미 존재, 스킵`);
+            } else {
+                console.warn(`  ! ${name} 생성 실패 (${res.status}):`, JSON.stringify(res.body).slice(0, 100));
+            }
+        } catch (e) {
+            console.warn(`  ! ${name} 요청 오류:`, e.message);
+        }
+        await sleep(50);
+    }
+
+    // 카테고리가 하나도 없으면 기존 것 조회 시도
+    if (!communityCategories.length) {
+        console.log('  카테고리 직접 생성 실패 — 기존 목록 조회 시도...');
+        try {
+            const res = await request('GET', `${COMMUNITY_URL}/v1/community-categories?size=10`);
+            const content = res.body?.data?.content || [];
+            content.forEach(c => communityCategories.push({ name: c.name, id: c.id }));
+            console.log(`  기존 카테고리 ${communityCategories.length}개 사용`);
+        } catch (e) {
+            console.error('  카테고리 조회도 실패:', e.message);
+        }
+    }
+
+    if (!communityCategories.length) {
+        console.error('[ERROR] 사용 가능한 카테고리가 없습니다. 서비스가 실행 중인지 확인하세요.');
+        process.exit(1);
+    }
+
+    // 3. 게시글 생성
+    console.log(`\n[2/3] 게시글 ${POST_COUNT}개 생성...`);
+    const posts        = [];
+    const batchSize    = 10;
+    let   successCount = 0;
+
+    for (let i = 0; i < POST_COUNT; i++) {
+        const user     = pick(users);
+        const category = pick(communityCategories);
+
+        try {
+            const res = await request(
+                'POST',
+                `${COMMUNITY_URL}/v1/posts`,
+                {
+                    categoryId: category.id,
+                    title:      `부하테스트 게시글 ${i + 1}`,
+                    content:    `이 게시글은 부하테스트를 위해 자동 생성되었습니다. (${i + 1}/${POST_COUNT})`,
+                },
+                authHeaders(user.userId, 'USER')
+            );
+
+            if (res.status === 201 && res.body?.data?.id) {
+                posts.push({
+                    postId:     res.body.data.id,
+                    categoryId: category.id,
+                    userId:     user.userId,
+                });
+                successCount++;
+
+                if (successCount % 20 === 0) {
+                    process.stdout.write(`\r  생성 중... ${successCount}/${POST_COUNT}`);
+                }
+            }
+        } catch (e) {
+            // 개별 실패는 무시하고 계속
+        }
+
+        // 너무 빠른 요청으로 서버 부하 방지
+        if (i % batchSize === batchSize - 1) {
+            await sleep(100);
+        }
+    }
+    console.log(`\r  ✓ 게시글 ${successCount}개 생성 완료`);
+
+    if (!posts.length) {
+        console.error('[ERROR] 게시글 생성에 모두 실패했습니다.');
+        process.exit(1);
+    }
+
+    // 4. 시드 파일 저장
+    console.log('\n[3/3] seed_data.json 저장...');
+    const seedData = {
+        generatedAt:         new Date().toISOString(),
+        communityUrl:        COMMUNITY_URL,
+        adminUserId:         adminId,
+        users:               users.map(u => ({ userId: u.userId, role: u.role || 'USER' })),
+        communityCategories,
+        posts,
+        // 핫스팟 테스트용: 상위 5개 게시글을 집중적으로 조회
+        hotPosts: posts.slice(0, Math.min(5, posts.length)),
+    };
+
+    fs.writeFileSync(OUT_FILE, JSON.stringify(seedData, null, 2));
+    console.log(`  ✓ 저장 완료: ${OUT_FILE}`);
+    console.log('\n=== 완료 ===');
+    console.log(`  카테고리: ${communityCategories.length}개`);
+    console.log(`  게시글:   ${posts.length}개`);
+    console.log(`  핫스팟:   ${seedData.hotPosts.length}개`);
+    console.log('\n이제 부하테스트를 실행하세요:');
+    console.log('  k6 run --env SCENARIO=stress loadtest/k6/community-loadtest.js');
+}
+
+main().catch(err => {
+    console.error('[FATAL]', err);
+    process.exit(1);
+});


### PR DESCRIPTION
## 🔗 Issue Number
- close #243

## 📝 작업 내역

- 게시글 단일 조회 성능 개선 => Redis Write-Behind 조회수 캐시 구현
ViewCountCacheService — Redis INCR+SADD pipeline
PostViewCountExecutor — 독립 트랜잭션
ViewCountFlushScheduler — 30초 주기 batch flush, Read-then-Reset 패턴으로 구현
Redis fallback 으로 DB 직접 UPDATE
-  게시글 목록 조회 성능 개선 => DB 인덱스 최적화
- HikariCP 커넥션 풀 튜닝
- 인증인가 도입
- PageResponse 래퍼 적용
- 인프라 설정 수정  
- 테스트 코드 작성
  
## 💡 PR 특이사항

🔄 단일 조회 개선 전
```
━━━━━━━━━ community-service 부하 테스트 결과 [detail] ━━━━━━━━━
  총 요청 수 .......................................... 8627 건
  실패율 .............................................. 0.14%
  평균 응답시간 ...................................... 592.23 ms
  p95 응답시간 ..................................... 978.18 ms
  p99 응답시간 ................................... 11008.56 ms
  평균 RPS ..................................... 50.63 req/s
────────────────────────────────────────────────────────
  목록 조회 p95 ...................................... 0.00 ms
  상세 조회 p95 .................................... 978.00 ms
  글쓰기 p95 ........................................ 0.00 ms
  글쓰기 요청 수 ........................................... 0 건
  좋아요 요청 수 ......................................... n/a 건
  성공 체크 수 ......................................... 8615 건
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━  source=console

```
🔄 단일 조회 개선 후
```
━━━━━━━━━ community-service 부하 테스트 결과 [detail] ━━━━━━━━━
  총 요청 수 ......................................... 20544 건
  실패율 .............................................. 0.01%
  평균 응답시간 ....................................... 10.96 ms
  p95 응답시간 ...................................... 12.65 ms
  p99 응답시간 ...................................... 62.77 ms
  평균 RPS .................................... 114.27 req/s
────────────────────────────────────────────────────────
  목록 조회 p95 ...................................... 0.00 ms
  상세 조회 p95 ..................................... 13.00 ms
  글쓰기 p95 ........................................ 0.00 ms
  글쓰기 요청 수 ........................................... 0 건
  좋아요 요청 수 ......................................... n/a 건
  성공 체크 수 ........................................ 20542 건
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━  source=console

```
🔄 목록 조회 개선 전
```
━━━━━━━━━━ community-service 부하 테스트 결과 [list] ━━━━━━━━━━
  총 요청 수 .......................................... 6648 건
  실패율 .............................................. 0.00%
  평균 응답시간 ...................................... 132.19 ms
  p95 응답시간 ..................................... 509.64 ms
  p99 응답시간 .................................... 2042.28 ms
  평균 RPS ..................................... 60.36 req/s
────────────────────────────────────────────────────────
  목록 조회 p95 .................................... 509.65 ms
  상세 조회 p95 ...................................... 0.00 ms
  글쓰기 p95 ........................................ 0.00 ms
  글쓰기 요청 수 ........................................... 0 건
  좋아요 요청 수 ......................................... n/a 건
  성공 체크 수 ......................................... 6648 건
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━  source=console

```
🔄 목록 조회 개선 후
```
━━━━━━━━━━ community-service 부하 테스트 결과 [list] ━━━━━━━━━━
  총 요청 수 .......................................... 8879 건
  실패율 .............................................. 0.00%
  평균 응답시간 ....................................... 37.66 ms
  p95 응답시간 ..................................... 131.11 ms
  p99 응답시간 ..................................... 278.00 ms
  평균 RPS ..................................... 80.37 req/s
────────────────────────────────────────────────────────
  목록 조회 p95 .................................... 131.10 ms
  상세 조회 p95 ...................................... 0.00 ms
  글쓰기 p95 ........................................ 0.00 ms
  글쓰기 요청 수 ........................................... 0 건
  좋아요 요청 수 ......................................... n/a 건
  성공 체크 수 ......................................... 8879 건
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━  source=console

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * Redis 기반 조회수 캐시 및 주기적 배치 플러시 추가
  * k6 기반 부하테스트 및 시드 생성 스크립트 추가

* **개선사항**
  * 보안 정책 강화 및 인증 흐름 전환(엔드포인트별 권한 명시화)
  * OpenAPI 문서(엔드포인트 설명) 보강
  * 모니터링에 Direct Buffer 메트릭 추가

* **기타**
  * DB 인덱스 최적화 및 모니터링 구성 업데이트 (데이터소스/헬스체크 보정)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/55josama/festie/pull/291?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->