### PR TITLE
[FIX] chat-service EventCreatedConsumer 한글 카테고리명 매핑 처리 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,7 @@ subprojects {
         implementation 'io.micrometer:micrometer-tracing-bridge-brave'
         implementation 'io.zipkin.reporter2:zipkin-reporter-brave'
         runtimeOnly 'com.google.cloud.sql:postgres-socket-factory:1.28.3'
+        runtimeOnly 'io.micrometer:micrometer-registry-stackdriver'
     }
 
     tasks.named('test') {

--- a/chat-service/src/main/java/com/ojosama/chatservice/infrastructure/messaging/kafka/consumer/EventCreatedConsumer.java
+++ b/chat-service/src/main/java/com/ojosama/chatservice/infrastructure/messaging/kafka/consumer/EventCreatedConsumer.java
@@ -11,6 +11,7 @@ import com.ojosama.chatservice.domain.model.EventCategory;
 import com.ojosama.chatservice.infrastructure.messaging.kafka.dto.EventCreatedEvent;
 import com.ojosama.common.kafka.domain.EventType;
 import com.ojosama.common.kafka.domain.IdempotentEventHandler;
+import java.util.Map;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -95,9 +96,20 @@ public class EventCreatedConsumer {
         }
     }
 
+    private static final Map<String, EventCategory> KOR_CATEGORY_MAP = Map.of(
+            "콘서트", EventCategory.CONCERT,
+            "페스티벌", EventCategory.FESTIVAL,
+            "팬미팅", EventCategory.FANMEETING,
+            "팝업스토어", EventCategory.POPUPSTORE
+    );
+
     private EventCategory parseCategory(String categoryName) {
         if (categoryName == null || categoryName.isBlank()) {
             throw new IllegalArgumentException("카테고리 이름은 비어 있을 수 없습니다.");
+        }
+        EventCategory mapped = KOR_CATEGORY_MAP.get(categoryName.trim());
+        if (mapped != null) {
+            return mapped;
         }
         try {
             return EventCategory.valueOf(categoryName.trim().toUpperCase());


### PR DESCRIPTION
## 문제
event-service가 카테고리명을 한글(`콘서트`, `페스티벌` 등)로 전송하는데,
chat-service의 `EventCreatedConsumer.parseCategory()`가 영어 enum명만 처리해
채팅방 자동 생성 실패

## 원인
```java
// 기존: "콘서트".toUpperCase() = "콘서트" → enum에 없음 → 예외
EventCategory.valueOf(categoryName.trim().toUpperCase());
```

## 해결
한글 카테고리명 → `EventCategory` enum 매핑 추가
영어 enum명도 하위 호환으로 유지

## 관련 이슈
closes #311

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 한국어 이벤트 카테고리명(콘서트, 페스티벌, 팬미팅, 팝업스토어) 인식 지원 추가
  * 카테고리 분석 로직 강화로 안정성 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->