### PR TITLE
[FIX] 행사 목록 조회 Redis 캐시 역직렬화 500 오류 해결

### DIFF
--- a/event-service/src/main/java/com/ojosama/eventservice/event/application/service/EventQueryService.java
+++ b/event-service/src/main/java/com/ojosama/eventservice/event/application/service/EventQueryService.java
@@ -1,5 +1,6 @@
 package com.ojosama.eventservice.event.application.service;
 
+import com.ojosama.common.response.PageResponse;
 import com.ojosama.eventservice.event.application.dto.command.EventListCommand;
 import com.ojosama.eventservice.event.application.dto.result.EventListResult;
 import com.ojosama.eventservice.event.application.dto.result.EventResult;
@@ -14,7 +15,6 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.Cacheable;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -32,7 +32,7 @@ public class EventQueryService {
             key = "(#command.category ?: 'all') + ':' + (#command.status?.name() ?: 'all') + ':' + (#command.year ?: 0) + ':' + (#command.month ?: 0) + ':' + #pageable.pageNumber + ':' + #pageable.pageSize + ':' + #pageable.sort.toString()",
             condition = "#command.startAt == null && #command.endAt == null"
     )
-    public Page<EventListResult> getEvents(EventListCommand command, Pageable pageable) {
+    public PageResponse<EventListResult> getEvents(EventListCommand command, Pageable pageable) {
         EventFilter filter = new EventFilter(
                 command.category(),
                 command.status(),
@@ -41,7 +41,7 @@ public class EventQueryService {
                 command.year(),
                 command.month()
         );
-        return eventRepository.findAll(filter, pageable).map(EventListResult::from);
+        return PageResponse.from(eventRepository.findAll(filter, pageable).map(EventListResult::from));
     }
 
     @Transactional(readOnly = true)

--- a/event-service/src/main/java/com/ojosama/eventservice/event/presentation/controller/EventController.java
+++ b/event-service/src/main/java/com/ojosama/eventservice/event/presentation/controller/EventController.java
@@ -22,7 +22,6 @@ import jakarta.validation.Valid;
 import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
@@ -74,8 +73,15 @@ public class EventController {
             @PageableDefault(size = 10, sort = "eventTime.startAt", direction = Sort.Direction.ASC) Pageable pageable) {
 
         EventListCommand command = new EventListCommand(category, status, startAt, endAt, year, month);
-        Page<EventListResult> result = eventQueryService.getEvents(command, pageable);
-        return ResponseEntity.ok(ApiResponse.success(PageResponse.from(result.map(EventListResponse::from))));
+        PageResponse<EventListResult> result = eventQueryService.getEvents(command, pageable);
+        PageResponse<EventListResponse> response = new PageResponse<>(
+                result.content().stream().map(EventListResponse::from).toList(),
+                result.page(),
+                result.size(),
+                result.totalElements(),
+                result.totalPages()
+        );
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     @GetMapping("/{eventId}")


### PR DESCRIPTION
## 🔗 Issue Number
- close #310

## 📝 작업 내역

 - EventQueryService.getEvents()의 반환 타입을 Page<EventListResult>에서 PageResponse<EventListResult>로 변경
  - Redis 캐시 저장 시 PageResponse(직렬화 가능한 record)로 저장하도록 수정하여 역직렬화 500 오류 해결
  - Page 인터페이스는 Jackson 역직렬화 대상으로 부적합하여 커스텀 PageResponse record로 대체


## 💡 PR 특이사항

  - 기존에는 Page<EventListResult>를 캐시에 저장했으나, Spring의 Page 구현체(PageImpl)는 Jackson 역직렬화 시 생성자를 찾지 못해 500 오류 발생
  - PageResponse는 common 모듈에 정의된 단순 record로 직렬화/역직렬화 모두 안전
  - 캐시 키 전략 및 @Cacheable 조건은 변경 없음


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 이벤트 목록 조회 시 페이지네이션 응답 형식이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->