### PR TITLE
[FIX] 행사 장소 반경 양수만 허용

### DIFF
--- a/event-service/src/main/java/com/ojosama/eventservice/event/domain/exception/EventErrorCode.java
+++ b/event-service/src/main/java/com/ojosama/eventservice/event/domain/exception/EventErrorCode.java
@@ -41,6 +41,7 @@ public enum EventErrorCode implements ErrorCode {
     // 위치 관련 에러
     INVALID_LATITUDE(HttpStatus.BAD_REQUEST, "위도는 -90 ~ 90 범위여야 합니다."),
     INVALID_LONGITUDE(HttpStatus.BAD_REQUEST, "경도는 -180 ~ 180 범위여야 합니다."),
+    INVALID_RADIUS(HttpStatus.BAD_REQUEST, "반경은 0보다 큰 값이어야 합니다."),
 
     // 권한 관련 에러
     EVENT_UNAUTHORIZED(HttpStatus.FORBIDDEN, "이 행사에 대한 권한이 없습니다."),

--- a/event-service/src/main/java/com/ojosama/eventservice/event/domain/model/vo/EventLocation.java
+++ b/event-service/src/main/java/com/ojosama/eventservice/event/domain/model/vo/EventLocation.java
@@ -18,7 +18,7 @@ public class EventLocation {
     private static final BigDecimal LATITUDE_MAX = new BigDecimal("90");
     private static final BigDecimal LONGITUDE_MIN = new BigDecimal("-180");
     private static final BigDecimal LONGITUDE_MAX = new BigDecimal("180");
-    private static final int RADIUS_MIN = 0;
+    private static final int RADIUS_MIN = 1;
 
     @Column(length = 500, nullable = false)
     private String place;
@@ -73,7 +73,7 @@ public class EventLocation {
 
     private void validateRadius(Integer radius) {
         if (radius != null && radius < RADIUS_MIN) {
-            throw new EventException(EventErrorCode.EVENT_INVALID_LOCATION);
+            throw new EventException(EventErrorCode.INVALID_RADIUS);
         }
     }
 }


### PR DESCRIPTION
## 🔗 Issue Number
- close #315

 ## 📝 작업 내역

  - `EventLocation.validateRadius`의 `RADIUS_MIN`을 `0` → `1`로 변경하여 행사 반경값을 양수만 허용
  - `EventErrorCode`에 `INVALID_RADIUS`("반경은 0보다 큰 값이어야 합니다.") 추가, `radius=0` 입력 시 400 반환
  - `radius=null`은 기존과 동일하게 허용 (값 없음 → chat-service가 기본값 1000m 적용)

  ## 💡 PR 특이사항

  - 문제: 기존 `validateRadius`는 `radius < RADIUS_MIN(=0)`만 체크하므로 `radius=0`이 유효 값으로 통과됨
  - chat-service의 위치 인증 로직(`EventLocationVerificationService`)은 `radiusMeters != null ? radiusMeters : 1000`으로 기본값을 적용 → `radius=0`은 "값       
  있음"으로 취급되어 `distance <= 0` 조건이 거의 항상 거짓이 됨
  - 결과: 운영자가 반경에 `0`을 입력하면 해당 행사는 누구도 채팅 위치 인증을 통과할 수 없게 됨 (의도와 반대 동작)
  - `radius=null`(미입력)은 chat-service 기본값 1000m 설정되어 있는데 이 부분 행사 쪽에서 null 허용 안되게 할지 아니면 기존 방식대로 유지할지 의견 주시면 감사하겠습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 위치 기반 검색에서 반경 값 검증이 강화되었습니다. 반경은 이제 최소 1 이상의 값이어야 합니다.
  * 유효하지 않은 반경 입력 시 더 명확한 오류 메시지(HTTP 400)가 제공됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->