### PR TITLE
[FEATURE] 행사 도메인 Swagger, PageResponse 적용

### DIFF
--- a/event-service/src/main/java/com/ojosama/eventservice/config/SecurityConfig.java
+++ b/event-service/src/main/java/com/ojosama/eventservice/config/SecurityConfig.java
@@ -24,6 +24,13 @@ public class SecurityConfig {
                 )
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/actuator/**").permitAll()
+                        .requestMatchers(
+                                "/swagger-ui/**",
+                                "/v3/api-docs/**",
+                                "/swagger-ui.html",
+                                "/swagger-resources/**",
+                                "/webjars/**"
+                        ).permitAll()
                         .requestMatchers("/v1/events/**").permitAll()
                         .requestMatchers("/internal/**").permitAll()
                         .anyRequest().authenticated()

--- a/event-service/src/main/java/com/ojosama/eventservice/config/SwaggerConfig.java
+++ b/event-service/src/main/java/com/ojosama/eventservice/config/SwaggerConfig.java
@@ -1,0 +1,36 @@
+package com.ojosama.eventservice.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("Festie Event Service API")
+                        .description("행사 관리 서비스 API 명세")
+                        .version("v1"))
+                .addSecurityItem(new SecurityRequirement()
+                        .addList("X-User-Id")
+                        .addList("X-User-Role"))
+                .components(new Components()
+                        .addSecuritySchemes("X-User-Id", new SecurityScheme()
+                                .type(SecurityScheme.Type.APIKEY)
+                                .in(SecurityScheme.In.HEADER)
+                                .name("X-User-Id")
+                                .description("게이트웨이에서 주입되는 사용자 UUID"))
+                        .addSecuritySchemes("X-User-Role", new SecurityScheme()
+                                .type(SecurityScheme.Type.APIKEY)
+                                .in(SecurityScheme.In.HEADER)
+                                .name("X-User-Role")
+                                .description("사용자 역할 (ADMIN, CONCERT_MANAGER, FESTIVAL_MANAGER, FANMEETING_MANAGER, POPUP_MANAGER, USER)")));
+    }
+}

--- a/event-service/src/main/java/com/ojosama/eventservice/event/presentation/controller/EventCategoryController.java
+++ b/event-service/src/main/java/com/ojosama/eventservice/event/presentation/controller/EventCategoryController.java
@@ -9,6 +9,9 @@ import com.ojosama.eventservice.event.application.service.EventCategoryQueryServ
 import com.ojosama.eventservice.event.presentation.dto.request.CreateEventCategoryRequest;
 import com.ojosama.eventservice.event.presentation.dto.request.UpdateEventCategoryRequest;
 import com.ojosama.eventservice.event.presentation.dto.response.EventCategoryResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.List;
 import java.util.UUID;
@@ -29,6 +32,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/v1/event-categories")
+@Tag(name = "행사 카테고리 API", description = "행사 카테고리 관리 (ADMIN 전용)")
 public class EventCategoryController {
 
     private final EventCategoryCommandService eventCategoryCommandService;
@@ -36,6 +40,7 @@ public class EventCategoryController {
 
     @GetMapping
     @PreAuthorize("hasRole('ADMIN')")
+    @Operation(summary = "카테고리 목록 조회", description = "관리자 전용 API입니다. 등록된 모든 행사 카테고리 목록을 반환합니다.")
     public ResponseEntity<ApiResponse<List<EventCategoryResponse>>> getCategories() {
 
         List<EventCategoryResponse> response = eventCategoryQueryService.getCategories().stream()
@@ -46,8 +51,9 @@ public class EventCategoryController {
 
     @PostMapping
     @PreAuthorize("hasRole('ADMIN')")
+    @Operation(summary = "카테고리 등록", description = "관리자 전용 API입니다. 새로운 행사 카테고리를 등록합니다. 카테고리 이름(name)은 필수이며 중복될 수 없습니다.")
     public ResponseEntity<ApiResponse<EventCategoryResponse>> createCategory(
-            @AuthenticationPrincipal String userId,
+            @Parameter(hidden = true) @AuthenticationPrincipal String userId,
             @Valid @RequestBody CreateEventCategoryRequest request) {
 
         CreateEventCategoryCommand command = new CreateEventCategoryCommand(UUID.fromString(userId), request.name());
@@ -58,20 +64,23 @@ public class EventCategoryController {
 
     @PatchMapping("/{categoryId}")
     @PreAuthorize("hasRole('ADMIN')")
+    @Operation(summary = "카테고리 수정", description = "관리자 전용 API입니다. 카테고리 이름(name)을 변경합니다. 존재하지 않는 카테고리 ID로 요청 시 404를 반환합니다.")
     public ResponseEntity<ApiResponse<EventCategoryResponse>> updateCategory(
-            @AuthenticationPrincipal String userId,
+            @Parameter(hidden = true) @AuthenticationPrincipal String userId,
             @PathVariable UUID categoryId,
             @Valid @RequestBody UpdateEventCategoryRequest request) {
 
-        UpdateEventCategoryCommand command = new UpdateEventCategoryCommand(UUID.fromString(userId), categoryId, request.name());
+        UpdateEventCategoryCommand command = new UpdateEventCategoryCommand(UUID.fromString(userId), categoryId,
+                request.name());
         EventCategoryResult result = eventCategoryCommandService.updateCategory(command);
         return ResponseEntity.ok(ApiResponse.success(EventCategoryResponse.from(result)));
     }
 
     @DeleteMapping("/{categoryId}")
     @PreAuthorize("hasRole('ADMIN')")
+    @Operation(summary = "카테고리 삭제", description = "관리자 전용 API입니다. 해당 카테고리를 삭제합니다. 카테고리에 연결된 행사가 하나라도 존재하면 삭제할 수 없습니다. 존재하지 않는 카테고리 ID로 요청 시 404를 반환합니다.")
     public ResponseEntity<Void> deleteCategory(
-            @AuthenticationPrincipal String userId,
+            @Parameter(hidden = true) @AuthenticationPrincipal String userId,
             @PathVariable UUID categoryId) {
 
         eventCategoryCommandService.deleteCategory(UUID.fromString(userId), categoryId);

--- a/event-service/src/main/java/com/ojosama/eventservice/event/presentation/controller/EventController.java
+++ b/event-service/src/main/java/com/ojosama/eventservice/event/presentation/controller/EventController.java
@@ -14,6 +14,9 @@ import com.ojosama.eventservice.event.presentation.dto.request.UpdateEventReques
 import com.ojosama.eventservice.event.presentation.dto.response.EventDetailResponse;
 import com.ojosama.eventservice.event.presentation.dto.response.EventListResponse;
 import com.ojosama.eventservice.event.presentation.dto.response.EventResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.time.LocalDateTime;
 import java.util.UUID;
@@ -40,6 +43,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/v1/events")
+@Tag(name = "행사 API", description = "행사 등록, 조회, 수정, 삭제")
 public class EventController {
 
     private final EventCommandService eventCommandService;
@@ -47,8 +51,9 @@ public class EventController {
 
     @PostMapping
     @PreAuthorize("hasAnyRole('ADMIN', 'CONCERT_MANAGER', 'FESTIVAL_MANAGER', 'FANMEETING_MANAGER', 'POPUP_MANAGER')")
+    @Operation(summary = "행사 등록", description = "매니저/관리자 전용 API입니다. 행사를 등록하면 SCHEDULED 상태로 생성됩니다. 티켓팅이 있는 경우 티켓팅 시작일, 종료일, 링크를 모두 입력해야 합니다. 세부 일정(schedules)은 최소 1개 이상 필수입니다.")
     public ResponseEntity<ApiResponse<EventResponse>> createEvent(
-            @AuthenticationPrincipal String userId,
+            @Parameter(hidden = true) @AuthenticationPrincipal String userId,
             @Valid @RequestBody CreateEventRequest request) {
 
         EventResult result = eventCommandService.createEvent(CreateEventCommand.from(UUID.fromString(userId), request));
@@ -57,6 +62,7 @@ public class EventController {
     }
 
     @GetMapping
+    @Operation(summary = "행사 목록 조회", description = "카테고리(category), 상태(status), 날짜 범위(startAt, endAt), 연도/월(year, month)로 필터링할 수 있습니다. 필터를 여러 개 조합할 수 있으며, 기본 정렬은 시작일 오름차순입니다. 삭제된 행사는 목록에 포함되지 않습니다.")
     public ResponseEntity<ApiResponse<Page<EventListResponse>>> getEvents(
             @RequestParam(required = false) String category,
             @RequestParam(required = false) EventStatus status,
@@ -72,6 +78,7 @@ public class EventController {
     }
 
     @GetMapping("/{eventId}")
+    @Operation(summary = "행사 상세 조회", description = "행사의 세부 정보와 함께 연결된 채팅방 정보를 반환합니다. 채팅 서비스와 연동하여 채팅방 상태, 오픈/종료 일정 등을 포함합니다. 채팅 서비스 장애 시에도 행사 정보는 정상 반환되며, 채팅방 정보는 chatRoomExists: false로 응답됩니다.")
     public ResponseEntity<ApiResponse<EventDetailResponse>> getEvent(
             @PathVariable UUID eventId) {
 
@@ -81,8 +88,9 @@ public class EventController {
 
     @PatchMapping("/{eventId}")
     @PreAuthorize("hasAnyRole('ADMIN', 'CONCERT_MANAGER', 'FESTIVAL_MANAGER', 'FANMEETING_MANAGER', 'POPUP_MANAGER')")
+    @Operation(summary = "행사 수정", description = "매니저/관리자 전용 API입니다. 행사의 모든 필드를 수정할 수 있습니다. 세부 일정(schedules)을 요청에 포함하면 기존 일정 전체가 교체되며, 생략하면 기존 일정이 그대로 유지됩니다. 수정된 내용은 Kafka를 통해 연관 서비스에 전파됩니다.")
     public ResponseEntity<ApiResponse<EventResponse>> updateEvent(
-            @AuthenticationPrincipal String userId,
+            @Parameter(hidden = true) @AuthenticationPrincipal String userId,
             @PathVariable UUID eventId,
             @Valid @RequestBody UpdateEventRequest request) {
 
@@ -92,8 +100,9 @@ public class EventController {
 
     @DeleteMapping("/{eventId}")
     @PreAuthorize("hasAnyRole('ADMIN', 'CONCERT_MANAGER', 'FESTIVAL_MANAGER', 'FANMEETING_MANAGER', 'POPUP_MANAGER')")
+    @Operation(summary = "행사 삭제", description = "매니저/관리자 전용 API입니다. 실제 데이터를 제거하지 않고 삭제된 것으로 처리하는 소프트 딜리트 방식입니다. 삭제 후 목록 및 상세 조회에서 노출되지 않으며, 삭제 이벤트가 Kafka를 통해 연관 서비스에 전파됩니다.")
     public ResponseEntity<Void> deleteEvent(
-            @AuthenticationPrincipal String userId,
+            @Parameter(hidden = true) @AuthenticationPrincipal String userId,
             @PathVariable UUID eventId) {
 
         eventCommandService.deleteEvent(UUID.fromString(userId), eventId);
@@ -102,8 +111,9 @@ public class EventController {
 
     @PatchMapping("/{eventId}/cancel")
     @PreAuthorize("hasAnyRole('ADMIN', 'CONCERT_MANAGER', 'FESTIVAL_MANAGER', 'FANMEETING_MANAGER', 'POPUP_MANAGER')")
+    @Operation(summary = "행사 취소", description = "매니저/관리자 전용 API입니다. SCHEDULED(예정) 또는 IN_PROGRESS(진행 중) 상태의 행사만 취소할 수 있습니다. 취소 시 아직 실행되지 않은 예약 액션도 함께 취소되며, 취소 이벤트가 Kafka를 통해 연관 서비스에 전파됩니다.")
     public ResponseEntity<ApiResponse<EventResponse>> cancelEvent(
-            @AuthenticationPrincipal String userId,
+            @Parameter(hidden = true) @AuthenticationPrincipal String userId,
             @PathVariable UUID eventId) {
 
         EventResult result = eventCommandService.cancelEvent(eventId, UUID.fromString(userId));

--- a/event-service/src/main/java/com/ojosama/eventservice/event/presentation/controller/EventController.java
+++ b/event-service/src/main/java/com/ojosama/eventservice/event/presentation/controller/EventController.java
@@ -1,6 +1,7 @@
 package com.ojosama.eventservice.event.presentation.controller;
 
 import com.ojosama.common.response.ApiResponse;
+import com.ojosama.common.response.PageResponse;
 import com.ojosama.eventservice.event.application.dto.command.CreateEventCommand;
 import com.ojosama.eventservice.event.application.dto.command.EventListCommand;
 import com.ojosama.eventservice.event.application.dto.command.UpdateEventCommand;
@@ -63,7 +64,7 @@ public class EventController {
 
     @GetMapping
     @Operation(summary = "행사 목록 조회", description = "카테고리(category), 상태(status), 날짜 범위(startAt, endAt), 연도/월(year, month)로 필터링할 수 있습니다. 필터를 여러 개 조합할 수 있으며, 기본 정렬은 시작일 오름차순입니다. 삭제된 행사는 목록에 포함되지 않습니다.")
-    public ResponseEntity<ApiResponse<Page<EventListResponse>>> getEvents(
+    public ResponseEntity<ApiResponse<PageResponse<EventListResponse>>> getEvents(
             @RequestParam(required = false) String category,
             @RequestParam(required = false) EventStatus status,
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime startAt,
@@ -74,7 +75,7 @@ public class EventController {
 
         EventListCommand command = new EventListCommand(category, status, startAt, endAt, year, month);
         Page<EventListResult> result = eventQueryService.getEvents(command, pageable);
-        return ResponseEntity.ok(ApiResponse.success(result.map(EventListResponse::from)));
+        return ResponseEntity.ok(ApiResponse.success(PageResponse.from(result.map(EventListResponse::from))));
     }
 
     @GetMapping("/{eventId}")

--- a/event-service/src/main/java/com/ojosama/eventservice/event/presentation/controller/InternalEventCategoryController.java
+++ b/event-service/src/main/java/com/ojosama/eventservice/event/presentation/controller/InternalEventCategoryController.java
@@ -2,6 +2,7 @@ package com.ojosama.eventservice.event.presentation.controller;
 
 import com.ojosama.eventservice.event.application.service.EventCategoryQueryService;
 import com.ojosama.eventservice.event.presentation.dto.response.EventCategoryResponse;
+import io.swagger.v3.oas.annotations.Hidden;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -10,6 +11,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Hidden
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/internal/v1/event-categories")

--- a/event-service/src/main/java/com/ojosama/eventservice/event/presentation/controller/InternalEventController.java
+++ b/event-service/src/main/java/com/ojosama/eventservice/event/presentation/controller/InternalEventController.java
@@ -3,6 +3,7 @@ package com.ojosama.eventservice.event.presentation.controller;
 import com.ojosama.eventservice.event.application.service.EventQueryService;
 import com.ojosama.eventservice.event.presentation.dto.response.EventLocationResponse;
 import com.ojosama.eventservice.event.presentation.dto.response.EventResponse;
+import io.swagger.v3.oas.annotations.Hidden;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -13,6 +14,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+@Hidden
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/internal/v1/events")

--- a/event-service/src/main/java/com/ojosama/eventservice/eventrequest/presentation/controller/EventRequestController.java
+++ b/event-service/src/main/java/com/ojosama/eventservice/eventrequest/presentation/controller/EventRequestController.java
@@ -9,6 +9,9 @@ import com.ojosama.eventservice.eventrequest.application.service.EventRequestQue
 import com.ojosama.eventservice.eventrequest.presentation.dto.request.CreateEventRequestRequest;
 import com.ojosama.eventservice.eventrequest.presentation.dto.request.RejectEventRequestRequest;
 import com.ojosama.eventservice.eventrequest.presentation.dto.response.EventRequestResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -32,6 +35,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/v1/event-requests")
+@Tag(name = "행사 신청 API", description = "행사 등록 요청 및 승인/반려 처리")
 public class EventRequestController {
 
     private final EventRequestCommandService eventRequestCommandService;
@@ -39,8 +43,9 @@ public class EventRequestController {
 
     @PostMapping
     @PreAuthorize("hasAnyRole('USER')")
+    @Operation(summary = "행사 등록 요청", description = "매니저가 행사 등록을 관리자에게 요청하는 API입니다. 요청이 생성되면 PENDING 상태로 시작되며, 관리자의 승인 또는 반려를 기다립니다. 제목, 카테고리, 링크는 필수 입력입니다.")
     public ResponseEntity<ApiResponse<EventRequestResponse>> createEventRequest(
-            @AuthenticationPrincipal String userId,
+            @Parameter(hidden = true) @AuthenticationPrincipal String userId,
             @Valid @RequestBody CreateEventRequestRequest request) {
 
         EventRequestResult result = eventRequestCommandService.createEventRequest(
@@ -51,8 +56,9 @@ public class EventRequestController {
 
     @DeleteMapping("/{requestId}")
     @PreAuthorize("hasRole('USER')")
+    @Operation(summary = "요청 취소 (작성자)", description = "본인이 등록한 요청을 취소하는 API입니다. PENDING(대기 중) 상태의 요청만 취소할 수 있으며, 타인의 요청은 취소할 수 없습니다. 취소된 요청은 CANCELLED 상태로 변경되며, 삭제되지 않고 목록에서 계속 조회됩니다.")
     public ResponseEntity<Void> cancelEventRequest(
-            @AuthenticationPrincipal String userId,
+            @Parameter(hidden = true) @AuthenticationPrincipal String userId,
             @PathVariable UUID requestId) {
 
         eventRequestCommandService.cancelEventRequest(UUID.fromString(userId), requestId);
@@ -61,8 +67,9 @@ public class EventRequestController {
 
     @DeleteMapping("/admin/{requestId}")
     @PreAuthorize("hasRole('ADMIN')")
+    @Operation(summary = "요청 삭제 (관리자)", description = "관리자 전용 API입니다. 요청의 소유자나 상태에 관계없이 강제로 삭제할 수 있습니다. 소프트 딜리트 방식으로 처리되며, 삭제 후 목록 및 상세 조회에서 노출되지 않습니다.")
     public ResponseEntity<Void> adminCancelEventRequest(
-            @AuthenticationPrincipal String userId,
+            @Parameter(hidden = true) @AuthenticationPrincipal String userId,
             @PathVariable UUID requestId) {
 
         eventRequestCommandService.adminCancelEventRequest(UUID.fromString(userId), requestId);
@@ -71,6 +78,7 @@ public class EventRequestController {
 
     @PostMapping("/{requestId}/approval")
     @PreAuthorize("hasAnyRole('ADMIN', 'CONCERT_MANAGER', 'FESTIVAL_MANAGER', 'FANMEETING_MANAGER', 'POPUP_MANAGER')")
+    @Operation(summary = "요청 승인", description = "매니저/관리자 전용 API입니다. PENDING(대기 중) 상태의 행사 등록 요청을 승인합니다. 승인된 요청은 APPROVED 상태로 변경됩니다. 이미 승인 또는 반려된 요청에 대해 요청 시 409를 반환합니다.")
     public ResponseEntity<ApiResponse<EventRequestResponse>> approveEventRequest(
             @PathVariable UUID requestId) {
 
@@ -80,6 +88,7 @@ public class EventRequestController {
 
     @PostMapping("/{requestId}/rejections")
     @PreAuthorize("hasAnyRole('ADMIN', 'CONCERT_MANAGER', 'FESTIVAL_MANAGER', 'FANMEETING_MANAGER', 'POPUP_MANAGER')")
+    @Operation(summary = "요청 반려", description = "매니저/관리자 전용 API입니다. PENDING(대기 중) 상태의 행사 등록 요청을 반려합니다. 반려 시 사유(rejectReason)는 필수 입력이며, 신청자에게 안내됩니다. 반려된 요청은 REJECTED 상태로 변경됩니다. 이미 처리된 요청에 대해 요청 시 409를 반환합니다.")
     public ResponseEntity<ApiResponse<EventRequestResponse>> rejectEventRequest(
             @PathVariable UUID requestId,
             @Valid @RequestBody RejectEventRequestRequest request) {
@@ -90,6 +99,7 @@ public class EventRequestController {
 
     @GetMapping
     @PreAuthorize("hasAnyRole('ADMIN', 'CONCERT_MANAGER', 'FESTIVAL_MANAGER', 'FANMEETING_MANAGER', 'POPUP_MANAGER')")
+    @Operation(summary = "요청 목록 조회 (관리자)", description = "매니저/관리자 전용 API입니다. 전체 행사 등록 요청 목록을 조회합니다. 상태(status), 카테고리명(categoryName), 행사명(eventName), 신청자 ID(requesterId), 생성일 범위(createdStart, createdEnd)로 필터링할 수 있습니다. 기본 정렬은 생성일 내림차순이며 페이지당 10건입니다.")
     public ResponseEntity<ApiResponse<Page<EventRequestResponse>>> getEventRequests(
             @ModelAttribute EventRequestListCommand query,
             @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
@@ -100,8 +110,9 @@ public class EventRequestController {
 
     @GetMapping("/me")
     @PreAuthorize("hasAnyRole('USER')")
+    @Operation(summary = "내 요청 목록 조회", description = "본인이 신청한 행사 등록 요청 목록을 조회합니다. 인증 헤더(X-User-Id)를 기준으로 본인 요청만 반환되며, 타인의 요청은 조회되지 않습니다.")
     public ResponseEntity<ApiResponse<Page<EventRequestResponse>>> getMyEventRequests(
-            @AuthenticationPrincipal String userId,
+            @Parameter(hidden = true) @AuthenticationPrincipal String userId,
             @ModelAttribute EventRequestListCommand query,
             @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
 
@@ -111,6 +122,7 @@ public class EventRequestController {
 
     @GetMapping("/{requestId}")
     @PreAuthorize("hasAnyRole('ADMIN', 'CONCERT_MANAGER', 'FESTIVAL_MANAGER', 'FANMEETING_MANAGER', 'POPUP_MANAGER')")
+    @Operation(summary = "요청 상세 조회 (관리자)", description = "매니저/관리자 전용 API입니다. 특정 행사 등록 요청의 상세 정보를 조회합니다. 존재하지 않는 요청 ID로 조회 시 404를 반환합니다.")
     public ResponseEntity<ApiResponse<EventRequestResponse>> getEventRequest(
             @PathVariable UUID requestId) {
 
@@ -120,8 +132,9 @@ public class EventRequestController {
 
     @GetMapping("/me/{requestId}")
     @PreAuthorize("hasRole('USER')")
+    @Operation(summary = "내 요청 상세 조회", description = "본인이 신청한 특정 행사 등록 요청의 상세 정보를 조회합니다. 타인의 요청 ID로 조회 시 접근이 거부됩니다.")
     public ResponseEntity<ApiResponse<EventRequestResponse>> getMyEventRequest(
-            @AuthenticationPrincipal String userId,
+            @Parameter(hidden = true) @AuthenticationPrincipal String userId,
             @PathVariable UUID requestId) {
 
         EventRequestResult result = eventRequestQueryService.getMyEventRequest(UUID.fromString(userId), requestId);

--- a/event-service/src/main/java/com/ojosama/eventservice/eventrequest/presentation/controller/EventRequestController.java
+++ b/event-service/src/main/java/com/ojosama/eventservice/eventrequest/presentation/controller/EventRequestController.java
@@ -1,6 +1,7 @@
 package com.ojosama.eventservice.eventrequest.presentation.controller;
 
 import com.ojosama.common.response.ApiResponse;
+import com.ojosama.common.response.PageResponse;
 import com.ojosama.eventservice.eventrequest.application.dto.command.CreateEventRequestCommand;
 import com.ojosama.eventservice.eventrequest.application.dto.command.EventRequestListCommand;
 import com.ojosama.eventservice.eventrequest.application.dto.result.EventRequestResult;
@@ -100,24 +101,24 @@ public class EventRequestController {
     @GetMapping
     @PreAuthorize("hasAnyRole('ADMIN', 'CONCERT_MANAGER', 'FESTIVAL_MANAGER', 'FANMEETING_MANAGER', 'POPUP_MANAGER')")
     @Operation(summary = "요청 목록 조회 (관리자)", description = "매니저/관리자 전용 API입니다. 전체 행사 등록 요청 목록을 조회합니다. 상태(status), 카테고리명(categoryName), 행사명(eventName), 신청자 ID(requesterId), 생성일 범위(createdStart, createdEnd)로 필터링할 수 있습니다. 기본 정렬은 생성일 내림차순이며 페이지당 10건입니다.")
-    public ResponseEntity<ApiResponse<Page<EventRequestResponse>>> getEventRequests(
+    public ResponseEntity<ApiResponse<PageResponse<EventRequestResponse>>> getEventRequests(
             @ModelAttribute EventRequestListCommand query,
             @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
 
         Page<EventRequestResult> result = eventRequestQueryService.getEventRequests(query, pageable);
-        return ResponseEntity.ok(ApiResponse.success(result.map(EventRequestResponse::from)));
+        return ResponseEntity.ok(ApiResponse.success(PageResponse.from(result.map(EventRequestResponse::from))));
     }
 
     @GetMapping("/me")
     @PreAuthorize("hasAnyRole('USER')")
     @Operation(summary = "내 요청 목록 조회", description = "본인이 신청한 행사 등록 요청 목록을 조회합니다. 인증 헤더(X-User-Id)를 기준으로 본인 요청만 반환되며, 타인의 요청은 조회되지 않습니다.")
-    public ResponseEntity<ApiResponse<Page<EventRequestResponse>>> getMyEventRequests(
+    public ResponseEntity<ApiResponse<PageResponse<EventRequestResponse>>> getMyEventRequests(
             @Parameter(hidden = true) @AuthenticationPrincipal String userId,
             @ModelAttribute EventRequestListCommand query,
             @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
 
         Page<EventRequestResult> result = eventRequestQueryService.getMyEventRequests(UUID.fromString(userId), query, pageable);
-        return ResponseEntity.ok(ApiResponse.success(result.map(EventRequestResponse::from)));
+        return ResponseEntity.ok(ApiResponse.success(PageResponse.from(result.map(EventRequestResponse::from))));
     }
 
     @GetMapping("/{requestId}")


### PR DESCRIPTION
## 🔗 Issue Number
- close #285

## 📝 작업 내역

- swagger 적용
- PageResponse<T> 적용

## 💡 PR 특이사항

- 서비스 간 내부 통신용 API는 Swagger UI 노출 제외


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * API 문서화 기능 추가로 엔드포인트 명세를 자동으로 생성합니다.
  * 보안 설정 확대로 API 문서 접근이 인증 없이 가능해졌습니다.

* **Documentation**
  * 모든 공개 API 엔드포인트에 상세 설명 및 메타데이터를 추가했습니다.
  * 내부 전용 API는 문서에서 숨김 처리되었습니다.

* **Refactor**
  * 행사 및 행사 요청 목록 조회 응답 형식을 표준화했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/55josama/festie/pull/295?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->